### PR TITLE
Fixed typo in variable. Added documentation for Mac OS X usage.

### DIFF
--- a/postgresql/scripts/bin/build_db
+++ b/postgresql/scripts/bin/build_db
@@ -16,7 +16,7 @@ owner=postgres
 db=urbandev
 # location of sql files and csv files
 sql=$SCRIPTDIR/../sql
-data=$SRIPTDIR/../data-loaders/data
+data=$SCRIPTDIR/../data-loaders/data
 
 
 # Create database

--- a/postgresql/scripts/bin/load
+++ b/postgresql/scripts/bin/load
@@ -5,6 +5,15 @@
 #   ./load <db name> <table name/csv name> <number of rows to skip>
 #
 #   ./load urbandev census_total_population 1
+#
+#
+# On Mac OS X 10.11.5, you need to install the 'realpath' utility. For
+# example, using Homebrew:
+#   $ brew install coreutils
+# which includes 'grealpath'. So to make that work with the 'load' script,
+# which uses 'realpath', follow the brew installation instructions to
+# add gnubin to your PATH, like this:
+#   PATH="/usr/local/opt/coreutils/libexec/gnubin:$PATH"
 
 
 # path to the directory of this script


### PR DESCRIPTION
* Fixed typo in 'build_db'.
* Added documentation in 'load' script for Mac OS X usage, because 'realpath' is not available on default OS X, although it can be added easily with Homebrew.