### PR TITLE
Aggregate Crime and Demolition data by Zillow neighborhood

### DIFF
--- a/json/city_data/aggregate_to_zillow_neighborhoods.sql
+++ b/json/city_data/aggregate_to_zillow_neighborhoods.sql
@@ -1,0 +1,135 @@
+DROP TABLE IF EXISTS zillow_neighborhoods_crime_violent;
+CREATE TEMP TABLE zillow_neighborhoods_crime_violent AS
+WITH groups AS (
+    -- make sure that even if data does not exist for a given
+    -- group there will still be a row with a null count, by using
+    -- cross product (NEIGHBORHOODS * YEARS * VIOLENT/NON-VIOLENT)
+    SELECT name, regionid, year, violent
+    FROM (
+        SELECT name, regionid
+        FROM zillow_neighborhoods
+        GROUP BY name, regionid
+    ) AS neighborhoods, (
+        SELECT to_char(report_datetime, 'YYYY') AS year
+        FROM crime
+        GROUP BY year
+    ) AS years, (
+        SELECT violent
+        FROM crime
+        GROUP BY violent
+    ) AS violent_groups
+)
+SELECT
+    groups.name,
+    groups.regionid,
+    groups.year,
+    groups.violent,
+    z.count
+FROM groups
+LEFT OUTER JOIN (
+    SELECT
+        z.name,
+        z.regionid,
+        to_char(report_datetime, 'YYYY') AS year,
+        c.violent,
+        count(*)
+    FROM zillow_neighborhoods AS z
+    JOIN crime AS c ON ST_Intersects(ST_Transform(c.geom, 2913), z.geom)
+    GROUP BY violent, name, regionid, to_char(report_datetime, 'YYYY')
+) AS z ON
+    groups.name = z.name AND
+    groups.regionid = z.regionid AND
+    groups.year = z.year AND
+    groups.violent = z.violent
+ORDER BY groups.name, groups.year, groups.violent;
+
+
+DROP TABLE IF EXISTS zillow_neighborhoods_crime_offense;
+CREATE TEMP TABLE zillow_neighborhoods_crime_offense AS
+WITH groups AS (
+    -- make sure that even if data does not exist for a given
+    -- group there will still be a row with a null count, by using
+    -- cross product (NEIGHBORHOODS * YEARS * OFFENSE_TYPE)
+    SELECT name, regionid, year, major_offense_type
+    FROM (
+        SELECT name, regionid
+        FROM zillow_neighborhoods
+        GROUP BY name, regionid
+    ) AS neighborhoods, (
+        SELECT to_char(report_datetime, 'YYYY') AS year
+        FROM crime
+        GROUP BY year
+    ) AS years, (
+        SELECT major_offense_type
+        FROM crime
+        GROUP BY major_offense_type
+    ) AS offense_types
+)
+SELECT
+    groups.name,
+    groups.regionid,
+    groups.year,
+    groups.major_offense_type,
+    z.count
+FROM groups
+LEFT OUTER JOIN (
+    SELECT
+        z.name,
+        z.regionid,
+        c.major_offense_type,
+        to_char(report_datetime, 'YYYY') AS year,
+        count(*)
+    FROM zillow_neighborhoods AS z
+    JOIN crime AS c ON ST_Intersects(ST_Transform(c.geom, 2913), z.geom)
+    GROUP BY major_offense_type, name, regionid, to_char(report_datetime, 'YYYY')
+) AS z ON
+    groups.name = z.name AND
+    groups.regionid = z.regionid AND
+    groups.year = z.year AND
+    groups.major_offense_type = z.major_offense_type
+ORDER BY groups.name, groups.year, groups.major_offense_type;
+
+
+DROP TABLE IF EXISTS zillow_neighborhoods_demolitions;
+CREATE TEMP TABLE zillow_neighborhoods_demolitions AS
+WITH groups AS (
+    -- make sure that even if data does not exist for a given
+    -- group there will still be a row with a null count, by using
+    -- cross product (NEIGHBORHOODS * YEARS)
+    SELECT name, regionid, year
+    FROM (
+        SELECT name, regionid
+        FROM zillow_neighborhoods
+        GROUP BY name, regionid
+    ) AS neighborhoods, (
+        SELECT to_char(demolition_date, 'YYYY') AS year
+        FROM demolitions
+        GROUP BY year
+    ) AS years
+)
+SELECT
+    groups.name,
+    groups.regionid,
+    groups.year,
+    z.count
+FROM groups
+LEFT OUTER JOIN (
+    SELECT
+        z.name,
+        z.regionid,
+        to_char(c.demolition_date, 'YYYY') AS year,
+        count(*)
+    FROM zillow_neighborhoods AS z
+    JOIN demolitions AS c ON ST_Intersects(ST_Transform(c.geom, 2913), z.geom)
+    GROUP BY name, regionid, to_char(demolition_date, 'YYYY')
+) AS z ON
+    groups.name = z.name AND
+    groups.regionid = z.regionid AND
+    groups.year = z.year
+ORDER BY groups.name, groups.year;
+
+
+-- write to csv
+\copy (SELECT * FROM zillow_neighborhoods_crime_violent) TO zillow_neighborhoods_crime_violent.csv CSV HEADER
+\copy (SELECT * FROM zillow_neighborhoods_crime_offense) TO zillow_neighborhoods_crime_offense.csv CSV HEADER
+\copy (SELECT * FROM zillow_neighborhoods_demolitions) TO zillow_neighborhoods_demolitions.csv CSV HEADER

--- a/json/city_data/zillow_neighborhoods_crime_offense.csv
+++ b/json/city_data/zillow_neighborhoods_crime_offense.csv
@@ -1,0 +1,25246 @@
+name,regionid,year,major_offense_type,count
+Alameda,206428,2004,Aggravated Assault,4
+Alameda,206428,2004,Arson,
+Alameda,206428,2004,"Assault, Simple",2
+Alameda,206428,2004,Burglary,32
+Alameda,206428,2004,Curfew,
+Alameda,206428,2004,Disorderly Conduct,3
+Alameda,206428,2004,Drugs,6
+Alameda,206428,2004,DUII,3
+Alameda,206428,2004,Embezzlement,1
+Alameda,206428,2004,Forgery,14
+Alameda,206428,2004,Fraud,15
+Alameda,206428,2004,Gambling,
+Alameda,206428,2004,Homicide,
+Alameda,206428,2004,Kidnap,
+Alameda,206428,2004,Larceny,182
+Alameda,206428,2004,Liquor Laws,2
+Alameda,206428,2004,Motor Vehicle Theft,13
+Alameda,206428,2004,Offenses Against Family,
+Alameda,206428,2004,Prostitution,
+Alameda,206428,2004,Rape,
+Alameda,206428,2004,Robbery,4
+Alameda,206428,2004,Runaway,
+Alameda,206428,2004,Sex Offenses,
+Alameda,206428,2004,Stolen Property,
+Alameda,206428,2004,Trespass,3
+Alameda,206428,2004,Vandalism,45
+Alameda,206428,2004,Weapons,1
+Alameda,206428,2005,Aggravated Assault,10
+Alameda,206428,2005,Arson,1
+Alameda,206428,2005,"Assault, Simple",8
+Alameda,206428,2005,Burglary,77
+Alameda,206428,2005,Curfew,1
+Alameda,206428,2005,Disorderly Conduct,19
+Alameda,206428,2005,Drugs,11
+Alameda,206428,2005,DUII,9
+Alameda,206428,2005,Embezzlement,6
+Alameda,206428,2005,Forgery,27
+Alameda,206428,2005,Fraud,36
+Alameda,206428,2005,Gambling,
+Alameda,206428,2005,Homicide,
+Alameda,206428,2005,Kidnap,
+Alameda,206428,2005,Larceny,456
+Alameda,206428,2005,Liquor Laws,6
+Alameda,206428,2005,Motor Vehicle Theft,36
+Alameda,206428,2005,Offenses Against Family,
+Alameda,206428,2005,Prostitution,
+Alameda,206428,2005,Rape,
+Alameda,206428,2005,Robbery,10
+Alameda,206428,2005,Runaway,
+Alameda,206428,2005,Sex Offenses,2
+Alameda,206428,2005,Stolen Property,
+Alameda,206428,2005,Trespass,20
+Alameda,206428,2005,Vandalism,101
+Alameda,206428,2005,Weapons,3
+Alameda,206428,2006,Aggravated Assault,6
+Alameda,206428,2006,Arson,1
+Alameda,206428,2006,"Assault, Simple",17
+Alameda,206428,2006,Burglary,86
+Alameda,206428,2006,Curfew,1
+Alameda,206428,2006,Disorderly Conduct,16
+Alameda,206428,2006,Drugs,8
+Alameda,206428,2006,DUII,12
+Alameda,206428,2006,Embezzlement,2
+Alameda,206428,2006,Forgery,13
+Alameda,206428,2006,Fraud,47
+Alameda,206428,2006,Gambling,
+Alameda,206428,2006,Homicide,
+Alameda,206428,2006,Kidnap,1
+Alameda,206428,2006,Larceny,353
+Alameda,206428,2006,Liquor Laws,5
+Alameda,206428,2006,Motor Vehicle Theft,28
+Alameda,206428,2006,Offenses Against Family,
+Alameda,206428,2006,Prostitution,
+Alameda,206428,2006,Rape,
+Alameda,206428,2006,Robbery,11
+Alameda,206428,2006,Runaway,
+Alameda,206428,2006,Sex Offenses,2
+Alameda,206428,2006,Stolen Property,
+Alameda,206428,2006,Trespass,18
+Alameda,206428,2006,Vandalism,103
+Alameda,206428,2006,Weapons,
+Alameda,206428,2007,Aggravated Assault,12
+Alameda,206428,2007,Arson,2
+Alameda,206428,2007,"Assault, Simple",19
+Alameda,206428,2007,Burglary,53
+Alameda,206428,2007,Curfew,
+Alameda,206428,2007,Disorderly Conduct,15
+Alameda,206428,2007,Drugs,9
+Alameda,206428,2007,DUII,15
+Alameda,206428,2007,Embezzlement,1
+Alameda,206428,2007,Forgery,12
+Alameda,206428,2007,Fraud,28
+Alameda,206428,2007,Gambling,
+Alameda,206428,2007,Homicide,
+Alameda,206428,2007,Kidnap,
+Alameda,206428,2007,Larceny,292
+Alameda,206428,2007,Liquor Laws,10
+Alameda,206428,2007,Motor Vehicle Theft,22
+Alameda,206428,2007,Offenses Against Family,
+Alameda,206428,2007,Prostitution,
+Alameda,206428,2007,Rape,
+Alameda,206428,2007,Robbery,20
+Alameda,206428,2007,Runaway,
+Alameda,206428,2007,Sex Offenses,
+Alameda,206428,2007,Stolen Property,
+Alameda,206428,2007,Trespass,16
+Alameda,206428,2007,Vandalism,54
+Alameda,206428,2007,Weapons,
+Alameda,206428,2008,Aggravated Assault,12
+Alameda,206428,2008,Arson,
+Alameda,206428,2008,"Assault, Simple",3
+Alameda,206428,2008,Burglary,51
+Alameda,206428,2008,Curfew,1
+Alameda,206428,2008,Disorderly Conduct,12
+Alameda,206428,2008,Drugs,9
+Alameda,206428,2008,DUII,17
+Alameda,206428,2008,Embezzlement,6
+Alameda,206428,2008,Forgery,7
+Alameda,206428,2008,Fraud,29
+Alameda,206428,2008,Gambling,
+Alameda,206428,2008,Homicide,
+Alameda,206428,2008,Kidnap,
+Alameda,206428,2008,Larceny,298
+Alameda,206428,2008,Liquor Laws,6
+Alameda,206428,2008,Motor Vehicle Theft,23
+Alameda,206428,2008,Offenses Against Family,
+Alameda,206428,2008,Prostitution,
+Alameda,206428,2008,Rape,1
+Alameda,206428,2008,Robbery,9
+Alameda,206428,2008,Runaway,
+Alameda,206428,2008,Sex Offenses,1
+Alameda,206428,2008,Stolen Property,
+Alameda,206428,2008,Trespass,14
+Alameda,206428,2008,Vandalism,57
+Alameda,206428,2008,Weapons,2
+Alameda,206428,2009,Aggravated Assault,3
+Alameda,206428,2009,Arson,2
+Alameda,206428,2009,"Assault, Simple",4
+Alameda,206428,2009,Burglary,35
+Alameda,206428,2009,Curfew,1
+Alameda,206428,2009,Disorderly Conduct,5
+Alameda,206428,2009,Drugs,2
+Alameda,206428,2009,DUII,8
+Alameda,206428,2009,Embezzlement,2
+Alameda,206428,2009,Forgery,25
+Alameda,206428,2009,Fraud,25
+Alameda,206428,2009,Gambling,
+Alameda,206428,2009,Homicide,
+Alameda,206428,2009,Kidnap,
+Alameda,206428,2009,Larceny,278
+Alameda,206428,2009,Liquor Laws,6
+Alameda,206428,2009,Motor Vehicle Theft,32
+Alameda,206428,2009,Offenses Against Family,
+Alameda,206428,2009,Prostitution,
+Alameda,206428,2009,Rape,
+Alameda,206428,2009,Robbery,11
+Alameda,206428,2009,Runaway,1
+Alameda,206428,2009,Sex Offenses,
+Alameda,206428,2009,Stolen Property,
+Alameda,206428,2009,Trespass,6
+Alameda,206428,2009,Vandalism,33
+Alameda,206428,2009,Weapons,
+Alameda,206428,2010,Aggravated Assault,2
+Alameda,206428,2010,Arson,1
+Alameda,206428,2010,"Assault, Simple",6
+Alameda,206428,2010,Burglary,55
+Alameda,206428,2010,Curfew,
+Alameda,206428,2010,Disorderly Conduct,12
+Alameda,206428,2010,Drugs,9
+Alameda,206428,2010,DUII,12
+Alameda,206428,2010,Embezzlement,
+Alameda,206428,2010,Forgery,3
+Alameda,206428,2010,Fraud,13
+Alameda,206428,2010,Gambling,
+Alameda,206428,2010,Homicide,1
+Alameda,206428,2010,Kidnap,
+Alameda,206428,2010,Larceny,269
+Alameda,206428,2010,Liquor Laws,5
+Alameda,206428,2010,Motor Vehicle Theft,23
+Alameda,206428,2010,Offenses Against Family,
+Alameda,206428,2010,Prostitution,
+Alameda,206428,2010,Rape,
+Alameda,206428,2010,Robbery,9
+Alameda,206428,2010,Runaway,
+Alameda,206428,2010,Sex Offenses,
+Alameda,206428,2010,Stolen Property,
+Alameda,206428,2010,Trespass,10
+Alameda,206428,2010,Vandalism,63
+Alameda,206428,2010,Weapons,2
+Alameda,206428,2011,Aggravated Assault,5
+Alameda,206428,2011,Arson,
+Alameda,206428,2011,"Assault, Simple",6
+Alameda,206428,2011,Burglary,47
+Alameda,206428,2011,Curfew,1
+Alameda,206428,2011,Disorderly Conduct,8
+Alameda,206428,2011,Drugs,5
+Alameda,206428,2011,DUII,18
+Alameda,206428,2011,Embezzlement,2
+Alameda,206428,2011,Forgery,15
+Alameda,206428,2011,Fraud,11
+Alameda,206428,2011,Gambling,
+Alameda,206428,2011,Homicide,
+Alameda,206428,2011,Kidnap,
+Alameda,206428,2011,Larceny,272
+Alameda,206428,2011,Liquor Laws,3
+Alameda,206428,2011,Motor Vehicle Theft,24
+Alameda,206428,2011,Offenses Against Family,
+Alameda,206428,2011,Prostitution,
+Alameda,206428,2011,Rape,
+Alameda,206428,2011,Robbery,4
+Alameda,206428,2011,Runaway,
+Alameda,206428,2011,Sex Offenses,1
+Alameda,206428,2011,Stolen Property,
+Alameda,206428,2011,Trespass,13
+Alameda,206428,2011,Vandalism,39
+Alameda,206428,2011,Weapons,
+Alameda,206428,2012,Aggravated Assault,5
+Alameda,206428,2012,Arson,
+Alameda,206428,2012,"Assault, Simple",4
+Alameda,206428,2012,Burglary,69
+Alameda,206428,2012,Curfew,
+Alameda,206428,2012,Disorderly Conduct,9
+Alameda,206428,2012,Drugs,11
+Alameda,206428,2012,DUII,7
+Alameda,206428,2012,Embezzlement,
+Alameda,206428,2012,Forgery,38
+Alameda,206428,2012,Fraud,5
+Alameda,206428,2012,Gambling,
+Alameda,206428,2012,Homicide,
+Alameda,206428,2012,Kidnap,
+Alameda,206428,2012,Larceny,252
+Alameda,206428,2012,Liquor Laws,1
+Alameda,206428,2012,Motor Vehicle Theft,20
+Alameda,206428,2012,Offenses Against Family,
+Alameda,206428,2012,Prostitution,
+Alameda,206428,2012,Rape,1
+Alameda,206428,2012,Robbery,5
+Alameda,206428,2012,Runaway,
+Alameda,206428,2012,Sex Offenses,
+Alameda,206428,2012,Stolen Property,2
+Alameda,206428,2012,Trespass,7
+Alameda,206428,2012,Vandalism,26
+Alameda,206428,2012,Weapons,
+Alameda,206428,2013,Aggravated Assault,9
+Alameda,206428,2013,Arson,1
+Alameda,206428,2013,"Assault, Simple",18
+Alameda,206428,2013,Burglary,57
+Alameda,206428,2013,Curfew,
+Alameda,206428,2013,Disorderly Conduct,12
+Alameda,206428,2013,Drugs,10
+Alameda,206428,2013,DUII,17
+Alameda,206428,2013,Embezzlement,2
+Alameda,206428,2013,Forgery,25
+Alameda,206428,2013,Fraud,7
+Alameda,206428,2013,Gambling,
+Alameda,206428,2013,Homicide,
+Alameda,206428,2013,Kidnap,
+Alameda,206428,2013,Larceny,234
+Alameda,206428,2013,Liquor Laws,5
+Alameda,206428,2013,Motor Vehicle Theft,20
+Alameda,206428,2013,Offenses Against Family,1
+Alameda,206428,2013,Prostitution,1
+Alameda,206428,2013,Rape,
+Alameda,206428,2013,Robbery,8
+Alameda,206428,2013,Runaway,
+Alameda,206428,2013,Sex Offenses,1
+Alameda,206428,2013,Stolen Property,1
+Alameda,206428,2013,Trespass,5
+Alameda,206428,2013,Vandalism,159
+Alameda,206428,2013,Weapons,1
+Alameda,206428,2014,Aggravated Assault,7
+Alameda,206428,2014,Arson,1
+Alameda,206428,2014,"Assault, Simple",5
+Alameda,206428,2014,Burglary,54
+Alameda,206428,2014,Curfew,
+Alameda,206428,2014,Disorderly Conduct,9
+Alameda,206428,2014,Drugs,4
+Alameda,206428,2014,DUII,12
+Alameda,206428,2014,Embezzlement,
+Alameda,206428,2014,Forgery,4
+Alameda,206428,2014,Fraud,31
+Alameda,206428,2014,Gambling,
+Alameda,206428,2014,Homicide,
+Alameda,206428,2014,Kidnap,
+Alameda,206428,2014,Larceny,248
+Alameda,206428,2014,Liquor Laws,3
+Alameda,206428,2014,Motor Vehicle Theft,19
+Alameda,206428,2014,Offenses Against Family,
+Alameda,206428,2014,Prostitution,
+Alameda,206428,2014,Rape,1
+Alameda,206428,2014,Robbery,2
+Alameda,206428,2014,Runaway,
+Alameda,206428,2014,Sex Offenses,3
+Alameda,206428,2014,Stolen Property,
+Alameda,206428,2014,Trespass,4
+Alameda,206428,2014,Vandalism,27
+Alameda,206428,2014,Weapons,
+Arbor Lodge,271060,2004,Aggravated Assault,4
+Arbor Lodge,271060,2004,Arson,
+Arbor Lodge,271060,2004,"Assault, Simple",10
+Arbor Lodge,271060,2004,Burglary,22
+Arbor Lodge,271060,2004,Curfew,4
+Arbor Lodge,271060,2004,Disorderly Conduct,11
+Arbor Lodge,271060,2004,Drugs,7
+Arbor Lodge,271060,2004,DUII,7
+Arbor Lodge,271060,2004,Embezzlement,2
+Arbor Lodge,271060,2004,Forgery,16
+Arbor Lodge,271060,2004,Fraud,14
+Arbor Lodge,271060,2004,Gambling,
+Arbor Lodge,271060,2004,Homicide,
+Arbor Lodge,271060,2004,Kidnap,
+Arbor Lodge,271060,2004,Larceny,72
+Arbor Lodge,271060,2004,Liquor Laws,2
+Arbor Lodge,271060,2004,Motor Vehicle Theft,15
+Arbor Lodge,271060,2004,Offenses Against Family,
+Arbor Lodge,271060,2004,Prostitution,
+Arbor Lodge,271060,2004,Rape,
+Arbor Lodge,271060,2004,Robbery,11
+Arbor Lodge,271060,2004,Runaway,
+Arbor Lodge,271060,2004,Sex Offenses,
+Arbor Lodge,271060,2004,Stolen Property,
+Arbor Lodge,271060,2004,Trespass,7
+Arbor Lodge,271060,2004,Vandalism,19
+Arbor Lodge,271060,2004,Weapons,1
+Arbor Lodge,271060,2005,Aggravated Assault,19
+Arbor Lodge,271060,2005,Arson,1
+Arbor Lodge,271060,2005,"Assault, Simple",29
+Arbor Lodge,271060,2005,Burglary,42
+Arbor Lodge,271060,2005,Curfew,33
+Arbor Lodge,271060,2005,Disorderly Conduct,59
+Arbor Lodge,271060,2005,Drugs,28
+Arbor Lodge,271060,2005,DUII,41
+Arbor Lodge,271060,2005,Embezzlement,6
+Arbor Lodge,271060,2005,Forgery,53
+Arbor Lodge,271060,2005,Fraud,57
+Arbor Lodge,271060,2005,Gambling,
+Arbor Lodge,271060,2005,Homicide,1
+Arbor Lodge,271060,2005,Kidnap,
+Arbor Lodge,271060,2005,Larceny,422
+Arbor Lodge,271060,2005,Liquor Laws,17
+Arbor Lodge,271060,2005,Motor Vehicle Theft,55
+Arbor Lodge,271060,2005,Offenses Against Family,
+Arbor Lodge,271060,2005,Prostitution,1
+Arbor Lodge,271060,2005,Rape,
+Arbor Lodge,271060,2005,Robbery,34
+Arbor Lodge,271060,2005,Runaway,
+Arbor Lodge,271060,2005,Sex Offenses,2
+Arbor Lodge,271060,2005,Stolen Property,
+Arbor Lodge,271060,2005,Trespass,41
+Arbor Lodge,271060,2005,Vandalism,69
+Arbor Lodge,271060,2005,Weapons,1
+Arbor Lodge,271060,2006,Aggravated Assault,22
+Arbor Lodge,271060,2006,Arson,
+Arbor Lodge,271060,2006,"Assault, Simple",33
+Arbor Lodge,271060,2006,Burglary,45
+Arbor Lodge,271060,2006,Curfew,3
+Arbor Lodge,271060,2006,Disorderly Conduct,41
+Arbor Lodge,271060,2006,Drugs,35
+Arbor Lodge,271060,2006,DUII,45
+Arbor Lodge,271060,2006,Embezzlement,12
+Arbor Lodge,271060,2006,Forgery,47
+Arbor Lodge,271060,2006,Fraud,73
+Arbor Lodge,271060,2006,Gambling,
+Arbor Lodge,271060,2006,Homicide,
+Arbor Lodge,271060,2006,Kidnap,2
+Arbor Lodge,271060,2006,Larceny,440
+Arbor Lodge,271060,2006,Liquor Laws,27
+Arbor Lodge,271060,2006,Motor Vehicle Theft,52
+Arbor Lodge,271060,2006,Offenses Against Family,
+Arbor Lodge,271060,2006,Prostitution,
+Arbor Lodge,271060,2006,Rape,
+Arbor Lodge,271060,2006,Robbery,23
+Arbor Lodge,271060,2006,Runaway,
+Arbor Lodge,271060,2006,Sex Offenses,
+Arbor Lodge,271060,2006,Stolen Property,1
+Arbor Lodge,271060,2006,Trespass,42
+Arbor Lodge,271060,2006,Vandalism,66
+Arbor Lodge,271060,2006,Weapons,5
+Arbor Lodge,271060,2007,Aggravated Assault,15
+Arbor Lodge,271060,2007,Arson,
+Arbor Lodge,271060,2007,"Assault, Simple",30
+Arbor Lodge,271060,2007,Burglary,54
+Arbor Lodge,271060,2007,Curfew,5
+Arbor Lodge,271060,2007,Disorderly Conduct,30
+Arbor Lodge,271060,2007,Drugs,54
+Arbor Lodge,271060,2007,DUII,37
+Arbor Lodge,271060,2007,Embezzlement,15
+Arbor Lodge,271060,2007,Forgery,37
+Arbor Lodge,271060,2007,Fraud,55
+Arbor Lodge,271060,2007,Gambling,
+Arbor Lodge,271060,2007,Homicide,2
+Arbor Lodge,271060,2007,Kidnap,
+Arbor Lodge,271060,2007,Larceny,456
+Arbor Lodge,271060,2007,Liquor Laws,29
+Arbor Lodge,271060,2007,Motor Vehicle Theft,57
+Arbor Lodge,271060,2007,Offenses Against Family,
+Arbor Lodge,271060,2007,Prostitution,
+Arbor Lodge,271060,2007,Rape,
+Arbor Lodge,271060,2007,Robbery,35
+Arbor Lodge,271060,2007,Runaway,
+Arbor Lodge,271060,2007,Sex Offenses,
+Arbor Lodge,271060,2007,Stolen Property,2
+Arbor Lodge,271060,2007,Trespass,21
+Arbor Lodge,271060,2007,Vandalism,118
+Arbor Lodge,271060,2007,Weapons,4
+Arbor Lodge,271060,2008,Aggravated Assault,11
+Arbor Lodge,271060,2008,Arson,1
+Arbor Lodge,271060,2008,"Assault, Simple",23
+Arbor Lodge,271060,2008,Burglary,55
+Arbor Lodge,271060,2008,Curfew,4
+Arbor Lodge,271060,2008,Disorderly Conduct,47
+Arbor Lodge,271060,2008,Drugs,32
+Arbor Lodge,271060,2008,DUII,44
+Arbor Lodge,271060,2008,Embezzlement,9
+Arbor Lodge,271060,2008,Forgery,18
+Arbor Lodge,271060,2008,Fraud,77
+Arbor Lodge,271060,2008,Gambling,
+Arbor Lodge,271060,2008,Homicide,
+Arbor Lodge,271060,2008,Kidnap,
+Arbor Lodge,271060,2008,Larceny,470
+Arbor Lodge,271060,2008,Liquor Laws,33
+Arbor Lodge,271060,2008,Motor Vehicle Theft,41
+Arbor Lodge,271060,2008,Offenses Against Family,
+Arbor Lodge,271060,2008,Prostitution,
+Arbor Lodge,271060,2008,Rape,2
+Arbor Lodge,271060,2008,Robbery,36
+Arbor Lodge,271060,2008,Runaway,2
+Arbor Lodge,271060,2008,Sex Offenses,
+Arbor Lodge,271060,2008,Stolen Property,1
+Arbor Lodge,271060,2008,Trespass,23
+Arbor Lodge,271060,2008,Vandalism,64
+Arbor Lodge,271060,2008,Weapons,3
+Arbor Lodge,271060,2009,Aggravated Assault,18
+Arbor Lodge,271060,2009,Arson,1
+Arbor Lodge,271060,2009,"Assault, Simple",22
+Arbor Lodge,271060,2009,Burglary,41
+Arbor Lodge,271060,2009,Curfew,
+Arbor Lodge,271060,2009,Disorderly Conduct,44
+Arbor Lodge,271060,2009,Drugs,24
+Arbor Lodge,271060,2009,DUII,18
+Arbor Lodge,271060,2009,Embezzlement,3
+Arbor Lodge,271060,2009,Forgery,19
+Arbor Lodge,271060,2009,Fraud,44
+Arbor Lodge,271060,2009,Gambling,
+Arbor Lodge,271060,2009,Homicide,
+Arbor Lodge,271060,2009,Kidnap,
+Arbor Lodge,271060,2009,Larceny,467
+Arbor Lodge,271060,2009,Liquor Laws,24
+Arbor Lodge,271060,2009,Motor Vehicle Theft,44
+Arbor Lodge,271060,2009,Offenses Against Family,
+Arbor Lodge,271060,2009,Prostitution,
+Arbor Lodge,271060,2009,Rape,
+Arbor Lodge,271060,2009,Robbery,30
+Arbor Lodge,271060,2009,Runaway,
+Arbor Lodge,271060,2009,Sex Offenses,
+Arbor Lodge,271060,2009,Stolen Property,2
+Arbor Lodge,271060,2009,Trespass,25
+Arbor Lodge,271060,2009,Vandalism,66
+Arbor Lodge,271060,2009,Weapons,
+Arbor Lodge,271060,2010,Aggravated Assault,8
+Arbor Lodge,271060,2010,Arson,
+Arbor Lodge,271060,2010,"Assault, Simple",18
+Arbor Lodge,271060,2010,Burglary,34
+Arbor Lodge,271060,2010,Curfew,6
+Arbor Lodge,271060,2010,Disorderly Conduct,40
+Arbor Lodge,271060,2010,Drugs,14
+Arbor Lodge,271060,2010,DUII,28
+Arbor Lodge,271060,2010,Embezzlement,
+Arbor Lodge,271060,2010,Forgery,21
+Arbor Lodge,271060,2010,Fraud,30
+Arbor Lodge,271060,2010,Gambling,
+Arbor Lodge,271060,2010,Homicide,
+Arbor Lodge,271060,2010,Kidnap,
+Arbor Lodge,271060,2010,Larceny,276
+Arbor Lodge,271060,2010,Liquor Laws,17
+Arbor Lodge,271060,2010,Motor Vehicle Theft,22
+Arbor Lodge,271060,2010,Offenses Against Family,
+Arbor Lodge,271060,2010,Prostitution,
+Arbor Lodge,271060,2010,Rape,
+Arbor Lodge,271060,2010,Robbery,18
+Arbor Lodge,271060,2010,Runaway,
+Arbor Lodge,271060,2010,Sex Offenses,1
+Arbor Lodge,271060,2010,Stolen Property,
+Arbor Lodge,271060,2010,Trespass,19
+Arbor Lodge,271060,2010,Vandalism,53
+Arbor Lodge,271060,2010,Weapons,2
+Arbor Lodge,271060,2011,Aggravated Assault,11
+Arbor Lodge,271060,2011,Arson,
+Arbor Lodge,271060,2011,"Assault, Simple",19
+Arbor Lodge,271060,2011,Burglary,40
+Arbor Lodge,271060,2011,Curfew,
+Arbor Lodge,271060,2011,Disorderly Conduct,44
+Arbor Lodge,271060,2011,Drugs,26
+Arbor Lodge,271060,2011,DUII,26
+Arbor Lodge,271060,2011,Embezzlement,2
+Arbor Lodge,271060,2011,Forgery,37
+Arbor Lodge,271060,2011,Fraud,34
+Arbor Lodge,271060,2011,Gambling,
+Arbor Lodge,271060,2011,Homicide,
+Arbor Lodge,271060,2011,Kidnap,
+Arbor Lodge,271060,2011,Larceny,273
+Arbor Lodge,271060,2011,Liquor Laws,51
+Arbor Lodge,271060,2011,Motor Vehicle Theft,33
+Arbor Lodge,271060,2011,Offenses Against Family,
+Arbor Lodge,271060,2011,Prostitution,
+Arbor Lodge,271060,2011,Rape,
+Arbor Lodge,271060,2011,Robbery,22
+Arbor Lodge,271060,2011,Runaway,
+Arbor Lodge,271060,2011,Sex Offenses,1
+Arbor Lodge,271060,2011,Stolen Property,
+Arbor Lodge,271060,2011,Trespass,29
+Arbor Lodge,271060,2011,Vandalism,50
+Arbor Lodge,271060,2011,Weapons,3
+Arbor Lodge,271060,2012,Aggravated Assault,9
+Arbor Lodge,271060,2012,Arson,
+Arbor Lodge,271060,2012,"Assault, Simple",24
+Arbor Lodge,271060,2012,Burglary,46
+Arbor Lodge,271060,2012,Curfew,
+Arbor Lodge,271060,2012,Disorderly Conduct,55
+Arbor Lodge,271060,2012,Drugs,18
+Arbor Lodge,271060,2012,DUII,17
+Arbor Lodge,271060,2012,Embezzlement,1
+Arbor Lodge,271060,2012,Forgery,21
+Arbor Lodge,271060,2012,Fraud,39
+Arbor Lodge,271060,2012,Gambling,
+Arbor Lodge,271060,2012,Homicide,
+Arbor Lodge,271060,2012,Kidnap,
+Arbor Lodge,271060,2012,Larceny,316
+Arbor Lodge,271060,2012,Liquor Laws,33
+Arbor Lodge,271060,2012,Motor Vehicle Theft,42
+Arbor Lodge,271060,2012,Offenses Against Family,
+Arbor Lodge,271060,2012,Prostitution,
+Arbor Lodge,271060,2012,Rape,
+Arbor Lodge,271060,2012,Robbery,16
+Arbor Lodge,271060,2012,Runaway,1
+Arbor Lodge,271060,2012,Sex Offenses,
+Arbor Lodge,271060,2012,Stolen Property,
+Arbor Lodge,271060,2012,Trespass,50
+Arbor Lodge,271060,2012,Vandalism,46
+Arbor Lodge,271060,2012,Weapons,1
+Arbor Lodge,271060,2013,Aggravated Assault,9
+Arbor Lodge,271060,2013,Arson,1
+Arbor Lodge,271060,2013,"Assault, Simple",26
+Arbor Lodge,271060,2013,Burglary,54
+Arbor Lodge,271060,2013,Curfew,1
+Arbor Lodge,271060,2013,Disorderly Conduct,38
+Arbor Lodge,271060,2013,Drugs,29
+Arbor Lodge,271060,2013,DUII,31
+Arbor Lodge,271060,2013,Embezzlement,4
+Arbor Lodge,271060,2013,Forgery,22
+Arbor Lodge,271060,2013,Fraud,29
+Arbor Lodge,271060,2013,Gambling,
+Arbor Lodge,271060,2013,Homicide,
+Arbor Lodge,271060,2013,Kidnap,
+Arbor Lodge,271060,2013,Larceny,299
+Arbor Lodge,271060,2013,Liquor Laws,40
+Arbor Lodge,271060,2013,Motor Vehicle Theft,36
+Arbor Lodge,271060,2013,Offenses Against Family,
+Arbor Lodge,271060,2013,Prostitution,
+Arbor Lodge,271060,2013,Rape,
+Arbor Lodge,271060,2013,Robbery,20
+Arbor Lodge,271060,2013,Runaway,
+Arbor Lodge,271060,2013,Sex Offenses,
+Arbor Lodge,271060,2013,Stolen Property,1
+Arbor Lodge,271060,2013,Trespass,37
+Arbor Lodge,271060,2013,Vandalism,44
+Arbor Lodge,271060,2013,Weapons,3
+Arbor Lodge,271060,2014,Aggravated Assault,12
+Arbor Lodge,271060,2014,Arson,
+Arbor Lodge,271060,2014,"Assault, Simple",16
+Arbor Lodge,271060,2014,Burglary,42
+Arbor Lodge,271060,2014,Curfew,
+Arbor Lodge,271060,2014,Disorderly Conduct,32
+Arbor Lodge,271060,2014,Drugs,22
+Arbor Lodge,271060,2014,DUII,23
+Arbor Lodge,271060,2014,Embezzlement,4
+Arbor Lodge,271060,2014,Forgery,8
+Arbor Lodge,271060,2014,Fraud,32
+Arbor Lodge,271060,2014,Gambling,
+Arbor Lodge,271060,2014,Homicide,
+Arbor Lodge,271060,2014,Kidnap,
+Arbor Lodge,271060,2014,Larceny,342
+Arbor Lodge,271060,2014,Liquor Laws,36
+Arbor Lodge,271060,2014,Motor Vehicle Theft,42
+Arbor Lodge,271060,2014,Offenses Against Family,
+Arbor Lodge,271060,2014,Prostitution,
+Arbor Lodge,271060,2014,Rape,
+Arbor Lodge,271060,2014,Robbery,22
+Arbor Lodge,271060,2014,Runaway,
+Arbor Lodge,271060,2014,Sex Offenses,
+Arbor Lodge,271060,2014,Stolen Property,2
+Arbor Lodge,271060,2014,Trespass,26
+Arbor Lodge,271060,2014,Vandalism,39
+Arbor Lodge,271060,2014,Weapons,2
+Ardenwald,272783,2004,Aggravated Assault,
+Ardenwald,272783,2004,Arson,
+Ardenwald,272783,2004,"Assault, Simple",
+Ardenwald,272783,2004,Burglary,
+Ardenwald,272783,2004,Curfew,
+Ardenwald,272783,2004,Disorderly Conduct,
+Ardenwald,272783,2004,Drugs,
+Ardenwald,272783,2004,DUII,
+Ardenwald,272783,2004,Embezzlement,
+Ardenwald,272783,2004,Forgery,
+Ardenwald,272783,2004,Fraud,
+Ardenwald,272783,2004,Gambling,
+Ardenwald,272783,2004,Homicide,
+Ardenwald,272783,2004,Kidnap,
+Ardenwald,272783,2004,Larceny,
+Ardenwald,272783,2004,Liquor Laws,
+Ardenwald,272783,2004,Motor Vehicle Theft,
+Ardenwald,272783,2004,Offenses Against Family,
+Ardenwald,272783,2004,Prostitution,
+Ardenwald,272783,2004,Rape,
+Ardenwald,272783,2004,Robbery,
+Ardenwald,272783,2004,Runaway,
+Ardenwald,272783,2004,Sex Offenses,
+Ardenwald,272783,2004,Stolen Property,
+Ardenwald,272783,2004,Trespass,
+Ardenwald,272783,2004,Vandalism,
+Ardenwald,272783,2004,Weapons,
+Ardenwald,272783,2005,Aggravated Assault,
+Ardenwald,272783,2005,Arson,
+Ardenwald,272783,2005,"Assault, Simple",
+Ardenwald,272783,2005,Burglary,
+Ardenwald,272783,2005,Curfew,
+Ardenwald,272783,2005,Disorderly Conduct,
+Ardenwald,272783,2005,Drugs,
+Ardenwald,272783,2005,DUII,
+Ardenwald,272783,2005,Embezzlement,
+Ardenwald,272783,2005,Forgery,
+Ardenwald,272783,2005,Fraud,
+Ardenwald,272783,2005,Gambling,
+Ardenwald,272783,2005,Homicide,
+Ardenwald,272783,2005,Kidnap,
+Ardenwald,272783,2005,Larceny,1
+Ardenwald,272783,2005,Liquor Laws,
+Ardenwald,272783,2005,Motor Vehicle Theft,
+Ardenwald,272783,2005,Offenses Against Family,
+Ardenwald,272783,2005,Prostitution,
+Ardenwald,272783,2005,Rape,
+Ardenwald,272783,2005,Robbery,
+Ardenwald,272783,2005,Runaway,
+Ardenwald,272783,2005,Sex Offenses,
+Ardenwald,272783,2005,Stolen Property,
+Ardenwald,272783,2005,Trespass,
+Ardenwald,272783,2005,Vandalism,
+Ardenwald,272783,2005,Weapons,
+Ardenwald,272783,2006,Aggravated Assault,
+Ardenwald,272783,2006,Arson,
+Ardenwald,272783,2006,"Assault, Simple",
+Ardenwald,272783,2006,Burglary,
+Ardenwald,272783,2006,Curfew,
+Ardenwald,272783,2006,Disorderly Conduct,
+Ardenwald,272783,2006,Drugs,
+Ardenwald,272783,2006,DUII,
+Ardenwald,272783,2006,Embezzlement,
+Ardenwald,272783,2006,Forgery,
+Ardenwald,272783,2006,Fraud,
+Ardenwald,272783,2006,Gambling,
+Ardenwald,272783,2006,Homicide,
+Ardenwald,272783,2006,Kidnap,
+Ardenwald,272783,2006,Larceny,
+Ardenwald,272783,2006,Liquor Laws,
+Ardenwald,272783,2006,Motor Vehicle Theft,
+Ardenwald,272783,2006,Offenses Against Family,
+Ardenwald,272783,2006,Prostitution,
+Ardenwald,272783,2006,Rape,
+Ardenwald,272783,2006,Robbery,
+Ardenwald,272783,2006,Runaway,
+Ardenwald,272783,2006,Sex Offenses,
+Ardenwald,272783,2006,Stolen Property,
+Ardenwald,272783,2006,Trespass,
+Ardenwald,272783,2006,Vandalism,
+Ardenwald,272783,2006,Weapons,
+Ardenwald,272783,2007,Aggravated Assault,
+Ardenwald,272783,2007,Arson,
+Ardenwald,272783,2007,"Assault, Simple",
+Ardenwald,272783,2007,Burglary,
+Ardenwald,272783,2007,Curfew,
+Ardenwald,272783,2007,Disorderly Conduct,
+Ardenwald,272783,2007,Drugs,
+Ardenwald,272783,2007,DUII,
+Ardenwald,272783,2007,Embezzlement,
+Ardenwald,272783,2007,Forgery,
+Ardenwald,272783,2007,Fraud,
+Ardenwald,272783,2007,Gambling,
+Ardenwald,272783,2007,Homicide,
+Ardenwald,272783,2007,Kidnap,
+Ardenwald,272783,2007,Larceny,
+Ardenwald,272783,2007,Liquor Laws,
+Ardenwald,272783,2007,Motor Vehicle Theft,
+Ardenwald,272783,2007,Offenses Against Family,
+Ardenwald,272783,2007,Prostitution,
+Ardenwald,272783,2007,Rape,
+Ardenwald,272783,2007,Robbery,
+Ardenwald,272783,2007,Runaway,
+Ardenwald,272783,2007,Sex Offenses,
+Ardenwald,272783,2007,Stolen Property,
+Ardenwald,272783,2007,Trespass,
+Ardenwald,272783,2007,Vandalism,
+Ardenwald,272783,2007,Weapons,
+Ardenwald,272783,2008,Aggravated Assault,
+Ardenwald,272783,2008,Arson,
+Ardenwald,272783,2008,"Assault, Simple",
+Ardenwald,272783,2008,Burglary,
+Ardenwald,272783,2008,Curfew,
+Ardenwald,272783,2008,Disorderly Conduct,
+Ardenwald,272783,2008,Drugs,
+Ardenwald,272783,2008,DUII,
+Ardenwald,272783,2008,Embezzlement,
+Ardenwald,272783,2008,Forgery,
+Ardenwald,272783,2008,Fraud,
+Ardenwald,272783,2008,Gambling,
+Ardenwald,272783,2008,Homicide,
+Ardenwald,272783,2008,Kidnap,
+Ardenwald,272783,2008,Larceny,1
+Ardenwald,272783,2008,Liquor Laws,
+Ardenwald,272783,2008,Motor Vehicle Theft,
+Ardenwald,272783,2008,Offenses Against Family,
+Ardenwald,272783,2008,Prostitution,
+Ardenwald,272783,2008,Rape,
+Ardenwald,272783,2008,Robbery,
+Ardenwald,272783,2008,Runaway,
+Ardenwald,272783,2008,Sex Offenses,
+Ardenwald,272783,2008,Stolen Property,
+Ardenwald,272783,2008,Trespass,
+Ardenwald,272783,2008,Vandalism,1
+Ardenwald,272783,2008,Weapons,
+Ardenwald,272783,2009,Aggravated Assault,
+Ardenwald,272783,2009,Arson,
+Ardenwald,272783,2009,"Assault, Simple",
+Ardenwald,272783,2009,Burglary,
+Ardenwald,272783,2009,Curfew,
+Ardenwald,272783,2009,Disorderly Conduct,
+Ardenwald,272783,2009,Drugs,
+Ardenwald,272783,2009,DUII,
+Ardenwald,272783,2009,Embezzlement,
+Ardenwald,272783,2009,Forgery,
+Ardenwald,272783,2009,Fraud,
+Ardenwald,272783,2009,Gambling,
+Ardenwald,272783,2009,Homicide,
+Ardenwald,272783,2009,Kidnap,
+Ardenwald,272783,2009,Larceny,
+Ardenwald,272783,2009,Liquor Laws,
+Ardenwald,272783,2009,Motor Vehicle Theft,
+Ardenwald,272783,2009,Offenses Against Family,
+Ardenwald,272783,2009,Prostitution,
+Ardenwald,272783,2009,Rape,
+Ardenwald,272783,2009,Robbery,
+Ardenwald,272783,2009,Runaway,
+Ardenwald,272783,2009,Sex Offenses,
+Ardenwald,272783,2009,Stolen Property,
+Ardenwald,272783,2009,Trespass,
+Ardenwald,272783,2009,Vandalism,1
+Ardenwald,272783,2009,Weapons,
+Ardenwald,272783,2010,Aggravated Assault,
+Ardenwald,272783,2010,Arson,
+Ardenwald,272783,2010,"Assault, Simple",
+Ardenwald,272783,2010,Burglary,
+Ardenwald,272783,2010,Curfew,
+Ardenwald,272783,2010,Disorderly Conduct,
+Ardenwald,272783,2010,Drugs,
+Ardenwald,272783,2010,DUII,
+Ardenwald,272783,2010,Embezzlement,
+Ardenwald,272783,2010,Forgery,
+Ardenwald,272783,2010,Fraud,
+Ardenwald,272783,2010,Gambling,
+Ardenwald,272783,2010,Homicide,
+Ardenwald,272783,2010,Kidnap,
+Ardenwald,272783,2010,Larceny,
+Ardenwald,272783,2010,Liquor Laws,
+Ardenwald,272783,2010,Motor Vehicle Theft,
+Ardenwald,272783,2010,Offenses Against Family,
+Ardenwald,272783,2010,Prostitution,
+Ardenwald,272783,2010,Rape,
+Ardenwald,272783,2010,Robbery,
+Ardenwald,272783,2010,Runaway,
+Ardenwald,272783,2010,Sex Offenses,
+Ardenwald,272783,2010,Stolen Property,
+Ardenwald,272783,2010,Trespass,
+Ardenwald,272783,2010,Vandalism,
+Ardenwald,272783,2010,Weapons,
+Ardenwald,272783,2011,Aggravated Assault,
+Ardenwald,272783,2011,Arson,
+Ardenwald,272783,2011,"Assault, Simple",
+Ardenwald,272783,2011,Burglary,
+Ardenwald,272783,2011,Curfew,
+Ardenwald,272783,2011,Disorderly Conduct,
+Ardenwald,272783,2011,Drugs,
+Ardenwald,272783,2011,DUII,
+Ardenwald,272783,2011,Embezzlement,
+Ardenwald,272783,2011,Forgery,
+Ardenwald,272783,2011,Fraud,
+Ardenwald,272783,2011,Gambling,
+Ardenwald,272783,2011,Homicide,
+Ardenwald,272783,2011,Kidnap,
+Ardenwald,272783,2011,Larceny,1
+Ardenwald,272783,2011,Liquor Laws,
+Ardenwald,272783,2011,Motor Vehicle Theft,
+Ardenwald,272783,2011,Offenses Against Family,
+Ardenwald,272783,2011,Prostitution,
+Ardenwald,272783,2011,Rape,
+Ardenwald,272783,2011,Robbery,
+Ardenwald,272783,2011,Runaway,
+Ardenwald,272783,2011,Sex Offenses,
+Ardenwald,272783,2011,Stolen Property,
+Ardenwald,272783,2011,Trespass,
+Ardenwald,272783,2011,Vandalism,
+Ardenwald,272783,2011,Weapons,
+Ardenwald,272783,2012,Aggravated Assault,
+Ardenwald,272783,2012,Arson,
+Ardenwald,272783,2012,"Assault, Simple",
+Ardenwald,272783,2012,Burglary,
+Ardenwald,272783,2012,Curfew,
+Ardenwald,272783,2012,Disorderly Conduct,
+Ardenwald,272783,2012,Drugs,
+Ardenwald,272783,2012,DUII,
+Ardenwald,272783,2012,Embezzlement,
+Ardenwald,272783,2012,Forgery,
+Ardenwald,272783,2012,Fraud,
+Ardenwald,272783,2012,Gambling,
+Ardenwald,272783,2012,Homicide,
+Ardenwald,272783,2012,Kidnap,
+Ardenwald,272783,2012,Larceny,1
+Ardenwald,272783,2012,Liquor Laws,
+Ardenwald,272783,2012,Motor Vehicle Theft,
+Ardenwald,272783,2012,Offenses Against Family,
+Ardenwald,272783,2012,Prostitution,
+Ardenwald,272783,2012,Rape,
+Ardenwald,272783,2012,Robbery,
+Ardenwald,272783,2012,Runaway,
+Ardenwald,272783,2012,Sex Offenses,
+Ardenwald,272783,2012,Stolen Property,
+Ardenwald,272783,2012,Trespass,
+Ardenwald,272783,2012,Vandalism,1
+Ardenwald,272783,2012,Weapons,
+Ardenwald,272783,2013,Aggravated Assault,
+Ardenwald,272783,2013,Arson,
+Ardenwald,272783,2013,"Assault, Simple",
+Ardenwald,272783,2013,Burglary,
+Ardenwald,272783,2013,Curfew,
+Ardenwald,272783,2013,Disorderly Conduct,
+Ardenwald,272783,2013,Drugs,
+Ardenwald,272783,2013,DUII,
+Ardenwald,272783,2013,Embezzlement,
+Ardenwald,272783,2013,Forgery,
+Ardenwald,272783,2013,Fraud,1
+Ardenwald,272783,2013,Gambling,
+Ardenwald,272783,2013,Homicide,
+Ardenwald,272783,2013,Kidnap,
+Ardenwald,272783,2013,Larceny,
+Ardenwald,272783,2013,Liquor Laws,
+Ardenwald,272783,2013,Motor Vehicle Theft,
+Ardenwald,272783,2013,Offenses Against Family,
+Ardenwald,272783,2013,Prostitution,
+Ardenwald,272783,2013,Rape,
+Ardenwald,272783,2013,Robbery,
+Ardenwald,272783,2013,Runaway,
+Ardenwald,272783,2013,Sex Offenses,
+Ardenwald,272783,2013,Stolen Property,
+Ardenwald,272783,2013,Trespass,1
+Ardenwald,272783,2013,Vandalism,1
+Ardenwald,272783,2013,Weapons,
+Ardenwald,272783,2014,Aggravated Assault,
+Ardenwald,272783,2014,Arson,
+Ardenwald,272783,2014,"Assault, Simple",
+Ardenwald,272783,2014,Burglary,1
+Ardenwald,272783,2014,Curfew,
+Ardenwald,272783,2014,Disorderly Conduct,
+Ardenwald,272783,2014,Drugs,
+Ardenwald,272783,2014,DUII,
+Ardenwald,272783,2014,Embezzlement,
+Ardenwald,272783,2014,Forgery,
+Ardenwald,272783,2014,Fraud,
+Ardenwald,272783,2014,Gambling,
+Ardenwald,272783,2014,Homicide,
+Ardenwald,272783,2014,Kidnap,
+Ardenwald,272783,2014,Larceny,
+Ardenwald,272783,2014,Liquor Laws,
+Ardenwald,272783,2014,Motor Vehicle Theft,
+Ardenwald,272783,2014,Offenses Against Family,
+Ardenwald,272783,2014,Prostitution,
+Ardenwald,272783,2014,Rape,
+Ardenwald,272783,2014,Robbery,
+Ardenwald,272783,2014,Runaway,
+Ardenwald,272783,2014,Sex Offenses,
+Ardenwald,272783,2014,Stolen Property,
+Ardenwald,272783,2014,Trespass,
+Ardenwald,272783,2014,Vandalism,
+Ardenwald,272783,2014,Weapons,
+Argay,271061,2004,Aggravated Assault,7
+Argay,271061,2004,Arson,
+Argay,271061,2004,"Assault, Simple",9
+Argay,271061,2004,Burglary,20
+Argay,271061,2004,Curfew,
+Argay,271061,2004,Disorderly Conduct,3
+Argay,271061,2004,Drugs,2
+Argay,271061,2004,DUII,5
+Argay,271061,2004,Embezzlement,2
+Argay,271061,2004,Forgery,17
+Argay,271061,2004,Fraud,5
+Argay,271061,2004,Gambling,
+Argay,271061,2004,Homicide,
+Argay,271061,2004,Kidnap,
+Argay,271061,2004,Larceny,72
+Argay,271061,2004,Liquor Laws,
+Argay,271061,2004,Motor Vehicle Theft,26
+Argay,271061,2004,Offenses Against Family,
+Argay,271061,2004,Prostitution,
+Argay,271061,2004,Rape,
+Argay,271061,2004,Robbery,2
+Argay,271061,2004,Runaway,
+Argay,271061,2004,Sex Offenses,
+Argay,271061,2004,Stolen Property,
+Argay,271061,2004,Trespass,7
+Argay,271061,2004,Vandalism,25
+Argay,271061,2004,Weapons,3
+Argay,271061,2005,Aggravated Assault,17
+Argay,271061,2005,Arson,1
+Argay,271061,2005,"Assault, Simple",28
+Argay,271061,2005,Burglary,117
+Argay,271061,2005,Curfew,1
+Argay,271061,2005,Disorderly Conduct,17
+Argay,271061,2005,Drugs,18
+Argay,271061,2005,DUII,18
+Argay,271061,2005,Embezzlement,8
+Argay,271061,2005,Forgery,30
+Argay,271061,2005,Fraud,61
+Argay,271061,2005,Gambling,
+Argay,271061,2005,Homicide,
+Argay,271061,2005,Kidnap,
+Argay,271061,2005,Larceny,307
+Argay,271061,2005,Liquor Laws,
+Argay,271061,2005,Motor Vehicle Theft,111
+Argay,271061,2005,Offenses Against Family,1
+Argay,271061,2005,Prostitution,
+Argay,271061,2005,Rape,
+Argay,271061,2005,Robbery,15
+Argay,271061,2005,Runaway,
+Argay,271061,2005,Sex Offenses,
+Argay,271061,2005,Stolen Property,
+Argay,271061,2005,Trespass,23
+Argay,271061,2005,Vandalism,72
+Argay,271061,2005,Weapons,4
+Argay,271061,2006,Aggravated Assault,10
+Argay,271061,2006,Arson,2
+Argay,271061,2006,"Assault, Simple",15
+Argay,271061,2006,Burglary,78
+Argay,271061,2006,Curfew,2
+Argay,271061,2006,Disorderly Conduct,10
+Argay,271061,2006,Drugs,24
+Argay,271061,2006,DUII,27
+Argay,271061,2006,Embezzlement,5
+Argay,271061,2006,Forgery,20
+Argay,271061,2006,Fraud,51
+Argay,271061,2006,Gambling,
+Argay,271061,2006,Homicide,
+Argay,271061,2006,Kidnap,
+Argay,271061,2006,Larceny,270
+Argay,271061,2006,Liquor Laws,3
+Argay,271061,2006,Motor Vehicle Theft,83
+Argay,271061,2006,Offenses Against Family,
+Argay,271061,2006,Prostitution,
+Argay,271061,2006,Rape,1
+Argay,271061,2006,Robbery,20
+Argay,271061,2006,Runaway,
+Argay,271061,2006,Sex Offenses,
+Argay,271061,2006,Stolen Property,
+Argay,271061,2006,Trespass,26
+Argay,271061,2006,Vandalism,80
+Argay,271061,2006,Weapons,5
+Argay,271061,2007,Aggravated Assault,24
+Argay,271061,2007,Arson,
+Argay,271061,2007,"Assault, Simple",23
+Argay,271061,2007,Burglary,54
+Argay,271061,2007,Curfew,
+Argay,271061,2007,Disorderly Conduct,27
+Argay,271061,2007,Drugs,28
+Argay,271061,2007,DUII,21
+Argay,271061,2007,Embezzlement,2
+Argay,271061,2007,Forgery,33
+Argay,271061,2007,Fraud,43
+Argay,271061,2007,Gambling,
+Argay,271061,2007,Homicide,1
+Argay,271061,2007,Kidnap,
+Argay,271061,2007,Larceny,298
+Argay,271061,2007,Liquor Laws,2
+Argay,271061,2007,Motor Vehicle Theft,91
+Argay,271061,2007,Offenses Against Family,
+Argay,271061,2007,Prostitution,5
+Argay,271061,2007,Rape,
+Argay,271061,2007,Robbery,19
+Argay,271061,2007,Runaway,
+Argay,271061,2007,Sex Offenses,1
+Argay,271061,2007,Stolen Property,
+Argay,271061,2007,Trespass,17
+Argay,271061,2007,Vandalism,85
+Argay,271061,2007,Weapons,4
+Argay,271061,2008,Aggravated Assault,19
+Argay,271061,2008,Arson,2
+Argay,271061,2008,"Assault, Simple",10
+Argay,271061,2008,Burglary,73
+Argay,271061,2008,Curfew,1
+Argay,271061,2008,Disorderly Conduct,18
+Argay,271061,2008,Drugs,23
+Argay,271061,2008,DUII,17
+Argay,271061,2008,Embezzlement,1
+Argay,271061,2008,Forgery,8
+Argay,271061,2008,Fraud,29
+Argay,271061,2008,Gambling,
+Argay,271061,2008,Homicide,
+Argay,271061,2008,Kidnap,
+Argay,271061,2008,Larceny,271
+Argay,271061,2008,Liquor Laws,8
+Argay,271061,2008,Motor Vehicle Theft,63
+Argay,271061,2008,Offenses Against Family,
+Argay,271061,2008,Prostitution,1
+Argay,271061,2008,Rape,
+Argay,271061,2008,Robbery,15
+Argay,271061,2008,Runaway,
+Argay,271061,2008,Sex Offenses,
+Argay,271061,2008,Stolen Property,
+Argay,271061,2008,Trespass,37
+Argay,271061,2008,Vandalism,104
+Argay,271061,2008,Weapons,4
+Argay,271061,2009,Aggravated Assault,19
+Argay,271061,2009,Arson,
+Argay,271061,2009,"Assault, Simple",21
+Argay,271061,2009,Burglary,48
+Argay,271061,2009,Curfew,
+Argay,271061,2009,Disorderly Conduct,16
+Argay,271061,2009,Drugs,11
+Argay,271061,2009,DUII,13
+Argay,271061,2009,Embezzlement,4
+Argay,271061,2009,Forgery,18
+Argay,271061,2009,Fraud,29
+Argay,271061,2009,Gambling,
+Argay,271061,2009,Homicide,
+Argay,271061,2009,Kidnap,
+Argay,271061,2009,Larceny,203
+Argay,271061,2009,Liquor Laws,1
+Argay,271061,2009,Motor Vehicle Theft,72
+Argay,271061,2009,Offenses Against Family,
+Argay,271061,2009,Prostitution,1
+Argay,271061,2009,Rape,
+Argay,271061,2009,Robbery,9
+Argay,271061,2009,Runaway,
+Argay,271061,2009,Sex Offenses,
+Argay,271061,2009,Stolen Property,
+Argay,271061,2009,Trespass,25
+Argay,271061,2009,Vandalism,77
+Argay,271061,2009,Weapons,1
+Argay,271061,2010,Aggravated Assault,14
+Argay,271061,2010,Arson,1
+Argay,271061,2010,"Assault, Simple",32
+Argay,271061,2010,Burglary,42
+Argay,271061,2010,Curfew,
+Argay,271061,2010,Disorderly Conduct,17
+Argay,271061,2010,Drugs,3
+Argay,271061,2010,DUII,8
+Argay,271061,2010,Embezzlement,3
+Argay,271061,2010,Forgery,22
+Argay,271061,2010,Fraud,18
+Argay,271061,2010,Gambling,
+Argay,271061,2010,Homicide,1
+Argay,271061,2010,Kidnap,
+Argay,271061,2010,Larceny,257
+Argay,271061,2010,Liquor Laws,1
+Argay,271061,2010,Motor Vehicle Theft,72
+Argay,271061,2010,Offenses Against Family,
+Argay,271061,2010,Prostitution,
+Argay,271061,2010,Rape,1
+Argay,271061,2010,Robbery,12
+Argay,271061,2010,Runaway,
+Argay,271061,2010,Sex Offenses,
+Argay,271061,2010,Stolen Property,
+Argay,271061,2010,Trespass,27
+Argay,271061,2010,Vandalism,70
+Argay,271061,2010,Weapons,2
+Argay,271061,2011,Aggravated Assault,21
+Argay,271061,2011,Arson,1
+Argay,271061,2011,"Assault, Simple",25
+Argay,271061,2011,Burglary,65
+Argay,271061,2011,Curfew,1
+Argay,271061,2011,Disorderly Conduct,15
+Argay,271061,2011,Drugs,7
+Argay,271061,2011,DUII,16
+Argay,271061,2011,Embezzlement,3
+Argay,271061,2011,Forgery,15
+Argay,271061,2011,Fraud,20
+Argay,271061,2011,Gambling,
+Argay,271061,2011,Homicide,
+Argay,271061,2011,Kidnap,
+Argay,271061,2011,Larceny,230
+Argay,271061,2011,Liquor Laws,6
+Argay,271061,2011,Motor Vehicle Theft,68
+Argay,271061,2011,Offenses Against Family,
+Argay,271061,2011,Prostitution,
+Argay,271061,2011,Rape,
+Argay,271061,2011,Robbery,9
+Argay,271061,2011,Runaway,
+Argay,271061,2011,Sex Offenses,
+Argay,271061,2011,Stolen Property,
+Argay,271061,2011,Trespass,23
+Argay,271061,2011,Vandalism,58
+Argay,271061,2011,Weapons,2
+Argay,271061,2012,Aggravated Assault,13
+Argay,271061,2012,Arson,
+Argay,271061,2012,"Assault, Simple",17
+Argay,271061,2012,Burglary,61
+Argay,271061,2012,Curfew,
+Argay,271061,2012,Disorderly Conduct,20
+Argay,271061,2012,Drugs,6
+Argay,271061,2012,DUII,14
+Argay,271061,2012,Embezzlement,3
+Argay,271061,2012,Forgery,4
+Argay,271061,2012,Fraud,23
+Argay,271061,2012,Gambling,
+Argay,271061,2012,Homicide,
+Argay,271061,2012,Kidnap,
+Argay,271061,2012,Larceny,161
+Argay,271061,2012,Liquor Laws,2
+Argay,271061,2012,Motor Vehicle Theft,79
+Argay,271061,2012,Offenses Against Family,
+Argay,271061,2012,Prostitution,1
+Argay,271061,2012,Rape,
+Argay,271061,2012,Robbery,11
+Argay,271061,2012,Runaway,
+Argay,271061,2012,Sex Offenses,
+Argay,271061,2012,Stolen Property,2
+Argay,271061,2012,Trespass,21
+Argay,271061,2012,Vandalism,50
+Argay,271061,2012,Weapons,3
+Argay,271061,2013,Aggravated Assault,18
+Argay,271061,2013,Arson,1
+Argay,271061,2013,"Assault, Simple",15
+Argay,271061,2013,Burglary,41
+Argay,271061,2013,Curfew,1
+Argay,271061,2013,Disorderly Conduct,20
+Argay,271061,2013,Drugs,12
+Argay,271061,2013,DUII,11
+Argay,271061,2013,Embezzlement,2
+Argay,271061,2013,Forgery,5
+Argay,271061,2013,Fraud,19
+Argay,271061,2013,Gambling,
+Argay,271061,2013,Homicide,
+Argay,271061,2013,Kidnap,
+Argay,271061,2013,Larceny,190
+Argay,271061,2013,Liquor Laws,2
+Argay,271061,2013,Motor Vehicle Theft,67
+Argay,271061,2013,Offenses Against Family,
+Argay,271061,2013,Prostitution,
+Argay,271061,2013,Rape,
+Argay,271061,2013,Robbery,8
+Argay,271061,2013,Runaway,
+Argay,271061,2013,Sex Offenses,
+Argay,271061,2013,Stolen Property,1
+Argay,271061,2013,Trespass,17
+Argay,271061,2013,Vandalism,47
+Argay,271061,2013,Weapons,2
+Argay,271061,2014,Aggravated Assault,20
+Argay,271061,2014,Arson,
+Argay,271061,2014,"Assault, Simple",16
+Argay,271061,2014,Burglary,70
+Argay,271061,2014,Curfew,
+Argay,271061,2014,Disorderly Conduct,15
+Argay,271061,2014,Drugs,9
+Argay,271061,2014,DUII,13
+Argay,271061,2014,Embezzlement,2
+Argay,271061,2014,Forgery,8
+Argay,271061,2014,Fraud,30
+Argay,271061,2014,Gambling,
+Argay,271061,2014,Homicide,
+Argay,271061,2014,Kidnap,1
+Argay,271061,2014,Larceny,272
+Argay,271061,2014,Liquor Laws,1
+Argay,271061,2014,Motor Vehicle Theft,67
+Argay,271061,2014,Offenses Against Family,
+Argay,271061,2014,Prostitution,2
+Argay,271061,2014,Rape,
+Argay,271061,2014,Robbery,9
+Argay,271061,2014,Runaway,
+Argay,271061,2014,Sex Offenses,1
+Argay,271061,2014,Stolen Property,
+Argay,271061,2014,Trespass,18
+Argay,271061,2014,Vandalism,42
+Argay,271061,2014,Weapons,
+Boise,271065,2004,Aggravated Assault,17
+Boise,271065,2004,Arson,
+Boise,271065,2004,"Assault, Simple",27
+Boise,271065,2004,Burglary,45
+Boise,271065,2004,Curfew,4
+Boise,271065,2004,Disorderly Conduct,21
+Boise,271065,2004,Drugs,55
+Boise,271065,2004,DUII,6
+Boise,271065,2004,Embezzlement,
+Boise,271065,2004,Forgery,1
+Boise,271065,2004,Fraud,23
+Boise,271065,2004,Gambling,
+Boise,271065,2004,Homicide,1
+Boise,271065,2004,Kidnap,
+Boise,271065,2004,Larceny,83
+Boise,271065,2004,Liquor Laws,2
+Boise,271065,2004,Motor Vehicle Theft,17
+Boise,271065,2004,Offenses Against Family,
+Boise,271065,2004,Prostitution,2
+Boise,271065,2004,Rape,1
+Boise,271065,2004,Robbery,9
+Boise,271065,2004,Runaway,1
+Boise,271065,2004,Sex Offenses,1
+Boise,271065,2004,Stolen Property,
+Boise,271065,2004,Trespass,18
+Boise,271065,2004,Vandalism,32
+Boise,271065,2004,Weapons,2
+Boise,271065,2005,Aggravated Assault,57
+Boise,271065,2005,Arson,
+Boise,271065,2005,"Assault, Simple",64
+Boise,271065,2005,Burglary,95
+Boise,271065,2005,Curfew,2
+Boise,271065,2005,Disorderly Conduct,33
+Boise,271065,2005,Drugs,97
+Boise,271065,2005,DUII,24
+Boise,271065,2005,Embezzlement,2
+Boise,271065,2005,Forgery,9
+Boise,271065,2005,Fraud,33
+Boise,271065,2005,Gambling,
+Boise,271065,2005,Homicide,4
+Boise,271065,2005,Kidnap,1
+Boise,271065,2005,Larceny,330
+Boise,271065,2005,Liquor Laws,7
+Boise,271065,2005,Motor Vehicle Theft,57
+Boise,271065,2005,Offenses Against Family,
+Boise,271065,2005,Prostitution,6
+Boise,271065,2005,Rape,1
+Boise,271065,2005,Robbery,20
+Boise,271065,2005,Runaway,1
+Boise,271065,2005,Sex Offenses,1
+Boise,271065,2005,Stolen Property,1
+Boise,271065,2005,Trespass,77
+Boise,271065,2005,Vandalism,135
+Boise,271065,2005,Weapons,17
+Boise,271065,2006,Aggravated Assault,52
+Boise,271065,2006,Arson,2
+Boise,271065,2006,"Assault, Simple",49
+Boise,271065,2006,Burglary,132
+Boise,271065,2006,Curfew,12
+Boise,271065,2006,Disorderly Conduct,44
+Boise,271065,2006,Drugs,136
+Boise,271065,2006,DUII,18
+Boise,271065,2006,Embezzlement,1
+Boise,271065,2006,Forgery,7
+Boise,271065,2006,Fraud,10
+Boise,271065,2006,Gambling,1
+Boise,271065,2006,Homicide,
+Boise,271065,2006,Kidnap,1
+Boise,271065,2006,Larceny,289
+Boise,271065,2006,Liquor Laws,12
+Boise,271065,2006,Motor Vehicle Theft,66
+Boise,271065,2006,Offenses Against Family,
+Boise,271065,2006,Prostitution,2
+Boise,271065,2006,Rape,
+Boise,271065,2006,Robbery,18
+Boise,271065,2006,Runaway,
+Boise,271065,2006,Sex Offenses,
+Boise,271065,2006,Stolen Property,
+Boise,271065,2006,Trespass,85
+Boise,271065,2006,Vandalism,149
+Boise,271065,2006,Weapons,11
+Boise,271065,2007,Aggravated Assault,41
+Boise,271065,2007,Arson,
+Boise,271065,2007,"Assault, Simple",54
+Boise,271065,2007,Burglary,133
+Boise,271065,2007,Curfew,4
+Boise,271065,2007,Disorderly Conduct,50
+Boise,271065,2007,Drugs,141
+Boise,271065,2007,DUII,25
+Boise,271065,2007,Embezzlement,1
+Boise,271065,2007,Forgery,7
+Boise,271065,2007,Fraud,21
+Boise,271065,2007,Gambling,1
+Boise,271065,2007,Homicide,4
+Boise,271065,2007,Kidnap,1
+Boise,271065,2007,Larceny,208
+Boise,271065,2007,Liquor Laws,18
+Boise,271065,2007,Motor Vehicle Theft,64
+Boise,271065,2007,Offenses Against Family,
+Boise,271065,2007,Prostitution,1
+Boise,271065,2007,Rape,1
+Boise,271065,2007,Robbery,29
+Boise,271065,2007,Runaway,
+Boise,271065,2007,Sex Offenses,1
+Boise,271065,2007,Stolen Property,2
+Boise,271065,2007,Trespass,59
+Boise,271065,2007,Vandalism,191
+Boise,271065,2007,Weapons,10
+Boise,271065,2008,Aggravated Assault,49
+Boise,271065,2008,Arson,2
+Boise,271065,2008,"Assault, Simple",58
+Boise,271065,2008,Burglary,84
+Boise,271065,2008,Curfew,3
+Boise,271065,2008,Disorderly Conduct,40
+Boise,271065,2008,Drugs,138
+Boise,271065,2008,DUII,22
+Boise,271065,2008,Embezzlement,2
+Boise,271065,2008,Forgery,8
+Boise,271065,2008,Fraud,24
+Boise,271065,2008,Gambling,
+Boise,271065,2008,Homicide,1
+Boise,271065,2008,Kidnap,
+Boise,271065,2008,Larceny,226
+Boise,271065,2008,Liquor Laws,40
+Boise,271065,2008,Motor Vehicle Theft,47
+Boise,271065,2008,Offenses Against Family,
+Boise,271065,2008,Prostitution,1
+Boise,271065,2008,Rape,
+Boise,271065,2008,Robbery,24
+Boise,271065,2008,Runaway,
+Boise,271065,2008,Sex Offenses,1
+Boise,271065,2008,Stolen Property,4
+Boise,271065,2008,Trespass,50
+Boise,271065,2008,Vandalism,110
+Boise,271065,2008,Weapons,18
+Boise,271065,2009,Aggravated Assault,33
+Boise,271065,2009,Arson,
+Boise,271065,2009,"Assault, Simple",50
+Boise,271065,2009,Burglary,66
+Boise,271065,2009,Curfew,4
+Boise,271065,2009,Disorderly Conduct,37
+Boise,271065,2009,Drugs,35
+Boise,271065,2009,DUII,21
+Boise,271065,2009,Embezzlement,1
+Boise,271065,2009,Forgery,2
+Boise,271065,2009,Fraud,16
+Boise,271065,2009,Gambling,
+Boise,271065,2009,Homicide,
+Boise,271065,2009,Kidnap,
+Boise,271065,2009,Larceny,195
+Boise,271065,2009,Liquor Laws,21
+Boise,271065,2009,Motor Vehicle Theft,43
+Boise,271065,2009,Offenses Against Family,
+Boise,271065,2009,Prostitution,
+Boise,271065,2009,Rape,2
+Boise,271065,2009,Robbery,16
+Boise,271065,2009,Runaway,
+Boise,271065,2009,Sex Offenses,3
+Boise,271065,2009,Stolen Property,
+Boise,271065,2009,Trespass,39
+Boise,271065,2009,Vandalism,87
+Boise,271065,2009,Weapons,5
+Boise,271065,2010,Aggravated Assault,29
+Boise,271065,2010,Arson,
+Boise,271065,2010,"Assault, Simple",28
+Boise,271065,2010,Burglary,65
+Boise,271065,2010,Curfew,1
+Boise,271065,2010,Disorderly Conduct,36
+Boise,271065,2010,Drugs,36
+Boise,271065,2010,DUII,19
+Boise,271065,2010,Embezzlement,1
+Boise,271065,2010,Forgery,2
+Boise,271065,2010,Fraud,31
+Boise,271065,2010,Gambling,
+Boise,271065,2010,Homicide,1
+Boise,271065,2010,Kidnap,
+Boise,271065,2010,Larceny,247
+Boise,271065,2010,Liquor Laws,36
+Boise,271065,2010,Motor Vehicle Theft,40
+Boise,271065,2010,Offenses Against Family,
+Boise,271065,2010,Prostitution,
+Boise,271065,2010,Rape,
+Boise,271065,2010,Robbery,18
+Boise,271065,2010,Runaway,
+Boise,271065,2010,Sex Offenses,
+Boise,271065,2010,Stolen Property,2
+Boise,271065,2010,Trespass,31
+Boise,271065,2010,Vandalism,106
+Boise,271065,2010,Weapons,9
+Boise,271065,2011,Aggravated Assault,32
+Boise,271065,2011,Arson,
+Boise,271065,2011,"Assault, Simple",37
+Boise,271065,2011,Burglary,76
+Boise,271065,2011,Curfew,4
+Boise,271065,2011,Disorderly Conduct,30
+Boise,271065,2011,Drugs,35
+Boise,271065,2011,DUII,20
+Boise,271065,2011,Embezzlement,1
+Boise,271065,2011,Forgery,2
+Boise,271065,2011,Fraud,13
+Boise,271065,2011,Gambling,
+Boise,271065,2011,Homicide,1
+Boise,271065,2011,Kidnap,2
+Boise,271065,2011,Larceny,274
+Boise,271065,2011,Liquor Laws,91
+Boise,271065,2011,Motor Vehicle Theft,29
+Boise,271065,2011,Offenses Against Family,
+Boise,271065,2011,Prostitution,
+Boise,271065,2011,Rape,2
+Boise,271065,2011,Robbery,6
+Boise,271065,2011,Runaway,
+Boise,271065,2011,Sex Offenses,1
+Boise,271065,2011,Stolen Property,1
+Boise,271065,2011,Trespass,25
+Boise,271065,2011,Vandalism,87
+Boise,271065,2011,Weapons,8
+Boise,271065,2012,Aggravated Assault,29
+Boise,271065,2012,Arson,2
+Boise,271065,2012,"Assault, Simple",29
+Boise,271065,2012,Burglary,41
+Boise,271065,2012,Curfew,
+Boise,271065,2012,Disorderly Conduct,39
+Boise,271065,2012,Drugs,75
+Boise,271065,2012,DUII,28
+Boise,271065,2012,Embezzlement,
+Boise,271065,2012,Forgery,4
+Boise,271065,2012,Fraud,20
+Boise,271065,2012,Gambling,1
+Boise,271065,2012,Homicide,
+Boise,271065,2012,Kidnap,
+Boise,271065,2012,Larceny,388
+Boise,271065,2012,Liquor Laws,122
+Boise,271065,2012,Motor Vehicle Theft,45
+Boise,271065,2012,Offenses Against Family,
+Boise,271065,2012,Prostitution,
+Boise,271065,2012,Rape,
+Boise,271065,2012,Robbery,20
+Boise,271065,2012,Runaway,
+Boise,271065,2012,Sex Offenses,
+Boise,271065,2012,Stolen Property,
+Boise,271065,2012,Trespass,40
+Boise,271065,2012,Vandalism,63
+Boise,271065,2012,Weapons,13
+Boise,271065,2013,Aggravated Assault,27
+Boise,271065,2013,Arson,1
+Boise,271065,2013,"Assault, Simple",33
+Boise,271065,2013,Burglary,46
+Boise,271065,2013,Curfew,
+Boise,271065,2013,Disorderly Conduct,25
+Boise,271065,2013,Drugs,38
+Boise,271065,2013,DUII,16
+Boise,271065,2013,Embezzlement,
+Boise,271065,2013,Forgery,3
+Boise,271065,2013,Fraud,25
+Boise,271065,2013,Gambling,
+Boise,271065,2013,Homicide,
+Boise,271065,2013,Kidnap,
+Boise,271065,2013,Larceny,310
+Boise,271065,2013,Liquor Laws,31
+Boise,271065,2013,Motor Vehicle Theft,47
+Boise,271065,2013,Offenses Against Family,
+Boise,271065,2013,Prostitution,
+Boise,271065,2013,Rape,
+Boise,271065,2013,Robbery,14
+Boise,271065,2013,Runaway,
+Boise,271065,2013,Sex Offenses,
+Boise,271065,2013,Stolen Property,
+Boise,271065,2013,Trespass,23
+Boise,271065,2013,Vandalism,82
+Boise,271065,2013,Weapons,3
+Boise,271065,2014,Aggravated Assault,38
+Boise,271065,2014,Arson,
+Boise,271065,2014,"Assault, Simple",38
+Boise,271065,2014,Burglary,85
+Boise,271065,2014,Curfew,
+Boise,271065,2014,Disorderly Conduct,34
+Boise,271065,2014,Drugs,27
+Boise,271065,2014,DUII,9
+Boise,271065,2014,Embezzlement,1
+Boise,271065,2014,Forgery,2
+Boise,271065,2014,Fraud,13
+Boise,271065,2014,Gambling,
+Boise,271065,2014,Homicide,1
+Boise,271065,2014,Kidnap,
+Boise,271065,2014,Larceny,453
+Boise,271065,2014,Liquor Laws,17
+Boise,271065,2014,Motor Vehicle Theft,34
+Boise,271065,2014,Offenses Against Family,
+Boise,271065,2014,Prostitution,
+Boise,271065,2014,Rape,
+Boise,271065,2014,Robbery,8
+Boise,271065,2014,Runaway,1
+Boise,271065,2014,Sex Offenses,
+Boise,271065,2014,Stolen Property,
+Boise,271065,2014,Trespass,19
+Boise,271065,2014,Vandalism,85
+Boise,271065,2014,Weapons,8
+Brentwood-Darlington,276222,2004,Aggravated Assault,5
+Brentwood-Darlington,276222,2004,Arson,
+Brentwood-Darlington,276222,2004,"Assault, Simple",9
+Brentwood-Darlington,276222,2004,Burglary,26
+Brentwood-Darlington,276222,2004,Curfew,1
+Brentwood-Darlington,276222,2004,Disorderly Conduct,10
+Brentwood-Darlington,276222,2004,Drugs,21
+Brentwood-Darlington,276222,2004,DUII,6
+Brentwood-Darlington,276222,2004,Embezzlement,
+Brentwood-Darlington,276222,2004,Forgery,3
+Brentwood-Darlington,276222,2004,Fraud,6
+Brentwood-Darlington,276222,2004,Gambling,
+Brentwood-Darlington,276222,2004,Homicide,
+Brentwood-Darlington,276222,2004,Kidnap,1
+Brentwood-Darlington,276222,2004,Larceny,50
+Brentwood-Darlington,276222,2004,Liquor Laws,4
+Brentwood-Darlington,276222,2004,Motor Vehicle Theft,14
+Brentwood-Darlington,276222,2004,Offenses Against Family,
+Brentwood-Darlington,276222,2004,Prostitution,9
+Brentwood-Darlington,276222,2004,Rape,
+Brentwood-Darlington,276222,2004,Robbery,3
+Brentwood-Darlington,276222,2004,Runaway,
+Brentwood-Darlington,276222,2004,Sex Offenses,
+Brentwood-Darlington,276222,2004,Stolen Property,
+Brentwood-Darlington,276222,2004,Trespass,9
+Brentwood-Darlington,276222,2004,Vandalism,24
+Brentwood-Darlington,276222,2004,Weapons,1
+Brentwood-Darlington,276222,2005,Aggravated Assault,22
+Brentwood-Darlington,276222,2005,Arson,
+Brentwood-Darlington,276222,2005,"Assault, Simple",40
+Brentwood-Darlington,276222,2005,Burglary,100
+Brentwood-Darlington,276222,2005,Curfew,1
+Brentwood-Darlington,276222,2005,Disorderly Conduct,31
+Brentwood-Darlington,276222,2005,Drugs,107
+Brentwood-Darlington,276222,2005,DUII,19
+Brentwood-Darlington,276222,2005,Embezzlement,5
+Brentwood-Darlington,276222,2005,Forgery,16
+Brentwood-Darlington,276222,2005,Fraud,48
+Brentwood-Darlington,276222,2005,Gambling,
+Brentwood-Darlington,276222,2005,Homicide,1
+Brentwood-Darlington,276222,2005,Kidnap,1
+Brentwood-Darlington,276222,2005,Larceny,259
+Brentwood-Darlington,276222,2005,Liquor Laws,9
+Brentwood-Darlington,276222,2005,Motor Vehicle Theft,63
+Brentwood-Darlington,276222,2005,Offenses Against Family,
+Brentwood-Darlington,276222,2005,Prostitution,4
+Brentwood-Darlington,276222,2005,Rape,
+Brentwood-Darlington,276222,2005,Robbery,9
+Brentwood-Darlington,276222,2005,Runaway,
+Brentwood-Darlington,276222,2005,Sex Offenses,
+Brentwood-Darlington,276222,2005,Stolen Property,1
+Brentwood-Darlington,276222,2005,Trespass,59
+Brentwood-Darlington,276222,2005,Vandalism,127
+Brentwood-Darlington,276222,2005,Weapons,12
+Brentwood-Darlington,276222,2006,Aggravated Assault,36
+Brentwood-Darlington,276222,2006,Arson,
+Brentwood-Darlington,276222,2006,"Assault, Simple",38
+Brentwood-Darlington,276222,2006,Burglary,115
+Brentwood-Darlington,276222,2006,Curfew,2
+Brentwood-Darlington,276222,2006,Disorderly Conduct,28
+Brentwood-Darlington,276222,2006,Drugs,85
+Brentwood-Darlington,276222,2006,DUII,15
+Brentwood-Darlington,276222,2006,Embezzlement,1
+Brentwood-Darlington,276222,2006,Forgery,14
+Brentwood-Darlington,276222,2006,Fraud,24
+Brentwood-Darlington,276222,2006,Gambling,
+Brentwood-Darlington,276222,2006,Homicide,
+Brentwood-Darlington,276222,2006,Kidnap,1
+Brentwood-Darlington,276222,2006,Larceny,190
+Brentwood-Darlington,276222,2006,Liquor Laws,13
+Brentwood-Darlington,276222,2006,Motor Vehicle Theft,71
+Brentwood-Darlington,276222,2006,Offenses Against Family,
+Brentwood-Darlington,276222,2006,Prostitution,5
+Brentwood-Darlington,276222,2006,Rape,1
+Brentwood-Darlington,276222,2006,Robbery,6
+Brentwood-Darlington,276222,2006,Runaway,
+Brentwood-Darlington,276222,2006,Sex Offenses,
+Brentwood-Darlington,276222,2006,Stolen Property,3
+Brentwood-Darlington,276222,2006,Trespass,23
+Brentwood-Darlington,276222,2006,Vandalism,98
+Brentwood-Darlington,276222,2006,Weapons,10
+Brentwood-Darlington,276222,2007,Aggravated Assault,30
+Brentwood-Darlington,276222,2007,Arson,1
+Brentwood-Darlington,276222,2007,"Assault, Simple",46
+Brentwood-Darlington,276222,2007,Burglary,96
+Brentwood-Darlington,276222,2007,Curfew,
+Brentwood-Darlington,276222,2007,Disorderly Conduct,36
+Brentwood-Darlington,276222,2007,Drugs,65
+Brentwood-Darlington,276222,2007,DUII,23
+Brentwood-Darlington,276222,2007,Embezzlement,1
+Brentwood-Darlington,276222,2007,Forgery,7
+Brentwood-Darlington,276222,2007,Fraud,26
+Brentwood-Darlington,276222,2007,Gambling,
+Brentwood-Darlington,276222,2007,Homicide,
+Brentwood-Darlington,276222,2007,Kidnap,1
+Brentwood-Darlington,276222,2007,Larceny,238
+Brentwood-Darlington,276222,2007,Liquor Laws,15
+Brentwood-Darlington,276222,2007,Motor Vehicle Theft,78
+Brentwood-Darlington,276222,2007,Offenses Against Family,
+Brentwood-Darlington,276222,2007,Prostitution,6
+Brentwood-Darlington,276222,2007,Rape,
+Brentwood-Darlington,276222,2007,Robbery,13
+Brentwood-Darlington,276222,2007,Runaway,
+Brentwood-Darlington,276222,2007,Sex Offenses,6
+Brentwood-Darlington,276222,2007,Stolen Property,2
+Brentwood-Darlington,276222,2007,Trespass,32
+Brentwood-Darlington,276222,2007,Vandalism,130
+Brentwood-Darlington,276222,2007,Weapons,11
+Brentwood-Darlington,276222,2008,Aggravated Assault,27
+Brentwood-Darlington,276222,2008,Arson,1
+Brentwood-Darlington,276222,2008,"Assault, Simple",44
+Brentwood-Darlington,276222,2008,Burglary,67
+Brentwood-Darlington,276222,2008,Curfew,
+Brentwood-Darlington,276222,2008,Disorderly Conduct,33
+Brentwood-Darlington,276222,2008,Drugs,42
+Brentwood-Darlington,276222,2008,DUII,22
+Brentwood-Darlington,276222,2008,Embezzlement,1
+Brentwood-Darlington,276222,2008,Forgery,10
+Brentwood-Darlington,276222,2008,Fraud,21
+Brentwood-Darlington,276222,2008,Gambling,
+Brentwood-Darlington,276222,2008,Homicide,1
+Brentwood-Darlington,276222,2008,Kidnap,
+Brentwood-Darlington,276222,2008,Larceny,162
+Brentwood-Darlington,276222,2008,Liquor Laws,21
+Brentwood-Darlington,276222,2008,Motor Vehicle Theft,44
+Brentwood-Darlington,276222,2008,Offenses Against Family,1
+Brentwood-Darlington,276222,2008,Prostitution,11
+Brentwood-Darlington,276222,2008,Rape,
+Brentwood-Darlington,276222,2008,Robbery,11
+Brentwood-Darlington,276222,2008,Runaway,
+Brentwood-Darlington,276222,2008,Sex Offenses,1
+Brentwood-Darlington,276222,2008,Stolen Property,
+Brentwood-Darlington,276222,2008,Trespass,30
+Brentwood-Darlington,276222,2008,Vandalism,100
+Brentwood-Darlington,276222,2008,Weapons,6
+Brentwood-Darlington,276222,2009,Aggravated Assault,19
+Brentwood-Darlington,276222,2009,Arson,1
+Brentwood-Darlington,276222,2009,"Assault, Simple",35
+Brentwood-Darlington,276222,2009,Burglary,65
+Brentwood-Darlington,276222,2009,Curfew,8
+Brentwood-Darlington,276222,2009,Disorderly Conduct,37
+Brentwood-Darlington,276222,2009,Drugs,38
+Brentwood-Darlington,276222,2009,DUII,19
+Brentwood-Darlington,276222,2009,Embezzlement,1
+Brentwood-Darlington,276222,2009,Forgery,4
+Brentwood-Darlington,276222,2009,Fraud,31
+Brentwood-Darlington,276222,2009,Gambling,
+Brentwood-Darlington,276222,2009,Homicide,2
+Brentwood-Darlington,276222,2009,Kidnap,
+Brentwood-Darlington,276222,2009,Larceny,133
+Brentwood-Darlington,276222,2009,Liquor Laws,20
+Brentwood-Darlington,276222,2009,Motor Vehicle Theft,36
+Brentwood-Darlington,276222,2009,Offenses Against Family,
+Brentwood-Darlington,276222,2009,Prostitution,13
+Brentwood-Darlington,276222,2009,Rape,1
+Brentwood-Darlington,276222,2009,Robbery,15
+Brentwood-Darlington,276222,2009,Runaway,1
+Brentwood-Darlington,276222,2009,Sex Offenses,
+Brentwood-Darlington,276222,2009,Stolen Property,1
+Brentwood-Darlington,276222,2009,Trespass,31
+Brentwood-Darlington,276222,2009,Vandalism,72
+Brentwood-Darlington,276222,2009,Weapons,
+Brentwood-Darlington,276222,2010,Aggravated Assault,18
+Brentwood-Darlington,276222,2010,Arson,
+Brentwood-Darlington,276222,2010,"Assault, Simple",41
+Brentwood-Darlington,276222,2010,Burglary,73
+Brentwood-Darlington,276222,2010,Curfew,
+Brentwood-Darlington,276222,2010,Disorderly Conduct,24
+Brentwood-Darlington,276222,2010,Drugs,25
+Brentwood-Darlington,276222,2010,DUII,15
+Brentwood-Darlington,276222,2010,Embezzlement,
+Brentwood-Darlington,276222,2010,Forgery,16
+Brentwood-Darlington,276222,2010,Fraud,24
+Brentwood-Darlington,276222,2010,Gambling,
+Brentwood-Darlington,276222,2010,Homicide,
+Brentwood-Darlington,276222,2010,Kidnap,
+Brentwood-Darlington,276222,2010,Larceny,175
+Brentwood-Darlington,276222,2010,Liquor Laws,8
+Brentwood-Darlington,276222,2010,Motor Vehicle Theft,41
+Brentwood-Darlington,276222,2010,Offenses Against Family,
+Brentwood-Darlington,276222,2010,Prostitution,3
+Brentwood-Darlington,276222,2010,Rape,
+Brentwood-Darlington,276222,2010,Robbery,8
+Brentwood-Darlington,276222,2010,Runaway,1
+Brentwood-Darlington,276222,2010,Sex Offenses,2
+Brentwood-Darlington,276222,2010,Stolen Property,2
+Brentwood-Darlington,276222,2010,Trespass,15
+Brentwood-Darlington,276222,2010,Vandalism,94
+Brentwood-Darlington,276222,2010,Weapons,11
+Brentwood-Darlington,276222,2011,Aggravated Assault,19
+Brentwood-Darlington,276222,2011,Arson,
+Brentwood-Darlington,276222,2011,"Assault, Simple",32
+Brentwood-Darlington,276222,2011,Burglary,82
+Brentwood-Darlington,276222,2011,Curfew,
+Brentwood-Darlington,276222,2011,Disorderly Conduct,26
+Brentwood-Darlington,276222,2011,Drugs,14
+Brentwood-Darlington,276222,2011,DUII,14
+Brentwood-Darlington,276222,2011,Embezzlement,
+Brentwood-Darlington,276222,2011,Forgery,31
+Brentwood-Darlington,276222,2011,Fraud,12
+Brentwood-Darlington,276222,2011,Gambling,
+Brentwood-Darlington,276222,2011,Homicide,1
+Brentwood-Darlington,276222,2011,Kidnap,
+Brentwood-Darlington,276222,2011,Larceny,182
+Brentwood-Darlington,276222,2011,Liquor Laws,7
+Brentwood-Darlington,276222,2011,Motor Vehicle Theft,33
+Brentwood-Darlington,276222,2011,Offenses Against Family,
+Brentwood-Darlington,276222,2011,Prostitution,13
+Brentwood-Darlington,276222,2011,Rape,
+Brentwood-Darlington,276222,2011,Robbery,10
+Brentwood-Darlington,276222,2011,Runaway,
+Brentwood-Darlington,276222,2011,Sex Offenses,2
+Brentwood-Darlington,276222,2011,Stolen Property,1
+Brentwood-Darlington,276222,2011,Trespass,15
+Brentwood-Darlington,276222,2011,Vandalism,80
+Brentwood-Darlington,276222,2011,Weapons,3
+Brentwood-Darlington,276222,2012,Aggravated Assault,17
+Brentwood-Darlington,276222,2012,Arson,
+Brentwood-Darlington,276222,2012,"Assault, Simple",26
+Brentwood-Darlington,276222,2012,Burglary,71
+Brentwood-Darlington,276222,2012,Curfew,
+Brentwood-Darlington,276222,2012,Disorderly Conduct,34
+Brentwood-Darlington,276222,2012,Drugs,35
+Brentwood-Darlington,276222,2012,DUII,14
+Brentwood-Darlington,276222,2012,Embezzlement,1
+Brentwood-Darlington,276222,2012,Forgery,15
+Brentwood-Darlington,276222,2012,Fraud,17
+Brentwood-Darlington,276222,2012,Gambling,
+Brentwood-Darlington,276222,2012,Homicide,1
+Brentwood-Darlington,276222,2012,Kidnap,
+Brentwood-Darlington,276222,2012,Larceny,205
+Brentwood-Darlington,276222,2012,Liquor Laws,2
+Brentwood-Darlington,276222,2012,Motor Vehicle Theft,47
+Brentwood-Darlington,276222,2012,Offenses Against Family,
+Brentwood-Darlington,276222,2012,Prostitution,5
+Brentwood-Darlington,276222,2012,Rape,
+Brentwood-Darlington,276222,2012,Robbery,15
+Brentwood-Darlington,276222,2012,Runaway,
+Brentwood-Darlington,276222,2012,Sex Offenses,2
+Brentwood-Darlington,276222,2012,Stolen Property,1
+Brentwood-Darlington,276222,2012,Trespass,24
+Brentwood-Darlington,276222,2012,Vandalism,75
+Brentwood-Darlington,276222,2012,Weapons,4
+Brentwood-Darlington,276222,2013,Aggravated Assault,23
+Brentwood-Darlington,276222,2013,Arson,1
+Brentwood-Darlington,276222,2013,"Assault, Simple",41
+Brentwood-Darlington,276222,2013,Burglary,80
+Brentwood-Darlington,276222,2013,Curfew,
+Brentwood-Darlington,276222,2013,Disorderly Conduct,36
+Brentwood-Darlington,276222,2013,Drugs,38
+Brentwood-Darlington,276222,2013,DUII,12
+Brentwood-Darlington,276222,2013,Embezzlement,
+Brentwood-Darlington,276222,2013,Forgery,16
+Brentwood-Darlington,276222,2013,Fraud,15
+Brentwood-Darlington,276222,2013,Gambling,
+Brentwood-Darlington,276222,2013,Homicide,
+Brentwood-Darlington,276222,2013,Kidnap,
+Brentwood-Darlington,276222,2013,Larceny,218
+Brentwood-Darlington,276222,2013,Liquor Laws,1
+Brentwood-Darlington,276222,2013,Motor Vehicle Theft,45
+Brentwood-Darlington,276222,2013,Offenses Against Family,
+Brentwood-Darlington,276222,2013,Prostitution,4
+Brentwood-Darlington,276222,2013,Rape,1
+Brentwood-Darlington,276222,2013,Robbery,5
+Brentwood-Darlington,276222,2013,Runaway,
+Brentwood-Darlington,276222,2013,Sex Offenses,1
+Brentwood-Darlington,276222,2013,Stolen Property,
+Brentwood-Darlington,276222,2013,Trespass,15
+Brentwood-Darlington,276222,2013,Vandalism,79
+Brentwood-Darlington,276222,2013,Weapons,6
+Brentwood-Darlington,276222,2014,Aggravated Assault,14
+Brentwood-Darlington,276222,2014,Arson,
+Brentwood-Darlington,276222,2014,"Assault, Simple",44
+Brentwood-Darlington,276222,2014,Burglary,63
+Brentwood-Darlington,276222,2014,Curfew,
+Brentwood-Darlington,276222,2014,Disorderly Conduct,36
+Brentwood-Darlington,276222,2014,Drugs,39
+Brentwood-Darlington,276222,2014,DUII,9
+Brentwood-Darlington,276222,2014,Embezzlement,1
+Brentwood-Darlington,276222,2014,Forgery,8
+Brentwood-Darlington,276222,2014,Fraud,14
+Brentwood-Darlington,276222,2014,Gambling,
+Brentwood-Darlington,276222,2014,Homicide,
+Brentwood-Darlington,276222,2014,Kidnap,2
+Brentwood-Darlington,276222,2014,Larceny,208
+Brentwood-Darlington,276222,2014,Liquor Laws,2
+Brentwood-Darlington,276222,2014,Motor Vehicle Theft,61
+Brentwood-Darlington,276222,2014,Offenses Against Family,
+Brentwood-Darlington,276222,2014,Prostitution,
+Brentwood-Darlington,276222,2014,Rape,3
+Brentwood-Darlington,276222,2014,Robbery,9
+Brentwood-Darlington,276222,2014,Runaway,
+Brentwood-Darlington,276222,2014,Sex Offenses,
+Brentwood-Darlington,276222,2014,Stolen Property,1
+Brentwood-Darlington,276222,2014,Trespass,21
+Brentwood-Darlington,276222,2014,Vandalism,50
+Brentwood-Darlington,276222,2014,Weapons,8
+Bridgeton,271067,2004,Aggravated Assault,1
+Bridgeton,271067,2004,Arson,
+Bridgeton,271067,2004,"Assault, Simple",1
+Bridgeton,271067,2004,Burglary,12
+Bridgeton,271067,2004,Curfew,
+Bridgeton,271067,2004,Disorderly Conduct,4
+Bridgeton,271067,2004,Drugs,2
+Bridgeton,271067,2004,DUII,5
+Bridgeton,271067,2004,Embezzlement,1
+Bridgeton,271067,2004,Forgery,2
+Bridgeton,271067,2004,Fraud,4
+Bridgeton,271067,2004,Gambling,
+Bridgeton,271067,2004,Homicide,1
+Bridgeton,271067,2004,Kidnap,
+Bridgeton,271067,2004,Larceny,35
+Bridgeton,271067,2004,Liquor Laws,
+Bridgeton,271067,2004,Motor Vehicle Theft,12
+Bridgeton,271067,2004,Offenses Against Family,
+Bridgeton,271067,2004,Prostitution,
+Bridgeton,271067,2004,Rape,
+Bridgeton,271067,2004,Robbery,
+Bridgeton,271067,2004,Runaway,
+Bridgeton,271067,2004,Sex Offenses,
+Bridgeton,271067,2004,Stolen Property,
+Bridgeton,271067,2004,Trespass,7
+Bridgeton,271067,2004,Vandalism,9
+Bridgeton,271067,2004,Weapons,1
+Bridgeton,271067,2005,Aggravated Assault,7
+Bridgeton,271067,2005,Arson,
+Bridgeton,271067,2005,"Assault, Simple",16
+Bridgeton,271067,2005,Burglary,76
+Bridgeton,271067,2005,Curfew,2
+Bridgeton,271067,2005,Disorderly Conduct,20
+Bridgeton,271067,2005,Drugs,18
+Bridgeton,271067,2005,DUII,13
+Bridgeton,271067,2005,Embezzlement,6
+Bridgeton,271067,2005,Forgery,7
+Bridgeton,271067,2005,Fraud,25
+Bridgeton,271067,2005,Gambling,
+Bridgeton,271067,2005,Homicide,
+Bridgeton,271067,2005,Kidnap,
+Bridgeton,271067,2005,Larceny,228
+Bridgeton,271067,2005,Liquor Laws,1
+Bridgeton,271067,2005,Motor Vehicle Theft,64
+Bridgeton,271067,2005,Offenses Against Family,
+Bridgeton,271067,2005,Prostitution,
+Bridgeton,271067,2005,Rape,1
+Bridgeton,271067,2005,Robbery,7
+Bridgeton,271067,2005,Runaway,
+Bridgeton,271067,2005,Sex Offenses,1
+Bridgeton,271067,2005,Stolen Property,
+Bridgeton,271067,2005,Trespass,23
+Bridgeton,271067,2005,Vandalism,28
+Bridgeton,271067,2005,Weapons,2
+Bridgeton,271067,2006,Aggravated Assault,14
+Bridgeton,271067,2006,Arson,
+Bridgeton,271067,2006,"Assault, Simple",21
+Bridgeton,271067,2006,Burglary,53
+Bridgeton,271067,2006,Curfew,
+Bridgeton,271067,2006,Disorderly Conduct,15
+Bridgeton,271067,2006,Drugs,25
+Bridgeton,271067,2006,DUII,20
+Bridgeton,271067,2006,Embezzlement,5
+Bridgeton,271067,2006,Forgery,44
+Bridgeton,271067,2006,Fraud,17
+Bridgeton,271067,2006,Gambling,
+Bridgeton,271067,2006,Homicide,
+Bridgeton,271067,2006,Kidnap,
+Bridgeton,271067,2006,Larceny,198
+Bridgeton,271067,2006,Liquor Laws,1
+Bridgeton,271067,2006,Motor Vehicle Theft,39
+Bridgeton,271067,2006,Offenses Against Family,
+Bridgeton,271067,2006,Prostitution,
+Bridgeton,271067,2006,Rape,
+Bridgeton,271067,2006,Robbery,13
+Bridgeton,271067,2006,Runaway,
+Bridgeton,271067,2006,Sex Offenses,1
+Bridgeton,271067,2006,Stolen Property,
+Bridgeton,271067,2006,Trespass,15
+Bridgeton,271067,2006,Vandalism,21
+Bridgeton,271067,2006,Weapons,2
+Bridgeton,271067,2007,Aggravated Assault,11
+Bridgeton,271067,2007,Arson,
+Bridgeton,271067,2007,"Assault, Simple",18
+Bridgeton,271067,2007,Burglary,41
+Bridgeton,271067,2007,Curfew,
+Bridgeton,271067,2007,Disorderly Conduct,12
+Bridgeton,271067,2007,Drugs,19
+Bridgeton,271067,2007,DUII,16
+Bridgeton,271067,2007,Embezzlement,3
+Bridgeton,271067,2007,Forgery,13
+Bridgeton,271067,2007,Fraud,29
+Bridgeton,271067,2007,Gambling,
+Bridgeton,271067,2007,Homicide,1
+Bridgeton,271067,2007,Kidnap,
+Bridgeton,271067,2007,Larceny,218
+Bridgeton,271067,2007,Liquor Laws,4
+Bridgeton,271067,2007,Motor Vehicle Theft,38
+Bridgeton,271067,2007,Offenses Against Family,
+Bridgeton,271067,2007,Prostitution,
+Bridgeton,271067,2007,Rape,
+Bridgeton,271067,2007,Robbery,7
+Bridgeton,271067,2007,Runaway,
+Bridgeton,271067,2007,Sex Offenses,
+Bridgeton,271067,2007,Stolen Property,
+Bridgeton,271067,2007,Trespass,20
+Bridgeton,271067,2007,Vandalism,34
+Bridgeton,271067,2007,Weapons,5
+Bridgeton,271067,2008,Aggravated Assault,13
+Bridgeton,271067,2008,Arson,1
+Bridgeton,271067,2008,"Assault, Simple",20
+Bridgeton,271067,2008,Burglary,36
+Bridgeton,271067,2008,Curfew,
+Bridgeton,271067,2008,Disorderly Conduct,19
+Bridgeton,271067,2008,Drugs,22
+Bridgeton,271067,2008,DUII,25
+Bridgeton,271067,2008,Embezzlement,5
+Bridgeton,271067,2008,Forgery,16
+Bridgeton,271067,2008,Fraud,26
+Bridgeton,271067,2008,Gambling,
+Bridgeton,271067,2008,Homicide,1
+Bridgeton,271067,2008,Kidnap,
+Bridgeton,271067,2008,Larceny,239
+Bridgeton,271067,2008,Liquor Laws,4
+Bridgeton,271067,2008,Motor Vehicle Theft,33
+Bridgeton,271067,2008,Offenses Against Family,
+Bridgeton,271067,2008,Prostitution,
+Bridgeton,271067,2008,Rape,
+Bridgeton,271067,2008,Robbery,2
+Bridgeton,271067,2008,Runaway,
+Bridgeton,271067,2008,Sex Offenses,
+Bridgeton,271067,2008,Stolen Property,
+Bridgeton,271067,2008,Trespass,18
+Bridgeton,271067,2008,Vandalism,48
+Bridgeton,271067,2008,Weapons,1
+Bridgeton,271067,2009,Aggravated Assault,7
+Bridgeton,271067,2009,Arson,
+Bridgeton,271067,2009,"Assault, Simple",14
+Bridgeton,271067,2009,Burglary,26
+Bridgeton,271067,2009,Curfew,
+Bridgeton,271067,2009,Disorderly Conduct,15
+Bridgeton,271067,2009,Drugs,11
+Bridgeton,271067,2009,DUII,18
+Bridgeton,271067,2009,Embezzlement,3
+Bridgeton,271067,2009,Forgery,11
+Bridgeton,271067,2009,Fraud,28
+Bridgeton,271067,2009,Gambling,
+Bridgeton,271067,2009,Homicide,
+Bridgeton,271067,2009,Kidnap,
+Bridgeton,271067,2009,Larceny,174
+Bridgeton,271067,2009,Liquor Laws,6
+Bridgeton,271067,2009,Motor Vehicle Theft,27
+Bridgeton,271067,2009,Offenses Against Family,
+Bridgeton,271067,2009,Prostitution,1
+Bridgeton,271067,2009,Rape,
+Bridgeton,271067,2009,Robbery,10
+Bridgeton,271067,2009,Runaway,
+Bridgeton,271067,2009,Sex Offenses,
+Bridgeton,271067,2009,Stolen Property,
+Bridgeton,271067,2009,Trespass,19
+Bridgeton,271067,2009,Vandalism,30
+Bridgeton,271067,2009,Weapons,1
+Bridgeton,271067,2010,Aggravated Assault,8
+Bridgeton,271067,2010,Arson,
+Bridgeton,271067,2010,"Assault, Simple",13
+Bridgeton,271067,2010,Burglary,32
+Bridgeton,271067,2010,Curfew,
+Bridgeton,271067,2010,Disorderly Conduct,14
+Bridgeton,271067,2010,Drugs,11
+Bridgeton,271067,2010,DUII,12
+Bridgeton,271067,2010,Embezzlement,6
+Bridgeton,271067,2010,Forgery,6
+Bridgeton,271067,2010,Fraud,10
+Bridgeton,271067,2010,Gambling,
+Bridgeton,271067,2010,Homicide,
+Bridgeton,271067,2010,Kidnap,
+Bridgeton,271067,2010,Larceny,215
+Bridgeton,271067,2010,Liquor Laws,2
+Bridgeton,271067,2010,Motor Vehicle Theft,33
+Bridgeton,271067,2010,Offenses Against Family,
+Bridgeton,271067,2010,Prostitution,1
+Bridgeton,271067,2010,Rape,
+Bridgeton,271067,2010,Robbery,7
+Bridgeton,271067,2010,Runaway,
+Bridgeton,271067,2010,Sex Offenses,
+Bridgeton,271067,2010,Stolen Property,
+Bridgeton,271067,2010,Trespass,17
+Bridgeton,271067,2010,Vandalism,36
+Bridgeton,271067,2010,Weapons,1
+Bridgeton,271067,2011,Aggravated Assault,4
+Bridgeton,271067,2011,Arson,
+Bridgeton,271067,2011,"Assault, Simple",16
+Bridgeton,271067,2011,Burglary,18
+Bridgeton,271067,2011,Curfew,
+Bridgeton,271067,2011,Disorderly Conduct,17
+Bridgeton,271067,2011,Drugs,9
+Bridgeton,271067,2011,DUII,19
+Bridgeton,271067,2011,Embezzlement,4
+Bridgeton,271067,2011,Forgery,6
+Bridgeton,271067,2011,Fraud,12
+Bridgeton,271067,2011,Gambling,
+Bridgeton,271067,2011,Homicide,
+Bridgeton,271067,2011,Kidnap,
+Bridgeton,271067,2011,Larceny,192
+Bridgeton,271067,2011,Liquor Laws,2
+Bridgeton,271067,2011,Motor Vehicle Theft,34
+Bridgeton,271067,2011,Offenses Against Family,
+Bridgeton,271067,2011,Prostitution,1
+Bridgeton,271067,2011,Rape,
+Bridgeton,271067,2011,Robbery,8
+Bridgeton,271067,2011,Runaway,
+Bridgeton,271067,2011,Sex Offenses,
+Bridgeton,271067,2011,Stolen Property,
+Bridgeton,271067,2011,Trespass,14
+Bridgeton,271067,2011,Vandalism,22
+Bridgeton,271067,2011,Weapons,5
+Bridgeton,271067,2012,Aggravated Assault,13
+Bridgeton,271067,2012,Arson,
+Bridgeton,271067,2012,"Assault, Simple",18
+Bridgeton,271067,2012,Burglary,22
+Bridgeton,271067,2012,Curfew,
+Bridgeton,271067,2012,Disorderly Conduct,11
+Bridgeton,271067,2012,Drugs,9
+Bridgeton,271067,2012,DUII,18
+Bridgeton,271067,2012,Embezzlement,6
+Bridgeton,271067,2012,Forgery,12
+Bridgeton,271067,2012,Fraud,35
+Bridgeton,271067,2012,Gambling,
+Bridgeton,271067,2012,Homicide,
+Bridgeton,271067,2012,Kidnap,
+Bridgeton,271067,2012,Larceny,219
+Bridgeton,271067,2012,Liquor Laws,1
+Bridgeton,271067,2012,Motor Vehicle Theft,36
+Bridgeton,271067,2012,Offenses Against Family,
+Bridgeton,271067,2012,Prostitution,
+Bridgeton,271067,2012,Rape,
+Bridgeton,271067,2012,Robbery,5
+Bridgeton,271067,2012,Runaway,
+Bridgeton,271067,2012,Sex Offenses,
+Bridgeton,271067,2012,Stolen Property,
+Bridgeton,271067,2012,Trespass,16
+Bridgeton,271067,2012,Vandalism,31
+Bridgeton,271067,2012,Weapons,2
+Bridgeton,271067,2013,Aggravated Assault,9
+Bridgeton,271067,2013,Arson,1
+Bridgeton,271067,2013,"Assault, Simple",21
+Bridgeton,271067,2013,Burglary,18
+Bridgeton,271067,2013,Curfew,
+Bridgeton,271067,2013,Disorderly Conduct,19
+Bridgeton,271067,2013,Drugs,15
+Bridgeton,271067,2013,DUII,20
+Bridgeton,271067,2013,Embezzlement,2
+Bridgeton,271067,2013,Forgery,7
+Bridgeton,271067,2013,Fraud,17
+Bridgeton,271067,2013,Gambling,
+Bridgeton,271067,2013,Homicide,
+Bridgeton,271067,2013,Kidnap,
+Bridgeton,271067,2013,Larceny,213
+Bridgeton,271067,2013,Liquor Laws,16
+Bridgeton,271067,2013,Motor Vehicle Theft,50
+Bridgeton,271067,2013,Offenses Against Family,
+Bridgeton,271067,2013,Prostitution,
+Bridgeton,271067,2013,Rape,
+Bridgeton,271067,2013,Robbery,5
+Bridgeton,271067,2013,Runaway,
+Bridgeton,271067,2013,Sex Offenses,
+Bridgeton,271067,2013,Stolen Property,
+Bridgeton,271067,2013,Trespass,24
+Bridgeton,271067,2013,Vandalism,29
+Bridgeton,271067,2013,Weapons,5
+Bridgeton,271067,2014,Aggravated Assault,13
+Bridgeton,271067,2014,Arson,
+Bridgeton,271067,2014,"Assault, Simple",18
+Bridgeton,271067,2014,Burglary,27
+Bridgeton,271067,2014,Curfew,
+Bridgeton,271067,2014,Disorderly Conduct,20
+Bridgeton,271067,2014,Drugs,17
+Bridgeton,271067,2014,DUII,11
+Bridgeton,271067,2014,Embezzlement,7
+Bridgeton,271067,2014,Forgery,6
+Bridgeton,271067,2014,Fraud,26
+Bridgeton,271067,2014,Gambling,
+Bridgeton,271067,2014,Homicide,
+Bridgeton,271067,2014,Kidnap,1
+Bridgeton,271067,2014,Larceny,379
+Bridgeton,271067,2014,Liquor Laws,22
+Bridgeton,271067,2014,Motor Vehicle Theft,32
+Bridgeton,271067,2014,Offenses Against Family,
+Bridgeton,271067,2014,Prostitution,2
+Bridgeton,271067,2014,Rape,
+Bridgeton,271067,2014,Robbery,13
+Bridgeton,271067,2014,Runaway,
+Bridgeton,271067,2014,Sex Offenses,1
+Bridgeton,271067,2014,Stolen Property,
+Bridgeton,271067,2014,Trespass,28
+Bridgeton,271067,2014,Vandalism,26
+Bridgeton,271067,2014,Weapons,5
+Bridlemile,206554,2004,Aggravated Assault,
+Bridlemile,206554,2004,Arson,
+Bridlemile,206554,2004,"Assault, Simple",
+Bridlemile,206554,2004,Burglary,5
+Bridlemile,206554,2004,Curfew,
+Bridlemile,206554,2004,Disorderly Conduct,1
+Bridlemile,206554,2004,Drugs,
+Bridlemile,206554,2004,DUII,1
+Bridlemile,206554,2004,Embezzlement,
+Bridlemile,206554,2004,Forgery,
+Bridlemile,206554,2004,Fraud,5
+Bridlemile,206554,2004,Gambling,
+Bridlemile,206554,2004,Homicide,
+Bridlemile,206554,2004,Kidnap,
+Bridlemile,206554,2004,Larceny,15
+Bridlemile,206554,2004,Liquor Laws,
+Bridlemile,206554,2004,Motor Vehicle Theft,2
+Bridlemile,206554,2004,Offenses Against Family,
+Bridlemile,206554,2004,Prostitution,
+Bridlemile,206554,2004,Rape,
+Bridlemile,206554,2004,Robbery,
+Bridlemile,206554,2004,Runaway,
+Bridlemile,206554,2004,Sex Offenses,
+Bridlemile,206554,2004,Stolen Property,
+Bridlemile,206554,2004,Trespass,2
+Bridlemile,206554,2004,Vandalism,5
+Bridlemile,206554,2004,Weapons,
+Bridlemile,206554,2005,Aggravated Assault,5
+Bridlemile,206554,2005,Arson,
+Bridlemile,206554,2005,"Assault, Simple",5
+Bridlemile,206554,2005,Burglary,28
+Bridlemile,206554,2005,Curfew,
+Bridlemile,206554,2005,Disorderly Conduct,9
+Bridlemile,206554,2005,Drugs,1
+Bridlemile,206554,2005,DUII,10
+Bridlemile,206554,2005,Embezzlement,1
+Bridlemile,206554,2005,Forgery,8
+Bridlemile,206554,2005,Fraud,6
+Bridlemile,206554,2005,Gambling,
+Bridlemile,206554,2005,Homicide,
+Bridlemile,206554,2005,Kidnap,
+Bridlemile,206554,2005,Larceny,83
+Bridlemile,206554,2005,Liquor Laws,2
+Bridlemile,206554,2005,Motor Vehicle Theft,8
+Bridlemile,206554,2005,Offenses Against Family,
+Bridlemile,206554,2005,Prostitution,
+Bridlemile,206554,2005,Rape,
+Bridlemile,206554,2005,Robbery,
+Bridlemile,206554,2005,Runaway,
+Bridlemile,206554,2005,Sex Offenses,
+Bridlemile,206554,2005,Stolen Property,
+Bridlemile,206554,2005,Trespass,4
+Bridlemile,206554,2005,Vandalism,31
+Bridlemile,206554,2005,Weapons,1
+Bridlemile,206554,2006,Aggravated Assault,3
+Bridlemile,206554,2006,Arson,
+Bridlemile,206554,2006,"Assault, Simple",4
+Bridlemile,206554,2006,Burglary,21
+Bridlemile,206554,2006,Curfew,
+Bridlemile,206554,2006,Disorderly Conduct,4
+Bridlemile,206554,2006,Drugs,5
+Bridlemile,206554,2006,DUII,5
+Bridlemile,206554,2006,Embezzlement,
+Bridlemile,206554,2006,Forgery,3
+Bridlemile,206554,2006,Fraud,5
+Bridlemile,206554,2006,Gambling,
+Bridlemile,206554,2006,Homicide,
+Bridlemile,206554,2006,Kidnap,1
+Bridlemile,206554,2006,Larceny,40
+Bridlemile,206554,2006,Liquor Laws,1
+Bridlemile,206554,2006,Motor Vehicle Theft,7
+Bridlemile,206554,2006,Offenses Against Family,
+Bridlemile,206554,2006,Prostitution,
+Bridlemile,206554,2006,Rape,
+Bridlemile,206554,2006,Robbery,2
+Bridlemile,206554,2006,Runaway,
+Bridlemile,206554,2006,Sex Offenses,
+Bridlemile,206554,2006,Stolen Property,
+Bridlemile,206554,2006,Trespass,4
+Bridlemile,206554,2006,Vandalism,26
+Bridlemile,206554,2006,Weapons,
+Bridlemile,206554,2007,Aggravated Assault,1
+Bridlemile,206554,2007,Arson,1
+Bridlemile,206554,2007,"Assault, Simple",2
+Bridlemile,206554,2007,Burglary,14
+Bridlemile,206554,2007,Curfew,
+Bridlemile,206554,2007,Disorderly Conduct,6
+Bridlemile,206554,2007,Drugs,4
+Bridlemile,206554,2007,DUII,7
+Bridlemile,206554,2007,Embezzlement,
+Bridlemile,206554,2007,Forgery,3
+Bridlemile,206554,2007,Fraud,18
+Bridlemile,206554,2007,Gambling,
+Bridlemile,206554,2007,Homicide,
+Bridlemile,206554,2007,Kidnap,
+Bridlemile,206554,2007,Larceny,60
+Bridlemile,206554,2007,Liquor Laws,2
+Bridlemile,206554,2007,Motor Vehicle Theft,7
+Bridlemile,206554,2007,Offenses Against Family,
+Bridlemile,206554,2007,Prostitution,
+Bridlemile,206554,2007,Rape,
+Bridlemile,206554,2007,Robbery,1
+Bridlemile,206554,2007,Runaway,
+Bridlemile,206554,2007,Sex Offenses,
+Bridlemile,206554,2007,Stolen Property,1
+Bridlemile,206554,2007,Trespass,4
+Bridlemile,206554,2007,Vandalism,16
+Bridlemile,206554,2007,Weapons,
+Bridlemile,206554,2008,Aggravated Assault,4
+Bridlemile,206554,2008,Arson,
+Bridlemile,206554,2008,"Assault, Simple",8
+Bridlemile,206554,2008,Burglary,16
+Bridlemile,206554,2008,Curfew,
+Bridlemile,206554,2008,Disorderly Conduct,12
+Bridlemile,206554,2008,Drugs,3
+Bridlemile,206554,2008,DUII,8
+Bridlemile,206554,2008,Embezzlement,1
+Bridlemile,206554,2008,Forgery,5
+Bridlemile,206554,2008,Fraud,3
+Bridlemile,206554,2008,Gambling,
+Bridlemile,206554,2008,Homicide,
+Bridlemile,206554,2008,Kidnap,
+Bridlemile,206554,2008,Larceny,67
+Bridlemile,206554,2008,Liquor Laws,
+Bridlemile,206554,2008,Motor Vehicle Theft,5
+Bridlemile,206554,2008,Offenses Against Family,
+Bridlemile,206554,2008,Prostitution,
+Bridlemile,206554,2008,Rape,
+Bridlemile,206554,2008,Robbery,
+Bridlemile,206554,2008,Runaway,
+Bridlemile,206554,2008,Sex Offenses,
+Bridlemile,206554,2008,Stolen Property,
+Bridlemile,206554,2008,Trespass,4
+Bridlemile,206554,2008,Vandalism,28
+Bridlemile,206554,2008,Weapons,1
+Bridlemile,206554,2009,Aggravated Assault,2
+Bridlemile,206554,2009,Arson,
+Bridlemile,206554,2009,"Assault, Simple",2
+Bridlemile,206554,2009,Burglary,16
+Bridlemile,206554,2009,Curfew,1
+Bridlemile,206554,2009,Disorderly Conduct,13
+Bridlemile,206554,2009,Drugs,1
+Bridlemile,206554,2009,DUII,11
+Bridlemile,206554,2009,Embezzlement,1
+Bridlemile,206554,2009,Forgery,2
+Bridlemile,206554,2009,Fraud,8
+Bridlemile,206554,2009,Gambling,
+Bridlemile,206554,2009,Homicide,1
+Bridlemile,206554,2009,Kidnap,
+Bridlemile,206554,2009,Larceny,71
+Bridlemile,206554,2009,Liquor Laws,2
+Bridlemile,206554,2009,Motor Vehicle Theft,2
+Bridlemile,206554,2009,Offenses Against Family,
+Bridlemile,206554,2009,Prostitution,
+Bridlemile,206554,2009,Rape,
+Bridlemile,206554,2009,Robbery,2
+Bridlemile,206554,2009,Runaway,
+Bridlemile,206554,2009,Sex Offenses,
+Bridlemile,206554,2009,Stolen Property,
+Bridlemile,206554,2009,Trespass,7
+Bridlemile,206554,2009,Vandalism,19
+Bridlemile,206554,2009,Weapons,
+Bridlemile,206554,2010,Aggravated Assault,1
+Bridlemile,206554,2010,Arson,
+Bridlemile,206554,2010,"Assault, Simple",5
+Bridlemile,206554,2010,Burglary,14
+Bridlemile,206554,2010,Curfew,
+Bridlemile,206554,2010,Disorderly Conduct,10
+Bridlemile,206554,2010,Drugs,1
+Bridlemile,206554,2010,DUII,6
+Bridlemile,206554,2010,Embezzlement,
+Bridlemile,206554,2010,Forgery,
+Bridlemile,206554,2010,Fraud,6
+Bridlemile,206554,2010,Gambling,
+Bridlemile,206554,2010,Homicide,
+Bridlemile,206554,2010,Kidnap,
+Bridlemile,206554,2010,Larceny,48
+Bridlemile,206554,2010,Liquor Laws,2
+Bridlemile,206554,2010,Motor Vehicle Theft,10
+Bridlemile,206554,2010,Offenses Against Family,
+Bridlemile,206554,2010,Prostitution,
+Bridlemile,206554,2010,Rape,
+Bridlemile,206554,2010,Robbery,1
+Bridlemile,206554,2010,Runaway,
+Bridlemile,206554,2010,Sex Offenses,
+Bridlemile,206554,2010,Stolen Property,
+Bridlemile,206554,2010,Trespass,3
+Bridlemile,206554,2010,Vandalism,17
+Bridlemile,206554,2010,Weapons,
+Bridlemile,206554,2011,Aggravated Assault,1
+Bridlemile,206554,2011,Arson,
+Bridlemile,206554,2011,"Assault, Simple",3
+Bridlemile,206554,2011,Burglary,15
+Bridlemile,206554,2011,Curfew,
+Bridlemile,206554,2011,Disorderly Conduct,7
+Bridlemile,206554,2011,Drugs,2
+Bridlemile,206554,2011,DUII,4
+Bridlemile,206554,2011,Embezzlement,1
+Bridlemile,206554,2011,Forgery,2
+Bridlemile,206554,2011,Fraud,7
+Bridlemile,206554,2011,Gambling,
+Bridlemile,206554,2011,Homicide,
+Bridlemile,206554,2011,Kidnap,
+Bridlemile,206554,2011,Larceny,58
+Bridlemile,206554,2011,Liquor Laws,1
+Bridlemile,206554,2011,Motor Vehicle Theft,6
+Bridlemile,206554,2011,Offenses Against Family,
+Bridlemile,206554,2011,Prostitution,
+Bridlemile,206554,2011,Rape,
+Bridlemile,206554,2011,Robbery,
+Bridlemile,206554,2011,Runaway,
+Bridlemile,206554,2011,Sex Offenses,
+Bridlemile,206554,2011,Stolen Property,
+Bridlemile,206554,2011,Trespass,1
+Bridlemile,206554,2011,Vandalism,18
+Bridlemile,206554,2011,Weapons,
+Bridlemile,206554,2012,Aggravated Assault,7
+Bridlemile,206554,2012,Arson,
+Bridlemile,206554,2012,"Assault, Simple",8
+Bridlemile,206554,2012,Burglary,29
+Bridlemile,206554,2012,Curfew,
+Bridlemile,206554,2012,Disorderly Conduct,5
+Bridlemile,206554,2012,Drugs,1
+Bridlemile,206554,2012,DUII,8
+Bridlemile,206554,2012,Embezzlement,
+Bridlemile,206554,2012,Forgery,1
+Bridlemile,206554,2012,Fraud,6
+Bridlemile,206554,2012,Gambling,
+Bridlemile,206554,2012,Homicide,
+Bridlemile,206554,2012,Kidnap,
+Bridlemile,206554,2012,Larceny,64
+Bridlemile,206554,2012,Liquor Laws,
+Bridlemile,206554,2012,Motor Vehicle Theft,9
+Bridlemile,206554,2012,Offenses Against Family,
+Bridlemile,206554,2012,Prostitution,
+Bridlemile,206554,2012,Rape,
+Bridlemile,206554,2012,Robbery,2
+Bridlemile,206554,2012,Runaway,
+Bridlemile,206554,2012,Sex Offenses,
+Bridlemile,206554,2012,Stolen Property,
+Bridlemile,206554,2012,Trespass,1
+Bridlemile,206554,2012,Vandalism,14
+Bridlemile,206554,2012,Weapons,
+Bridlemile,206554,2013,Aggravated Assault,2
+Bridlemile,206554,2013,Arson,
+Bridlemile,206554,2013,"Assault, Simple",2
+Bridlemile,206554,2013,Burglary,12
+Bridlemile,206554,2013,Curfew,
+Bridlemile,206554,2013,Disorderly Conduct,3
+Bridlemile,206554,2013,Drugs,
+Bridlemile,206554,2013,DUII,2
+Bridlemile,206554,2013,Embezzlement,1
+Bridlemile,206554,2013,Forgery,1
+Bridlemile,206554,2013,Fraud,3
+Bridlemile,206554,2013,Gambling,
+Bridlemile,206554,2013,Homicide,
+Bridlemile,206554,2013,Kidnap,
+Bridlemile,206554,2013,Larceny,51
+Bridlemile,206554,2013,Liquor Laws,
+Bridlemile,206554,2013,Motor Vehicle Theft,11
+Bridlemile,206554,2013,Offenses Against Family,
+Bridlemile,206554,2013,Prostitution,
+Bridlemile,206554,2013,Rape,
+Bridlemile,206554,2013,Robbery,
+Bridlemile,206554,2013,Runaway,
+Bridlemile,206554,2013,Sex Offenses,
+Bridlemile,206554,2013,Stolen Property,
+Bridlemile,206554,2013,Trespass,3
+Bridlemile,206554,2013,Vandalism,9
+Bridlemile,206554,2013,Weapons,
+Bridlemile,206554,2014,Aggravated Assault,2
+Bridlemile,206554,2014,Arson,
+Bridlemile,206554,2014,"Assault, Simple",2
+Bridlemile,206554,2014,Burglary,14
+Bridlemile,206554,2014,Curfew,
+Bridlemile,206554,2014,Disorderly Conduct,4
+Bridlemile,206554,2014,Drugs,2
+Bridlemile,206554,2014,DUII,5
+Bridlemile,206554,2014,Embezzlement,
+Bridlemile,206554,2014,Forgery,2
+Bridlemile,206554,2014,Fraud,10
+Bridlemile,206554,2014,Gambling,
+Bridlemile,206554,2014,Homicide,
+Bridlemile,206554,2014,Kidnap,
+Bridlemile,206554,2014,Larceny,53
+Bridlemile,206554,2014,Liquor Laws,
+Bridlemile,206554,2014,Motor Vehicle Theft,11
+Bridlemile,206554,2014,Offenses Against Family,
+Bridlemile,206554,2014,Prostitution,
+Bridlemile,206554,2014,Rape,
+Bridlemile,206554,2014,Robbery,
+Bridlemile,206554,2014,Runaway,
+Bridlemile,206554,2014,Sex Offenses,
+Bridlemile,206554,2014,Stolen Property,
+Bridlemile,206554,2014,Trespass,5
+Bridlemile,206554,2014,Vandalism,15
+Bridlemile,206554,2014,Weapons,
+Brooklyn,206562,2004,Aggravated Assault,3
+Brooklyn,206562,2004,Arson,
+Brooklyn,206562,2004,"Assault, Simple",2
+Brooklyn,206562,2004,Burglary,24
+Brooklyn,206562,2004,Curfew,1
+Brooklyn,206562,2004,Disorderly Conduct,4
+Brooklyn,206562,2004,Drugs,6
+Brooklyn,206562,2004,DUII,8
+Brooklyn,206562,2004,Embezzlement,
+Brooklyn,206562,2004,Forgery,4
+Brooklyn,206562,2004,Fraud,8
+Brooklyn,206562,2004,Gambling,
+Brooklyn,206562,2004,Homicide,
+Brooklyn,206562,2004,Kidnap,
+Brooklyn,206562,2004,Larceny,33
+Brooklyn,206562,2004,Liquor Laws,
+Brooklyn,206562,2004,Motor Vehicle Theft,13
+Brooklyn,206562,2004,Offenses Against Family,
+Brooklyn,206562,2004,Prostitution,
+Brooklyn,206562,2004,Rape,
+Brooklyn,206562,2004,Robbery,4
+Brooklyn,206562,2004,Runaway,
+Brooklyn,206562,2004,Sex Offenses,
+Brooklyn,206562,2004,Stolen Property,
+Brooklyn,206562,2004,Trespass,1
+Brooklyn,206562,2004,Vandalism,15
+Brooklyn,206562,2004,Weapons,2
+Brooklyn,206562,2005,Aggravated Assault,6
+Brooklyn,206562,2005,Arson,1
+Brooklyn,206562,2005,"Assault, Simple",18
+Brooklyn,206562,2005,Burglary,42
+Brooklyn,206562,2005,Curfew,
+Brooklyn,206562,2005,Disorderly Conduct,8
+Brooklyn,206562,2005,Drugs,47
+Brooklyn,206562,2005,DUII,16
+Brooklyn,206562,2005,Embezzlement,4
+Brooklyn,206562,2005,Forgery,19
+Brooklyn,206562,2005,Fraud,18
+Brooklyn,206562,2005,Gambling,
+Brooklyn,206562,2005,Homicide,
+Brooklyn,206562,2005,Kidnap,
+Brooklyn,206562,2005,Larceny,101
+Brooklyn,206562,2005,Liquor Laws,13
+Brooklyn,206562,2005,Motor Vehicle Theft,37
+Brooklyn,206562,2005,Offenses Against Family,
+Brooklyn,206562,2005,Prostitution,
+Brooklyn,206562,2005,Rape,
+Brooklyn,206562,2005,Robbery,7
+Brooklyn,206562,2005,Runaway,
+Brooklyn,206562,2005,Sex Offenses,1
+Brooklyn,206562,2005,Stolen Property,1
+Brooklyn,206562,2005,Trespass,22
+Brooklyn,206562,2005,Vandalism,43
+Brooklyn,206562,2005,Weapons,3
+Brooklyn,206562,2006,Aggravated Assault,9
+Brooklyn,206562,2006,Arson,1
+Brooklyn,206562,2006,"Assault, Simple",18
+Brooklyn,206562,2006,Burglary,26
+Brooklyn,206562,2006,Curfew,
+Brooklyn,206562,2006,Disorderly Conduct,10
+Brooklyn,206562,2006,Drugs,41
+Brooklyn,206562,2006,DUII,21
+Brooklyn,206562,2006,Embezzlement,1
+Brooklyn,206562,2006,Forgery,7
+Brooklyn,206562,2006,Fraud,17
+Brooklyn,206562,2006,Gambling,
+Brooklyn,206562,2006,Homicide,
+Brooklyn,206562,2006,Kidnap,
+Brooklyn,206562,2006,Larceny,110
+Brooklyn,206562,2006,Liquor Laws,12
+Brooklyn,206562,2006,Motor Vehicle Theft,37
+Brooklyn,206562,2006,Offenses Against Family,
+Brooklyn,206562,2006,Prostitution,
+Brooklyn,206562,2006,Rape,
+Brooklyn,206562,2006,Robbery,3
+Brooklyn,206562,2006,Runaway,
+Brooklyn,206562,2006,Sex Offenses,1
+Brooklyn,206562,2006,Stolen Property,
+Brooklyn,206562,2006,Trespass,22
+Brooklyn,206562,2006,Vandalism,64
+Brooklyn,206562,2006,Weapons,2
+Brooklyn,206562,2007,Aggravated Assault,6
+Brooklyn,206562,2007,Arson,1
+Brooklyn,206562,2007,"Assault, Simple",16
+Brooklyn,206562,2007,Burglary,29
+Brooklyn,206562,2007,Curfew,
+Brooklyn,206562,2007,Disorderly Conduct,21
+Brooklyn,206562,2007,Drugs,25
+Brooklyn,206562,2007,DUII,21
+Brooklyn,206562,2007,Embezzlement,2
+Brooklyn,206562,2007,Forgery,7
+Brooklyn,206562,2007,Fraud,22
+Brooklyn,206562,2007,Gambling,
+Brooklyn,206562,2007,Homicide,
+Brooklyn,206562,2007,Kidnap,
+Brooklyn,206562,2007,Larceny,85
+Brooklyn,206562,2007,Liquor Laws,20
+Brooklyn,206562,2007,Motor Vehicle Theft,32
+Brooklyn,206562,2007,Offenses Against Family,
+Brooklyn,206562,2007,Prostitution,
+Brooklyn,206562,2007,Rape,
+Brooklyn,206562,2007,Robbery,8
+Brooklyn,206562,2007,Runaway,
+Brooklyn,206562,2007,Sex Offenses,
+Brooklyn,206562,2007,Stolen Property,
+Brooklyn,206562,2007,Trespass,15
+Brooklyn,206562,2007,Vandalism,37
+Brooklyn,206562,2007,Weapons,
+Brooklyn,206562,2008,Aggravated Assault,7
+Brooklyn,206562,2008,Arson,
+Brooklyn,206562,2008,"Assault, Simple",4
+Brooklyn,206562,2008,Burglary,30
+Brooklyn,206562,2008,Curfew,
+Brooklyn,206562,2008,Disorderly Conduct,9
+Brooklyn,206562,2008,Drugs,10
+Brooklyn,206562,2008,DUII,13
+Brooklyn,206562,2008,Embezzlement,1
+Brooklyn,206562,2008,Forgery,4
+Brooklyn,206562,2008,Fraud,18
+Brooklyn,206562,2008,Gambling,
+Brooklyn,206562,2008,Homicide,
+Brooklyn,206562,2008,Kidnap,
+Brooklyn,206562,2008,Larceny,113
+Brooklyn,206562,2008,Liquor Laws,11
+Brooklyn,206562,2008,Motor Vehicle Theft,23
+Brooklyn,206562,2008,Offenses Against Family,
+Brooklyn,206562,2008,Prostitution,
+Brooklyn,206562,2008,Rape,
+Brooklyn,206562,2008,Robbery,4
+Brooklyn,206562,2008,Runaway,
+Brooklyn,206562,2008,Sex Offenses,1
+Brooklyn,206562,2008,Stolen Property,
+Brooklyn,206562,2008,Trespass,11
+Brooklyn,206562,2008,Vandalism,20
+Brooklyn,206562,2008,Weapons,1
+Brooklyn,206562,2009,Aggravated Assault,2
+Brooklyn,206562,2009,Arson,
+Brooklyn,206562,2009,"Assault, Simple",12
+Brooklyn,206562,2009,Burglary,33
+Brooklyn,206562,2009,Curfew,
+Brooklyn,206562,2009,Disorderly Conduct,13
+Brooklyn,206562,2009,Drugs,9
+Brooklyn,206562,2009,DUII,15
+Brooklyn,206562,2009,Embezzlement,1
+Brooklyn,206562,2009,Forgery,4
+Brooklyn,206562,2009,Fraud,9
+Brooklyn,206562,2009,Gambling,
+Brooklyn,206562,2009,Homicide,
+Brooklyn,206562,2009,Kidnap,
+Brooklyn,206562,2009,Larceny,135
+Brooklyn,206562,2009,Liquor Laws,22
+Brooklyn,206562,2009,Motor Vehicle Theft,18
+Brooklyn,206562,2009,Offenses Against Family,
+Brooklyn,206562,2009,Prostitution,
+Brooklyn,206562,2009,Rape,
+Brooklyn,206562,2009,Robbery,3
+Brooklyn,206562,2009,Runaway,
+Brooklyn,206562,2009,Sex Offenses,
+Brooklyn,206562,2009,Stolen Property,
+Brooklyn,206562,2009,Trespass,16
+Brooklyn,206562,2009,Vandalism,27
+Brooklyn,206562,2009,Weapons,
+Brooklyn,206562,2010,Aggravated Assault,6
+Brooklyn,206562,2010,Arson,
+Brooklyn,206562,2010,"Assault, Simple",9
+Brooklyn,206562,2010,Burglary,22
+Brooklyn,206562,2010,Curfew,
+Brooklyn,206562,2010,Disorderly Conduct,13
+Brooklyn,206562,2010,Drugs,9
+Brooklyn,206562,2010,DUII,20
+Brooklyn,206562,2010,Embezzlement,1
+Brooklyn,206562,2010,Forgery,12
+Brooklyn,206562,2010,Fraud,11
+Brooklyn,206562,2010,Gambling,
+Brooklyn,206562,2010,Homicide,
+Brooklyn,206562,2010,Kidnap,
+Brooklyn,206562,2010,Larceny,135
+Brooklyn,206562,2010,Liquor Laws,13
+Brooklyn,206562,2010,Motor Vehicle Theft,27
+Brooklyn,206562,2010,Offenses Against Family,
+Brooklyn,206562,2010,Prostitution,
+Brooklyn,206562,2010,Rape,1
+Brooklyn,206562,2010,Robbery,3
+Brooklyn,206562,2010,Runaway,
+Brooklyn,206562,2010,Sex Offenses,
+Brooklyn,206562,2010,Stolen Property,
+Brooklyn,206562,2010,Trespass,5
+Brooklyn,206562,2010,Vandalism,30
+Brooklyn,206562,2010,Weapons,3
+Brooklyn,206562,2011,Aggravated Assault,8
+Brooklyn,206562,2011,Arson,1
+Brooklyn,206562,2011,"Assault, Simple",7
+Brooklyn,206562,2011,Burglary,39
+Brooklyn,206562,2011,Curfew,1
+Brooklyn,206562,2011,Disorderly Conduct,12
+Brooklyn,206562,2011,Drugs,6
+Brooklyn,206562,2011,DUII,20
+Brooklyn,206562,2011,Embezzlement,
+Brooklyn,206562,2011,Forgery,13
+Brooklyn,206562,2011,Fraud,9
+Brooklyn,206562,2011,Gambling,
+Brooklyn,206562,2011,Homicide,
+Brooklyn,206562,2011,Kidnap,
+Brooklyn,206562,2011,Larceny,161
+Brooklyn,206562,2011,Liquor Laws,2
+Brooklyn,206562,2011,Motor Vehicle Theft,28
+Brooklyn,206562,2011,Offenses Against Family,
+Brooklyn,206562,2011,Prostitution,
+Brooklyn,206562,2011,Rape,1
+Brooklyn,206562,2011,Robbery,2
+Brooklyn,206562,2011,Runaway,
+Brooklyn,206562,2011,Sex Offenses,
+Brooklyn,206562,2011,Stolen Property,
+Brooklyn,206562,2011,Trespass,8
+Brooklyn,206562,2011,Vandalism,30
+Brooklyn,206562,2011,Weapons,
+Brooklyn,206562,2012,Aggravated Assault,3
+Brooklyn,206562,2012,Arson,
+Brooklyn,206562,2012,"Assault, Simple",8
+Brooklyn,206562,2012,Burglary,61
+Brooklyn,206562,2012,Curfew,
+Brooklyn,206562,2012,Disorderly Conduct,9
+Brooklyn,206562,2012,Drugs,2
+Brooklyn,206562,2012,DUII,19
+Brooklyn,206562,2012,Embezzlement,
+Brooklyn,206562,2012,Forgery,3
+Brooklyn,206562,2012,Fraud,5
+Brooklyn,206562,2012,Gambling,
+Brooklyn,206562,2012,Homicide,
+Brooklyn,206562,2012,Kidnap,
+Brooklyn,206562,2012,Larceny,136
+Brooklyn,206562,2012,Liquor Laws,11
+Brooklyn,206562,2012,Motor Vehicle Theft,34
+Brooklyn,206562,2012,Offenses Against Family,1
+Brooklyn,206562,2012,Prostitution,1
+Brooklyn,206562,2012,Rape,
+Brooklyn,206562,2012,Robbery,4
+Brooklyn,206562,2012,Runaway,
+Brooklyn,206562,2012,Sex Offenses,2
+Brooklyn,206562,2012,Stolen Property,1
+Brooklyn,206562,2012,Trespass,13
+Brooklyn,206562,2012,Vandalism,26
+Brooklyn,206562,2012,Weapons,
+Brooklyn,206562,2013,Aggravated Assault,6
+Brooklyn,206562,2013,Arson,
+Brooklyn,206562,2013,"Assault, Simple",9
+Brooklyn,206562,2013,Burglary,24
+Brooklyn,206562,2013,Curfew,
+Brooklyn,206562,2013,Disorderly Conduct,9
+Brooklyn,206562,2013,Drugs,6
+Brooklyn,206562,2013,DUII,12
+Brooklyn,206562,2013,Embezzlement,
+Brooklyn,206562,2013,Forgery,1
+Brooklyn,206562,2013,Fraud,8
+Brooklyn,206562,2013,Gambling,
+Brooklyn,206562,2013,Homicide,
+Brooklyn,206562,2013,Kidnap,
+Brooklyn,206562,2013,Larceny,123
+Brooklyn,206562,2013,Liquor Laws,3
+Brooklyn,206562,2013,Motor Vehicle Theft,15
+Brooklyn,206562,2013,Offenses Against Family,
+Brooklyn,206562,2013,Prostitution,
+Brooklyn,206562,2013,Rape,
+Brooklyn,206562,2013,Robbery,5
+Brooklyn,206562,2013,Runaway,
+Brooklyn,206562,2013,Sex Offenses,1
+Brooklyn,206562,2013,Stolen Property,
+Brooklyn,206562,2013,Trespass,5
+Brooklyn,206562,2013,Vandalism,103
+Brooklyn,206562,2013,Weapons,2
+Brooklyn,206562,2014,Aggravated Assault,6
+Brooklyn,206562,2014,Arson,
+Brooklyn,206562,2014,"Assault, Simple",8
+Brooklyn,206562,2014,Burglary,25
+Brooklyn,206562,2014,Curfew,
+Brooklyn,206562,2014,Disorderly Conduct,8
+Brooklyn,206562,2014,Drugs,5
+Brooklyn,206562,2014,DUII,15
+Brooklyn,206562,2014,Embezzlement,1
+Brooklyn,206562,2014,Forgery,2
+Brooklyn,206562,2014,Fraud,9
+Brooklyn,206562,2014,Gambling,
+Brooklyn,206562,2014,Homicide,
+Brooklyn,206562,2014,Kidnap,
+Brooklyn,206562,2014,Larceny,104
+Brooklyn,206562,2014,Liquor Laws,3
+Brooklyn,206562,2014,Motor Vehicle Theft,28
+Brooklyn,206562,2014,Offenses Against Family,
+Brooklyn,206562,2014,Prostitution,
+Brooklyn,206562,2014,Rape,
+Brooklyn,206562,2014,Robbery,4
+Brooklyn,206562,2014,Runaway,
+Brooklyn,206562,2014,Sex Offenses,
+Brooklyn,206562,2014,Stolen Property,
+Brooklyn,206562,2014,Trespass,5
+Brooklyn,206562,2014,Vandalism,29
+Brooklyn,206562,2014,Weapons,
+Buckman,271068,2004,Aggravated Assault,12
+Buckman,271068,2004,Arson,
+Buckman,271068,2004,"Assault, Simple",14
+Buckman,271068,2004,Burglary,60
+Buckman,271068,2004,Curfew,1
+Buckman,271068,2004,Disorderly Conduct,17
+Buckman,271068,2004,Drugs,28
+Buckman,271068,2004,DUII,21
+Buckman,271068,2004,Embezzlement,1
+Buckman,271068,2004,Forgery,16
+Buckman,271068,2004,Fraud,15
+Buckman,271068,2004,Gambling,
+Buckman,271068,2004,Homicide,
+Buckman,271068,2004,Kidnap,
+Buckman,271068,2004,Larceny,244
+Buckman,271068,2004,Liquor Laws,34
+Buckman,271068,2004,Motor Vehicle Theft,58
+Buckman,271068,2004,Offenses Against Family,
+Buckman,271068,2004,Prostitution,1
+Buckman,271068,2004,Rape,1
+Buckman,271068,2004,Robbery,2
+Buckman,271068,2004,Runaway,
+Buckman,271068,2004,Sex Offenses,1
+Buckman,271068,2004,Stolen Property,
+Buckman,271068,2004,Trespass,14
+Buckman,271068,2004,Vandalism,68
+Buckman,271068,2004,Weapons,1
+Buckman,271068,2005,Aggravated Assault,50
+Buckman,271068,2005,Arson,7
+Buckman,271068,2005,"Assault, Simple",50
+Buckman,271068,2005,Burglary,110
+Buckman,271068,2005,Curfew,2
+Buckman,271068,2005,Disorderly Conduct,54
+Buckman,271068,2005,Drugs,137
+Buckman,271068,2005,DUII,139
+Buckman,271068,2005,Embezzlement,8
+Buckman,271068,2005,Forgery,47
+Buckman,271068,2005,Fraud,58
+Buckman,271068,2005,Gambling,
+Buckman,271068,2005,Homicide,
+Buckman,271068,2005,Kidnap,
+Buckman,271068,2005,Larceny,649
+Buckman,271068,2005,Liquor Laws,122
+Buckman,271068,2005,Motor Vehicle Theft,129
+Buckman,271068,2005,Offenses Against Family,1
+Buckman,271068,2005,Prostitution,2
+Buckman,271068,2005,Rape,
+Buckman,271068,2005,Robbery,21
+Buckman,271068,2005,Runaway,2
+Buckman,271068,2005,Sex Offenses,5
+Buckman,271068,2005,Stolen Property,4
+Buckman,271068,2005,Trespass,130
+Buckman,271068,2005,Vandalism,205
+Buckman,271068,2005,Weapons,9
+Buckman,271068,2006,Aggravated Assault,36
+Buckman,271068,2006,Arson,2
+Buckman,271068,2006,"Assault, Simple",65
+Buckman,271068,2006,Burglary,112
+Buckman,271068,2006,Curfew,
+Buckman,271068,2006,Disorderly Conduct,59
+Buckman,271068,2006,Drugs,98
+Buckman,271068,2006,DUII,127
+Buckman,271068,2006,Embezzlement,10
+Buckman,271068,2006,Forgery,34
+Buckman,271068,2006,Fraud,41
+Buckman,271068,2006,Gambling,
+Buckman,271068,2006,Homicide,
+Buckman,271068,2006,Kidnap,1
+Buckman,271068,2006,Larceny,444
+Buckman,271068,2006,Liquor Laws,143
+Buckman,271068,2006,Motor Vehicle Theft,102
+Buckman,271068,2006,Offenses Against Family,
+Buckman,271068,2006,Prostitution,16
+Buckman,271068,2006,Rape,3
+Buckman,271068,2006,Robbery,12
+Buckman,271068,2006,Runaway,
+Buckman,271068,2006,Sex Offenses,5
+Buckman,271068,2006,Stolen Property,2
+Buckman,271068,2006,Trespass,102
+Buckman,271068,2006,Vandalism,232
+Buckman,271068,2006,Weapons,8
+Buckman,271068,2007,Aggravated Assault,33
+Buckman,271068,2007,Arson,5
+Buckman,271068,2007,"Assault, Simple",61
+Buckman,271068,2007,Burglary,113
+Buckman,271068,2007,Curfew,1
+Buckman,271068,2007,Disorderly Conduct,57
+Buckman,271068,2007,Drugs,64
+Buckman,271068,2007,DUII,67
+Buckman,271068,2007,Embezzlement,3
+Buckman,271068,2007,Forgery,31
+Buckman,271068,2007,Fraud,40
+Buckman,271068,2007,Gambling,
+Buckman,271068,2007,Homicide,
+Buckman,271068,2007,Kidnap,
+Buckman,271068,2007,Larceny,482
+Buckman,271068,2007,Liquor Laws,135
+Buckman,271068,2007,Motor Vehicle Theft,119
+Buckman,271068,2007,Offenses Against Family,
+Buckman,271068,2007,Prostitution,
+Buckman,271068,2007,Rape,3
+Buckman,271068,2007,Robbery,18
+Buckman,271068,2007,Runaway,
+Buckman,271068,2007,Sex Offenses,2
+Buckman,271068,2007,Stolen Property,
+Buckman,271068,2007,Trespass,131
+Buckman,271068,2007,Vandalism,200
+Buckman,271068,2007,Weapons,5
+Buckman,271068,2008,Aggravated Assault,31
+Buckman,271068,2008,Arson,5
+Buckman,271068,2008,"Assault, Simple",49
+Buckman,271068,2008,Burglary,78
+Buckman,271068,2008,Curfew,2
+Buckman,271068,2008,Disorderly Conduct,79
+Buckman,271068,2008,Drugs,70
+Buckman,271068,2008,DUII,71
+Buckman,271068,2008,Embezzlement,4
+Buckman,271068,2008,Forgery,29
+Buckman,271068,2008,Fraud,49
+Buckman,271068,2008,Gambling,
+Buckman,271068,2008,Homicide,1
+Buckman,271068,2008,Kidnap,
+Buckman,271068,2008,Larceny,562
+Buckman,271068,2008,Liquor Laws,230
+Buckman,271068,2008,Motor Vehicle Theft,87
+Buckman,271068,2008,Offenses Against Family,
+Buckman,271068,2008,Prostitution,
+Buckman,271068,2008,Rape,2
+Buckman,271068,2008,Robbery,20
+Buckman,271068,2008,Runaway,
+Buckman,271068,2008,Sex Offenses,6
+Buckman,271068,2008,Stolen Property,1
+Buckman,271068,2008,Trespass,204
+Buckman,271068,2008,Vandalism,136
+Buckman,271068,2008,Weapons,4
+Buckman,271068,2009,Aggravated Assault,32
+Buckman,271068,2009,Arson,4
+Buckman,271068,2009,"Assault, Simple",64
+Buckman,271068,2009,Burglary,62
+Buckman,271068,2009,Curfew,
+Buckman,271068,2009,Disorderly Conduct,90
+Buckman,271068,2009,Drugs,95
+Buckman,271068,2009,DUII,63
+Buckman,271068,2009,Embezzlement,8
+Buckman,271068,2009,Forgery,13
+Buckman,271068,2009,Fraud,29
+Buckman,271068,2009,Gambling,
+Buckman,271068,2009,Homicide,
+Buckman,271068,2009,Kidnap,
+Buckman,271068,2009,Larceny,511
+Buckman,271068,2009,Liquor Laws,254
+Buckman,271068,2009,Motor Vehicle Theft,87
+Buckman,271068,2009,Offenses Against Family,
+Buckman,271068,2009,Prostitution,
+Buckman,271068,2009,Rape,
+Buckman,271068,2009,Robbery,21
+Buckman,271068,2009,Runaway,
+Buckman,271068,2009,Sex Offenses,6
+Buckman,271068,2009,Stolen Property,5
+Buckman,271068,2009,Trespass,208
+Buckman,271068,2009,Vandalism,169
+Buckman,271068,2009,Weapons,5
+Buckman,271068,2010,Aggravated Assault,28
+Buckman,271068,2010,Arson,4
+Buckman,271068,2010,"Assault, Simple",59
+Buckman,271068,2010,Burglary,100
+Buckman,271068,2010,Curfew,
+Buckman,271068,2010,Disorderly Conduct,45
+Buckman,271068,2010,Drugs,69
+Buckman,271068,2010,DUII,75
+Buckman,271068,2010,Embezzlement,6
+Buckman,271068,2010,Forgery,28
+Buckman,271068,2010,Fraud,19
+Buckman,271068,2010,Gambling,
+Buckman,271068,2010,Homicide,
+Buckman,271068,2010,Kidnap,
+Buckman,271068,2010,Larceny,497
+Buckman,271068,2010,Liquor Laws,141
+Buckman,271068,2010,Motor Vehicle Theft,93
+Buckman,271068,2010,Offenses Against Family,
+Buckman,271068,2010,Prostitution,
+Buckman,271068,2010,Rape,1
+Buckman,271068,2010,Robbery,14
+Buckman,271068,2010,Runaway,2
+Buckman,271068,2010,Sex Offenses,3
+Buckman,271068,2010,Stolen Property,1
+Buckman,271068,2010,Trespass,67
+Buckman,271068,2010,Vandalism,164
+Buckman,271068,2010,Weapons,7
+Buckman,271068,2011,Aggravated Assault,27
+Buckman,271068,2011,Arson,9
+Buckman,271068,2011,"Assault, Simple",51
+Buckman,271068,2011,Burglary,87
+Buckman,271068,2011,Curfew,1
+Buckman,271068,2011,Disorderly Conduct,64
+Buckman,271068,2011,Drugs,61
+Buckman,271068,2011,DUII,100
+Buckman,271068,2011,Embezzlement,5
+Buckman,271068,2011,Forgery,12
+Buckman,271068,2011,Fraud,33
+Buckman,271068,2011,Gambling,
+Buckman,271068,2011,Homicide,
+Buckman,271068,2011,Kidnap,
+Buckman,271068,2011,Larceny,598
+Buckman,271068,2011,Liquor Laws,165
+Buckman,271068,2011,Motor Vehicle Theft,57
+Buckman,271068,2011,Offenses Against Family,
+Buckman,271068,2011,Prostitution,
+Buckman,271068,2011,Rape,2
+Buckman,271068,2011,Robbery,12
+Buckman,271068,2011,Runaway,4
+Buckman,271068,2011,Sex Offenses,3
+Buckman,271068,2011,Stolen Property,1
+Buckman,271068,2011,Trespass,64
+Buckman,271068,2011,Vandalism,207
+Buckman,271068,2011,Weapons,11
+Buckman,271068,2012,Aggravated Assault,37
+Buckman,271068,2012,Arson,6
+Buckman,271068,2012,"Assault, Simple",58
+Buckman,271068,2012,Burglary,77
+Buckman,271068,2012,Curfew,
+Buckman,271068,2012,Disorderly Conduct,81
+Buckman,271068,2012,Drugs,45
+Buckman,271068,2012,DUII,104
+Buckman,271068,2012,Embezzlement,1
+Buckman,271068,2012,Forgery,24
+Buckman,271068,2012,Fraud,27
+Buckman,271068,2012,Gambling,
+Buckman,271068,2012,Homicide,2
+Buckman,271068,2012,Kidnap,
+Buckman,271068,2012,Larceny,824
+Buckman,271068,2012,Liquor Laws,167
+Buckman,271068,2012,Motor Vehicle Theft,92
+Buckman,271068,2012,Offenses Against Family,
+Buckman,271068,2012,Prostitution,
+Buckman,271068,2012,Rape,2
+Buckman,271068,2012,Robbery,22
+Buckman,271068,2012,Runaway,2
+Buckman,271068,2012,Sex Offenses,3
+Buckman,271068,2012,Stolen Property,2
+Buckman,271068,2012,Trespass,68
+Buckman,271068,2012,Vandalism,213
+Buckman,271068,2012,Weapons,6
+Buckman,271068,2013,Aggravated Assault,29
+Buckman,271068,2013,Arson,1
+Buckman,271068,2013,"Assault, Simple",61
+Buckman,271068,2013,Burglary,108
+Buckman,271068,2013,Curfew,2
+Buckman,271068,2013,Disorderly Conduct,75
+Buckman,271068,2013,Drugs,57
+Buckman,271068,2013,DUII,89
+Buckman,271068,2013,Embezzlement,2
+Buckman,271068,2013,Forgery,18
+Buckman,271068,2013,Fraud,27
+Buckman,271068,2013,Gambling,
+Buckman,271068,2013,Homicide,
+Buckman,271068,2013,Kidnap,
+Buckman,271068,2013,Larceny,736
+Buckman,271068,2013,Liquor Laws,103
+Buckman,271068,2013,Motor Vehicle Theft,110
+Buckman,271068,2013,Offenses Against Family,
+Buckman,271068,2013,Prostitution,1
+Buckman,271068,2013,Rape,
+Buckman,271068,2013,Robbery,19
+Buckman,271068,2013,Runaway,
+Buckman,271068,2013,Sex Offenses,
+Buckman,271068,2013,Stolen Property,4
+Buckman,271068,2013,Trespass,70
+Buckman,271068,2013,Vandalism,226
+Buckman,271068,2013,Weapons,10
+Buckman,271068,2014,Aggravated Assault,37
+Buckman,271068,2014,Arson,7
+Buckman,271068,2014,"Assault, Simple",80
+Buckman,271068,2014,Burglary,76
+Buckman,271068,2014,Curfew,
+Buckman,271068,2014,Disorderly Conduct,94
+Buckman,271068,2014,Drugs,52
+Buckman,271068,2014,DUII,72
+Buckman,271068,2014,Embezzlement,2
+Buckman,271068,2014,Forgery,7
+Buckman,271068,2014,Fraud,32
+Buckman,271068,2014,Gambling,
+Buckman,271068,2014,Homicide,
+Buckman,271068,2014,Kidnap,1
+Buckman,271068,2014,Larceny,880
+Buckman,271068,2014,Liquor Laws,119
+Buckman,271068,2014,Motor Vehicle Theft,95
+Buckman,271068,2014,Offenses Against Family,
+Buckman,271068,2014,Prostitution,
+Buckman,271068,2014,Rape,2
+Buckman,271068,2014,Robbery,18
+Buckman,271068,2014,Runaway,
+Buckman,271068,2014,Sex Offenses,5
+Buckman,271068,2014,Stolen Property,3
+Buckman,271068,2014,Trespass,58
+Buckman,271068,2014,Vandalism,165
+Buckman,271068,2014,Weapons,10
+Cathedral Park,271070,2004,Aggravated Assault,9
+Cathedral Park,271070,2004,Arson,2
+Cathedral Park,271070,2004,"Assault, Simple",32
+Cathedral Park,271070,2004,Burglary,37
+Cathedral Park,271070,2004,Curfew,3
+Cathedral Park,271070,2004,Disorderly Conduct,18
+Cathedral Park,271070,2004,Drugs,23
+Cathedral Park,271070,2004,DUII,11
+Cathedral Park,271070,2004,Embezzlement,3
+Cathedral Park,271070,2004,Forgery,22
+Cathedral Park,271070,2004,Fraud,16
+Cathedral Park,271070,2004,Gambling,
+Cathedral Park,271070,2004,Homicide,1
+Cathedral Park,271070,2004,Kidnap,1
+Cathedral Park,271070,2004,Larceny,139
+Cathedral Park,271070,2004,Liquor Laws,12
+Cathedral Park,271070,2004,Motor Vehicle Theft,24
+Cathedral Park,271070,2004,Offenses Against Family,
+Cathedral Park,271070,2004,Prostitution,
+Cathedral Park,271070,2004,Rape,
+Cathedral Park,271070,2004,Robbery,15
+Cathedral Park,271070,2004,Runaway,
+Cathedral Park,271070,2004,Sex Offenses,1
+Cathedral Park,271070,2004,Stolen Property,2
+Cathedral Park,271070,2004,Trespass,20
+Cathedral Park,271070,2004,Vandalism,56
+Cathedral Park,271070,2004,Weapons,4
+Cathedral Park,271070,2005,Aggravated Assault,41
+Cathedral Park,271070,2005,Arson,2
+Cathedral Park,271070,2005,"Assault, Simple",82
+Cathedral Park,271070,2005,Burglary,95
+Cathedral Park,271070,2005,Curfew,14
+Cathedral Park,271070,2005,Disorderly Conduct,63
+Cathedral Park,271070,2005,Drugs,50
+Cathedral Park,271070,2005,DUII,44
+Cathedral Park,271070,2005,Embezzlement,4
+Cathedral Park,271070,2005,Forgery,51
+Cathedral Park,271070,2005,Fraud,50
+Cathedral Park,271070,2005,Gambling,
+Cathedral Park,271070,2005,Homicide,
+Cathedral Park,271070,2005,Kidnap,
+Cathedral Park,271070,2005,Larceny,486
+Cathedral Park,271070,2005,Liquor Laws,69
+Cathedral Park,271070,2005,Motor Vehicle Theft,60
+Cathedral Park,271070,2005,Offenses Against Family,
+Cathedral Park,271070,2005,Prostitution,2
+Cathedral Park,271070,2005,Rape,
+Cathedral Park,271070,2005,Robbery,24
+Cathedral Park,271070,2005,Runaway,1
+Cathedral Park,271070,2005,Sex Offenses,3
+Cathedral Park,271070,2005,Stolen Property,5
+Cathedral Park,271070,2005,Trespass,72
+Cathedral Park,271070,2005,Vandalism,148
+Cathedral Park,271070,2005,Weapons,11
+Cathedral Park,271070,2006,Aggravated Assault,33
+Cathedral Park,271070,2006,Arson,5
+Cathedral Park,271070,2006,"Assault, Simple",78
+Cathedral Park,271070,2006,Burglary,96
+Cathedral Park,271070,2006,Curfew,5
+Cathedral Park,271070,2006,Disorderly Conduct,34
+Cathedral Park,271070,2006,Drugs,26
+Cathedral Park,271070,2006,DUII,39
+Cathedral Park,271070,2006,Embezzlement,3
+Cathedral Park,271070,2006,Forgery,24
+Cathedral Park,271070,2006,Fraud,35
+Cathedral Park,271070,2006,Gambling,
+Cathedral Park,271070,2006,Homicide,
+Cathedral Park,271070,2006,Kidnap,1
+Cathedral Park,271070,2006,Larceny,420
+Cathedral Park,271070,2006,Liquor Laws,53
+Cathedral Park,271070,2006,Motor Vehicle Theft,57
+Cathedral Park,271070,2006,Offenses Against Family,
+Cathedral Park,271070,2006,Prostitution,
+Cathedral Park,271070,2006,Rape,
+Cathedral Park,271070,2006,Robbery,26
+Cathedral Park,271070,2006,Runaway,
+Cathedral Park,271070,2006,Sex Offenses,3
+Cathedral Park,271070,2006,Stolen Property,2
+Cathedral Park,271070,2006,Trespass,57
+Cathedral Park,271070,2006,Vandalism,115
+Cathedral Park,271070,2006,Weapons,10
+Cathedral Park,271070,2007,Aggravated Assault,27
+Cathedral Park,271070,2007,Arson,1
+Cathedral Park,271070,2007,"Assault, Simple",68
+Cathedral Park,271070,2007,Burglary,75
+Cathedral Park,271070,2007,Curfew,17
+Cathedral Park,271070,2007,Disorderly Conduct,52
+Cathedral Park,271070,2007,Drugs,58
+Cathedral Park,271070,2007,DUII,30
+Cathedral Park,271070,2007,Embezzlement,6
+Cathedral Park,271070,2007,Forgery,32
+Cathedral Park,271070,2007,Fraud,36
+Cathedral Park,271070,2007,Gambling,
+Cathedral Park,271070,2007,Homicide,
+Cathedral Park,271070,2007,Kidnap,
+Cathedral Park,271070,2007,Larceny,418
+Cathedral Park,271070,2007,Liquor Laws,113
+Cathedral Park,271070,2007,Motor Vehicle Theft,97
+Cathedral Park,271070,2007,Offenses Against Family,
+Cathedral Park,271070,2007,Prostitution,2
+Cathedral Park,271070,2007,Rape,
+Cathedral Park,271070,2007,Robbery,32
+Cathedral Park,271070,2007,Runaway,1
+Cathedral Park,271070,2007,Sex Offenses,1
+Cathedral Park,271070,2007,Stolen Property,2
+Cathedral Park,271070,2007,Trespass,68
+Cathedral Park,271070,2007,Vandalism,163
+Cathedral Park,271070,2007,Weapons,3
+Cathedral Park,271070,2008,Aggravated Assault,37
+Cathedral Park,271070,2008,Arson,3
+Cathedral Park,271070,2008,"Assault, Simple",55
+Cathedral Park,271070,2008,Burglary,79
+Cathedral Park,271070,2008,Curfew,3
+Cathedral Park,271070,2008,Disorderly Conduct,67
+Cathedral Park,271070,2008,Drugs,43
+Cathedral Park,271070,2008,DUII,22
+Cathedral Park,271070,2008,Embezzlement,6
+Cathedral Park,271070,2008,Forgery,16
+Cathedral Park,271070,2008,Fraud,33
+Cathedral Park,271070,2008,Gambling,
+Cathedral Park,271070,2008,Homicide,1
+Cathedral Park,271070,2008,Kidnap,1
+Cathedral Park,271070,2008,Larceny,383
+Cathedral Park,271070,2008,Liquor Laws,72
+Cathedral Park,271070,2008,Motor Vehicle Theft,46
+Cathedral Park,271070,2008,Offenses Against Family,
+Cathedral Park,271070,2008,Prostitution,
+Cathedral Park,271070,2008,Rape,
+Cathedral Park,271070,2008,Robbery,23
+Cathedral Park,271070,2008,Runaway,
+Cathedral Park,271070,2008,Sex Offenses,1
+Cathedral Park,271070,2008,Stolen Property,4
+Cathedral Park,271070,2008,Trespass,73
+Cathedral Park,271070,2008,Vandalism,96
+Cathedral Park,271070,2008,Weapons,6
+Cathedral Park,271070,2009,Aggravated Assault,19
+Cathedral Park,271070,2009,Arson,2
+Cathedral Park,271070,2009,"Assault, Simple",46
+Cathedral Park,271070,2009,Burglary,79
+Cathedral Park,271070,2009,Curfew,3
+Cathedral Park,271070,2009,Disorderly Conduct,44
+Cathedral Park,271070,2009,Drugs,51
+Cathedral Park,271070,2009,DUII,33
+Cathedral Park,271070,2009,Embezzlement,3
+Cathedral Park,271070,2009,Forgery,13
+Cathedral Park,271070,2009,Fraud,24
+Cathedral Park,271070,2009,Gambling,
+Cathedral Park,271070,2009,Homicide,
+Cathedral Park,271070,2009,Kidnap,
+Cathedral Park,271070,2009,Larceny,396
+Cathedral Park,271070,2009,Liquor Laws,63
+Cathedral Park,271070,2009,Motor Vehicle Theft,88
+Cathedral Park,271070,2009,Offenses Against Family,
+Cathedral Park,271070,2009,Prostitution,
+Cathedral Park,271070,2009,Rape,1
+Cathedral Park,271070,2009,Robbery,22
+Cathedral Park,271070,2009,Runaway,
+Cathedral Park,271070,2009,Sex Offenses,
+Cathedral Park,271070,2009,Stolen Property,1
+Cathedral Park,271070,2009,Trespass,66
+Cathedral Park,271070,2009,Vandalism,100
+Cathedral Park,271070,2009,Weapons,9
+Cathedral Park,271070,2010,Aggravated Assault,32
+Cathedral Park,271070,2010,Arson,1
+Cathedral Park,271070,2010,"Assault, Simple",39
+Cathedral Park,271070,2010,Burglary,85
+Cathedral Park,271070,2010,Curfew,
+Cathedral Park,271070,2010,Disorderly Conduct,48
+Cathedral Park,271070,2010,Drugs,34
+Cathedral Park,271070,2010,DUII,34
+Cathedral Park,271070,2010,Embezzlement,
+Cathedral Park,271070,2010,Forgery,11
+Cathedral Park,271070,2010,Fraud,26
+Cathedral Park,271070,2010,Gambling,
+Cathedral Park,271070,2010,Homicide,
+Cathedral Park,271070,2010,Kidnap,
+Cathedral Park,271070,2010,Larceny,419
+Cathedral Park,271070,2010,Liquor Laws,64
+Cathedral Park,271070,2010,Motor Vehicle Theft,40
+Cathedral Park,271070,2010,Offenses Against Family,
+Cathedral Park,271070,2010,Prostitution,
+Cathedral Park,271070,2010,Rape,
+Cathedral Park,271070,2010,Robbery,20
+Cathedral Park,271070,2010,Runaway,
+Cathedral Park,271070,2010,Sex Offenses,1
+Cathedral Park,271070,2010,Stolen Property,1
+Cathedral Park,271070,2010,Trespass,46
+Cathedral Park,271070,2010,Vandalism,124
+Cathedral Park,271070,2010,Weapons,2
+Cathedral Park,271070,2011,Aggravated Assault,18
+Cathedral Park,271070,2011,Arson,
+Cathedral Park,271070,2011,"Assault, Simple",45
+Cathedral Park,271070,2011,Burglary,66
+Cathedral Park,271070,2011,Curfew,1
+Cathedral Park,271070,2011,Disorderly Conduct,50
+Cathedral Park,271070,2011,Drugs,32
+Cathedral Park,271070,2011,DUII,27
+Cathedral Park,271070,2011,Embezzlement,5
+Cathedral Park,271070,2011,Forgery,18
+Cathedral Park,271070,2011,Fraud,48
+Cathedral Park,271070,2011,Gambling,
+Cathedral Park,271070,2011,Homicide,
+Cathedral Park,271070,2011,Kidnap,1
+Cathedral Park,271070,2011,Larceny,395
+Cathedral Park,271070,2011,Liquor Laws,41
+Cathedral Park,271070,2011,Motor Vehicle Theft,59
+Cathedral Park,271070,2011,Offenses Against Family,
+Cathedral Park,271070,2011,Prostitution,
+Cathedral Park,271070,2011,Rape,
+Cathedral Park,271070,2011,Robbery,18
+Cathedral Park,271070,2011,Runaway,
+Cathedral Park,271070,2011,Sex Offenses,
+Cathedral Park,271070,2011,Stolen Property,
+Cathedral Park,271070,2011,Trespass,44
+Cathedral Park,271070,2011,Vandalism,82
+Cathedral Park,271070,2011,Weapons,3
+Cathedral Park,271070,2012,Aggravated Assault,29
+Cathedral Park,271070,2012,Arson,1
+Cathedral Park,271070,2012,"Assault, Simple",61
+Cathedral Park,271070,2012,Burglary,78
+Cathedral Park,271070,2012,Curfew,
+Cathedral Park,271070,2012,Disorderly Conduct,55
+Cathedral Park,271070,2012,Drugs,25
+Cathedral Park,271070,2012,DUII,27
+Cathedral Park,271070,2012,Embezzlement,5
+Cathedral Park,271070,2012,Forgery,21
+Cathedral Park,271070,2012,Fraud,24
+Cathedral Park,271070,2012,Gambling,
+Cathedral Park,271070,2012,Homicide,
+Cathedral Park,271070,2012,Kidnap,
+Cathedral Park,271070,2012,Larceny,461
+Cathedral Park,271070,2012,Liquor Laws,17
+Cathedral Park,271070,2012,Motor Vehicle Theft,55
+Cathedral Park,271070,2012,Offenses Against Family,
+Cathedral Park,271070,2012,Prostitution,
+Cathedral Park,271070,2012,Rape,1
+Cathedral Park,271070,2012,Robbery,24
+Cathedral Park,271070,2012,Runaway,
+Cathedral Park,271070,2012,Sex Offenses,
+Cathedral Park,271070,2012,Stolen Property,
+Cathedral Park,271070,2012,Trespass,42
+Cathedral Park,271070,2012,Vandalism,102
+Cathedral Park,271070,2012,Weapons,5
+Cathedral Park,271070,2013,Aggravated Assault,20
+Cathedral Park,271070,2013,Arson,
+Cathedral Park,271070,2013,"Assault, Simple",57
+Cathedral Park,271070,2013,Burglary,91
+Cathedral Park,271070,2013,Curfew,
+Cathedral Park,271070,2013,Disorderly Conduct,56
+Cathedral Park,271070,2013,Drugs,44
+Cathedral Park,271070,2013,DUII,38
+Cathedral Park,271070,2013,Embezzlement,7
+Cathedral Park,271070,2013,Forgery,20
+Cathedral Park,271070,2013,Fraud,28
+Cathedral Park,271070,2013,Gambling,
+Cathedral Park,271070,2013,Homicide,
+Cathedral Park,271070,2013,Kidnap,1
+Cathedral Park,271070,2013,Larceny,396
+Cathedral Park,271070,2013,Liquor Laws,15
+Cathedral Park,271070,2013,Motor Vehicle Theft,60
+Cathedral Park,271070,2013,Offenses Against Family,
+Cathedral Park,271070,2013,Prostitution,
+Cathedral Park,271070,2013,Rape,
+Cathedral Park,271070,2013,Robbery,14
+Cathedral Park,271070,2013,Runaway,1
+Cathedral Park,271070,2013,Sex Offenses,1
+Cathedral Park,271070,2013,Stolen Property,2
+Cathedral Park,271070,2013,Trespass,35
+Cathedral Park,271070,2013,Vandalism,66
+Cathedral Park,271070,2013,Weapons,6
+Cathedral Park,271070,2014,Aggravated Assault,19
+Cathedral Park,271070,2014,Arson,
+Cathedral Park,271070,2014,"Assault, Simple",49
+Cathedral Park,271070,2014,Burglary,101
+Cathedral Park,271070,2014,Curfew,1
+Cathedral Park,271070,2014,Disorderly Conduct,36
+Cathedral Park,271070,2014,Drugs,37
+Cathedral Park,271070,2014,DUII,24
+Cathedral Park,271070,2014,Embezzlement,1
+Cathedral Park,271070,2014,Forgery,17
+Cathedral Park,271070,2014,Fraud,24
+Cathedral Park,271070,2014,Gambling,
+Cathedral Park,271070,2014,Homicide,
+Cathedral Park,271070,2014,Kidnap,
+Cathedral Park,271070,2014,Larceny,424
+Cathedral Park,271070,2014,Liquor Laws,33
+Cathedral Park,271070,2014,Motor Vehicle Theft,25
+Cathedral Park,271070,2014,Offenses Against Family,
+Cathedral Park,271070,2014,Prostitution,1
+Cathedral Park,271070,2014,Rape,
+Cathedral Park,271070,2014,Robbery,9
+Cathedral Park,271070,2014,Runaway,1
+Cathedral Park,271070,2014,Sex Offenses,1
+Cathedral Park,271070,2014,Stolen Property,
+Cathedral Park,271070,2014,Trespass,25
+Cathedral Park,271070,2014,Vandalism,80
+Cathedral Park,271070,2014,Weapons,4
+Centennial,271071,2004,Aggravated Assault,11
+Centennial,271071,2004,Arson,1
+Centennial,271071,2004,"Assault, Simple",21
+Centennial,271071,2004,Burglary,55
+Centennial,271071,2004,Curfew,1
+Centennial,271071,2004,Disorderly Conduct,5
+Centennial,271071,2004,Drugs,8
+Centennial,271071,2004,DUII,10
+Centennial,271071,2004,Embezzlement,
+Centennial,271071,2004,Forgery,12
+Centennial,271071,2004,Fraud,19
+Centennial,271071,2004,Gambling,
+Centennial,271071,2004,Homicide,
+Centennial,271071,2004,Kidnap,
+Centennial,271071,2004,Larceny,138
+Centennial,271071,2004,Liquor Laws,
+Centennial,271071,2004,Motor Vehicle Theft,45
+Centennial,271071,2004,Offenses Against Family,
+Centennial,271071,2004,Prostitution,
+Centennial,271071,2004,Rape,
+Centennial,271071,2004,Robbery,6
+Centennial,271071,2004,Runaway,
+Centennial,271071,2004,Sex Offenses,2
+Centennial,271071,2004,Stolen Property,
+Centennial,271071,2004,Trespass,12
+Centennial,271071,2004,Vandalism,34
+Centennial,271071,2004,Weapons,2
+Centennial,271071,2005,Aggravated Assault,46
+Centennial,271071,2005,Arson,
+Centennial,271071,2005,"Assault, Simple",71
+Centennial,271071,2005,Burglary,215
+Centennial,271071,2005,Curfew,1
+Centennial,271071,2005,Disorderly Conduct,61
+Centennial,271071,2005,Drugs,65
+Centennial,271071,2005,DUII,51
+Centennial,271071,2005,Embezzlement,5
+Centennial,271071,2005,Forgery,90
+Centennial,271071,2005,Fraud,81
+Centennial,271071,2005,Gambling,
+Centennial,271071,2005,Homicide,
+Centennial,271071,2005,Kidnap,3
+Centennial,271071,2005,Larceny,1024
+Centennial,271071,2005,Liquor Laws,2
+Centennial,271071,2005,Motor Vehicle Theft,281
+Centennial,271071,2005,Offenses Against Family,
+Centennial,271071,2005,Prostitution,1
+Centennial,271071,2005,Rape,3
+Centennial,271071,2005,Robbery,37
+Centennial,271071,2005,Runaway,
+Centennial,271071,2005,Sex Offenses,4
+Centennial,271071,2005,Stolen Property,4
+Centennial,271071,2005,Trespass,63
+Centennial,271071,2005,Vandalism,200
+Centennial,271071,2005,Weapons,18
+Centennial,271071,2006,Aggravated Assault,57
+Centennial,271071,2006,Arson,2
+Centennial,271071,2006,"Assault, Simple",108
+Centennial,271071,2006,Burglary,175
+Centennial,271071,2006,Curfew,5
+Centennial,271071,2006,Disorderly Conduct,52
+Centennial,271071,2006,Drugs,61
+Centennial,271071,2006,DUII,73
+Centennial,271071,2006,Embezzlement,2
+Centennial,271071,2006,Forgery,63
+Centennial,271071,2006,Fraud,97
+Centennial,271071,2006,Gambling,
+Centennial,271071,2006,Homicide,2
+Centennial,271071,2006,Kidnap,3
+Centennial,271071,2006,Larceny,634
+Centennial,271071,2006,Liquor Laws,8
+Centennial,271071,2006,Motor Vehicle Theft,196
+Centennial,271071,2006,Offenses Against Family,
+Centennial,271071,2006,Prostitution,1
+Centennial,271071,2006,Rape,1
+Centennial,271071,2006,Robbery,31
+Centennial,271071,2006,Runaway,
+Centennial,271071,2006,Sex Offenses,2
+Centennial,271071,2006,Stolen Property,6
+Centennial,271071,2006,Trespass,63
+Centennial,271071,2006,Vandalism,241
+Centennial,271071,2006,Weapons,15
+Centennial,271071,2007,Aggravated Assault,57
+Centennial,271071,2007,Arson,3
+Centennial,271071,2007,"Assault, Simple",100
+Centennial,271071,2007,Burglary,181
+Centennial,271071,2007,Curfew,7
+Centennial,271071,2007,Disorderly Conduct,61
+Centennial,271071,2007,Drugs,51
+Centennial,271071,2007,DUII,59
+Centennial,271071,2007,Embezzlement,7
+Centennial,271071,2007,Forgery,51
+Centennial,271071,2007,Fraud,87
+Centennial,271071,2007,Gambling,
+Centennial,271071,2007,Homicide,
+Centennial,271071,2007,Kidnap,1
+Centennial,271071,2007,Larceny,749
+Centennial,271071,2007,Liquor Laws,12
+Centennial,271071,2007,Motor Vehicle Theft,186
+Centennial,271071,2007,Offenses Against Family,
+Centennial,271071,2007,Prostitution,1
+Centennial,271071,2007,Rape,3
+Centennial,271071,2007,Robbery,33
+Centennial,271071,2007,Runaway,
+Centennial,271071,2007,Sex Offenses,4
+Centennial,271071,2007,Stolen Property,3
+Centennial,271071,2007,Trespass,53
+Centennial,271071,2007,Vandalism,279
+Centennial,271071,2007,Weapons,5
+Centennial,271071,2008,Aggravated Assault,60
+Centennial,271071,2008,Arson,1
+Centennial,271071,2008,"Assault, Simple",98
+Centennial,271071,2008,Burglary,197
+Centennial,271071,2008,Curfew,5
+Centennial,271071,2008,Disorderly Conduct,69
+Centennial,271071,2008,Drugs,63
+Centennial,271071,2008,DUII,66
+Centennial,271071,2008,Embezzlement,8
+Centennial,271071,2008,Forgery,55
+Centennial,271071,2008,Fraud,65
+Centennial,271071,2008,Gambling,
+Centennial,271071,2008,Homicide,5
+Centennial,271071,2008,Kidnap,2
+Centennial,271071,2008,Larceny,682
+Centennial,271071,2008,Liquor Laws,24
+Centennial,271071,2008,Motor Vehicle Theft,127
+Centennial,271071,2008,Offenses Against Family,
+Centennial,271071,2008,Prostitution,1
+Centennial,271071,2008,Rape,2
+Centennial,271071,2008,Robbery,46
+Centennial,271071,2008,Runaway,1
+Centennial,271071,2008,Sex Offenses,3
+Centennial,271071,2008,Stolen Property,3
+Centennial,271071,2008,Trespass,54
+Centennial,271071,2008,Vandalism,233
+Centennial,271071,2008,Weapons,17
+Centennial,271071,2009,Aggravated Assault,44
+Centennial,271071,2009,Arson,1
+Centennial,271071,2009,"Assault, Simple",93
+Centennial,271071,2009,Burglary,163
+Centennial,271071,2009,Curfew,4
+Centennial,271071,2009,Disorderly Conduct,78
+Centennial,271071,2009,Drugs,67
+Centennial,271071,2009,DUII,53
+Centennial,271071,2009,Embezzlement,2
+Centennial,271071,2009,Forgery,44
+Centennial,271071,2009,Fraud,58
+Centennial,271071,2009,Gambling,
+Centennial,271071,2009,Homicide,
+Centennial,271071,2009,Kidnap,
+Centennial,271071,2009,Larceny,604
+Centennial,271071,2009,Liquor Laws,20
+Centennial,271071,2009,Motor Vehicle Theft,141
+Centennial,271071,2009,Offenses Against Family,
+Centennial,271071,2009,Prostitution,2
+Centennial,271071,2009,Rape,
+Centennial,271071,2009,Robbery,44
+Centennial,271071,2009,Runaway,
+Centennial,271071,2009,Sex Offenses,1
+Centennial,271071,2009,Stolen Property,3
+Centennial,271071,2009,Trespass,59
+Centennial,271071,2009,Vandalism,213
+Centennial,271071,2009,Weapons,22
+Centennial,271071,2010,Aggravated Assault,34
+Centennial,271071,2010,Arson,
+Centennial,271071,2010,"Assault, Simple",74
+Centennial,271071,2010,Burglary,176
+Centennial,271071,2010,Curfew,4
+Centennial,271071,2010,Disorderly Conduct,66
+Centennial,271071,2010,Drugs,93
+Centennial,271071,2010,DUII,46
+Centennial,271071,2010,Embezzlement,5
+Centennial,271071,2010,Forgery,60
+Centennial,271071,2010,Fraud,64
+Centennial,271071,2010,Gambling,
+Centennial,271071,2010,Homicide,
+Centennial,271071,2010,Kidnap,1
+Centennial,271071,2010,Larceny,581
+Centennial,271071,2010,Liquor Laws,11
+Centennial,271071,2010,Motor Vehicle Theft,165
+Centennial,271071,2010,Offenses Against Family,
+Centennial,271071,2010,Prostitution,2
+Centennial,271071,2010,Rape,2
+Centennial,271071,2010,Robbery,44
+Centennial,271071,2010,Runaway,3
+Centennial,271071,2010,Sex Offenses,
+Centennial,271071,2010,Stolen Property,6
+Centennial,271071,2010,Trespass,55
+Centennial,271071,2010,Vandalism,193
+Centennial,271071,2010,Weapons,15
+Centennial,271071,2011,Aggravated Assault,67
+Centennial,271071,2011,Arson,
+Centennial,271071,2011,"Assault, Simple",73
+Centennial,271071,2011,Burglary,162
+Centennial,271071,2011,Curfew,2
+Centennial,271071,2011,Disorderly Conduct,101
+Centennial,271071,2011,Drugs,67
+Centennial,271071,2011,DUII,52
+Centennial,271071,2011,Embezzlement,
+Centennial,271071,2011,Forgery,93
+Centennial,271071,2011,Fraud,61
+Centennial,271071,2011,Gambling,
+Centennial,271071,2011,Homicide,
+Centennial,271071,2011,Kidnap,
+Centennial,271071,2011,Larceny,569
+Centennial,271071,2011,Liquor Laws,7
+Centennial,271071,2011,Motor Vehicle Theft,150
+Centennial,271071,2011,Offenses Against Family,
+Centennial,271071,2011,Prostitution,1
+Centennial,271071,2011,Rape,1
+Centennial,271071,2011,Robbery,49
+Centennial,271071,2011,Runaway,1
+Centennial,271071,2011,Sex Offenses,1
+Centennial,271071,2011,Stolen Property,
+Centennial,271071,2011,Trespass,70
+Centennial,271071,2011,Vandalism,176
+Centennial,271071,2011,Weapons,21
+Centennial,271071,2012,Aggravated Assault,55
+Centennial,271071,2012,Arson,
+Centennial,271071,2012,"Assault, Simple",89
+Centennial,271071,2012,Burglary,185
+Centennial,271071,2012,Curfew,
+Centennial,271071,2012,Disorderly Conduct,99
+Centennial,271071,2012,Drugs,112
+Centennial,271071,2012,DUII,48
+Centennial,271071,2012,Embezzlement,2
+Centennial,271071,2012,Forgery,59
+Centennial,271071,2012,Fraud,62
+Centennial,271071,2012,Gambling,
+Centennial,271071,2012,Homicide,
+Centennial,271071,2012,Kidnap,1
+Centennial,271071,2012,Larceny,589
+Centennial,271071,2012,Liquor Laws,20
+Centennial,271071,2012,Motor Vehicle Theft,156
+Centennial,271071,2012,Offenses Against Family,
+Centennial,271071,2012,Prostitution,1
+Centennial,271071,2012,Rape,
+Centennial,271071,2012,Robbery,42
+Centennial,271071,2012,Runaway,
+Centennial,271071,2012,Sex Offenses,1
+Centennial,271071,2012,Stolen Property,4
+Centennial,271071,2012,Trespass,74
+Centennial,271071,2012,Vandalism,142
+Centennial,271071,2012,Weapons,29
+Centennial,271071,2013,Aggravated Assault,51
+Centennial,271071,2013,Arson,1
+Centennial,271071,2013,"Assault, Simple",95
+Centennial,271071,2013,Burglary,160
+Centennial,271071,2013,Curfew,3
+Centennial,271071,2013,Disorderly Conduct,78
+Centennial,271071,2013,Drugs,98
+Centennial,271071,2013,DUII,36
+Centennial,271071,2013,Embezzlement,4
+Centennial,271071,2013,Forgery,67
+Centennial,271071,2013,Fraud,46
+Centennial,271071,2013,Gambling,
+Centennial,271071,2013,Homicide,
+Centennial,271071,2013,Kidnap,1
+Centennial,271071,2013,Larceny,641
+Centennial,271071,2013,Liquor Laws,20
+Centennial,271071,2013,Motor Vehicle Theft,124
+Centennial,271071,2013,Offenses Against Family,
+Centennial,271071,2013,Prostitution,
+Centennial,271071,2013,Rape,
+Centennial,271071,2013,Robbery,42
+Centennial,271071,2013,Runaway,
+Centennial,271071,2013,Sex Offenses,
+Centennial,271071,2013,Stolen Property,2
+Centennial,271071,2013,Trespass,36
+Centennial,271071,2013,Vandalism,119
+Centennial,271071,2013,Weapons,11
+Centennial,271071,2014,Aggravated Assault,56
+Centennial,271071,2014,Arson,1
+Centennial,271071,2014,"Assault, Simple",76
+Centennial,271071,2014,Burglary,137
+Centennial,271071,2014,Curfew,
+Centennial,271071,2014,Disorderly Conduct,73
+Centennial,271071,2014,Drugs,68
+Centennial,271071,2014,DUII,42
+Centennial,271071,2014,Embezzlement,4
+Centennial,271071,2014,Forgery,25
+Centennial,271071,2014,Fraud,56
+Centennial,271071,2014,Gambling,
+Centennial,271071,2014,Homicide,2
+Centennial,271071,2014,Kidnap,
+Centennial,271071,2014,Larceny,584
+Centennial,271071,2014,Liquor Laws,5
+Centennial,271071,2014,Motor Vehicle Theft,185
+Centennial,271071,2014,Offenses Against Family,1
+Centennial,271071,2014,Prostitution,1
+Centennial,271071,2014,Rape,
+Centennial,271071,2014,Robbery,35
+Centennial,271071,2014,Runaway,
+Centennial,271071,2014,Sex Offenses,
+Centennial,271071,2014,Stolen Property,4
+Centennial,271071,2014,Trespass,55
+Centennial,271071,2014,Vandalism,138
+Centennial,271071,2014,Weapons,19
+Center,271072,2004,Aggravated Assault,
+Center,271072,2004,Arson,1
+Center,271072,2004,"Assault, Simple",7
+Center,271072,2004,Burglary,35
+Center,271072,2004,Curfew,
+Center,271072,2004,Disorderly Conduct,5
+Center,271072,2004,Drugs,1
+Center,271072,2004,DUII,11
+Center,271072,2004,Embezzlement,1
+Center,271072,2004,Forgery,1
+Center,271072,2004,Fraud,12
+Center,271072,2004,Gambling,
+Center,271072,2004,Homicide,
+Center,271072,2004,Kidnap,
+Center,271072,2004,Larceny,104
+Center,271072,2004,Liquor Laws,5
+Center,271072,2004,Motor Vehicle Theft,18
+Center,271072,2004,Offenses Against Family,
+Center,271072,2004,Prostitution,
+Center,271072,2004,Rape,
+Center,271072,2004,Robbery,
+Center,271072,2004,Runaway,
+Center,271072,2004,Sex Offenses,
+Center,271072,2004,Stolen Property,
+Center,271072,2004,Trespass,6
+Center,271072,2004,Vandalism,19
+Center,271072,2004,Weapons,
+Center,271072,2005,Aggravated Assault,20
+Center,271072,2005,Arson,
+Center,271072,2005,"Assault, Simple",22
+Center,271072,2005,Burglary,104
+Center,271072,2005,Curfew,
+Center,271072,2005,Disorderly Conduct,27
+Center,271072,2005,Drugs,23
+Center,271072,2005,DUII,56
+Center,271072,2005,Embezzlement,4
+Center,271072,2005,Forgery,21
+Center,271072,2005,Fraud,52
+Center,271072,2005,Gambling,
+Center,271072,2005,Homicide,
+Center,271072,2005,Kidnap,
+Center,271072,2005,Larceny,312
+Center,271072,2005,Liquor Laws,14
+Center,271072,2005,Motor Vehicle Theft,106
+Center,271072,2005,Offenses Against Family,
+Center,271072,2005,Prostitution,1
+Center,271072,2005,Rape,1
+Center,271072,2005,Robbery,11
+Center,271072,2005,Runaway,1
+Center,271072,2005,Sex Offenses,
+Center,271072,2005,Stolen Property,
+Center,271072,2005,Trespass,34
+Center,271072,2005,Vandalism,87
+Center,271072,2005,Weapons,3
+Center,271072,2006,Aggravated Assault,8
+Center,271072,2006,Arson,
+Center,271072,2006,"Assault, Simple",26
+Center,271072,2006,Burglary,72
+Center,271072,2006,Curfew,1
+Center,271072,2006,Disorderly Conduct,23
+Center,271072,2006,Drugs,27
+Center,271072,2006,DUII,71
+Center,271072,2006,Embezzlement,3
+Center,271072,2006,Forgery,13
+Center,271072,2006,Fraud,32
+Center,271072,2006,Gambling,
+Center,271072,2006,Homicide,
+Center,271072,2006,Kidnap,
+Center,271072,2006,Larceny,182
+Center,271072,2006,Liquor Laws,21
+Center,271072,2006,Motor Vehicle Theft,44
+Center,271072,2006,Offenses Against Family,
+Center,271072,2006,Prostitution,
+Center,271072,2006,Rape,1
+Center,271072,2006,Robbery,13
+Center,271072,2006,Runaway,
+Center,271072,2006,Sex Offenses,
+Center,271072,2006,Stolen Property,1
+Center,271072,2006,Trespass,33
+Center,271072,2006,Vandalism,97
+Center,271072,2006,Weapons,4
+Center,271072,2007,Aggravated Assault,18
+Center,271072,2007,Arson,
+Center,271072,2007,"Assault, Simple",12
+Center,271072,2007,Burglary,39
+Center,271072,2007,Curfew,
+Center,271072,2007,Disorderly Conduct,22
+Center,271072,2007,Drugs,25
+Center,271072,2007,DUII,31
+Center,271072,2007,Embezzlement,3
+Center,271072,2007,Forgery,9
+Center,271072,2007,Fraud,36
+Center,271072,2007,Gambling,
+Center,271072,2007,Homicide,
+Center,271072,2007,Kidnap,
+Center,271072,2007,Larceny,197
+Center,271072,2007,Liquor Laws,20
+Center,271072,2007,Motor Vehicle Theft,66
+Center,271072,2007,Offenses Against Family,
+Center,271072,2007,Prostitution,
+Center,271072,2007,Rape,
+Center,271072,2007,Robbery,15
+Center,271072,2007,Runaway,
+Center,271072,2007,Sex Offenses,2
+Center,271072,2007,Stolen Property,
+Center,271072,2007,Trespass,41
+Center,271072,2007,Vandalism,70
+Center,271072,2007,Weapons,1
+Center,271072,2008,Aggravated Assault,11
+Center,271072,2008,Arson,
+Center,271072,2008,"Assault, Simple",20
+Center,271072,2008,Burglary,59
+Center,271072,2008,Curfew,
+Center,271072,2008,Disorderly Conduct,25
+Center,271072,2008,Drugs,15
+Center,271072,2008,DUII,29
+Center,271072,2008,Embezzlement,5
+Center,271072,2008,Forgery,10
+Center,271072,2008,Fraud,34
+Center,271072,2008,Gambling,
+Center,271072,2008,Homicide,1
+Center,271072,2008,Kidnap,
+Center,271072,2008,Larceny,189
+Center,271072,2008,Liquor Laws,7
+Center,271072,2008,Motor Vehicle Theft,40
+Center,271072,2008,Offenses Against Family,
+Center,271072,2008,Prostitution,1
+Center,271072,2008,Rape,
+Center,271072,2008,Robbery,7
+Center,271072,2008,Runaway,2
+Center,271072,2008,Sex Offenses,
+Center,271072,2008,Stolen Property,1
+Center,271072,2008,Trespass,24
+Center,271072,2008,Vandalism,53
+Center,271072,2008,Weapons,1
+Center,271072,2009,Aggravated Assault,2
+Center,271072,2009,Arson,2
+Center,271072,2009,"Assault, Simple",18
+Center,271072,2009,Burglary,40
+Center,271072,2009,Curfew,
+Center,271072,2009,Disorderly Conduct,21
+Center,271072,2009,Drugs,19
+Center,271072,2009,DUII,33
+Center,271072,2009,Embezzlement,2
+Center,271072,2009,Forgery,19
+Center,271072,2009,Fraud,25
+Center,271072,2009,Gambling,
+Center,271072,2009,Homicide,
+Center,271072,2009,Kidnap,
+Center,271072,2009,Larceny,230
+Center,271072,2009,Liquor Laws,13
+Center,271072,2009,Motor Vehicle Theft,30
+Center,271072,2009,Offenses Against Family,
+Center,271072,2009,Prostitution,1
+Center,271072,2009,Rape,
+Center,271072,2009,Robbery,6
+Center,271072,2009,Runaway,
+Center,271072,2009,Sex Offenses,1
+Center,271072,2009,Stolen Property,1
+Center,271072,2009,Trespass,25
+Center,271072,2009,Vandalism,48
+Center,271072,2009,Weapons,3
+Center,271072,2010,Aggravated Assault,9
+Center,271072,2010,Arson,1
+Center,271072,2010,"Assault, Simple",20
+Center,271072,2010,Burglary,85
+Center,271072,2010,Curfew,
+Center,271072,2010,Disorderly Conduct,24
+Center,271072,2010,Drugs,17
+Center,271072,2010,DUII,23
+Center,271072,2010,Embezzlement,1
+Center,271072,2010,Forgery,6
+Center,271072,2010,Fraud,16
+Center,271072,2010,Gambling,
+Center,271072,2010,Homicide,
+Center,271072,2010,Kidnap,
+Center,271072,2010,Larceny,210
+Center,271072,2010,Liquor Laws,10
+Center,271072,2010,Motor Vehicle Theft,31
+Center,271072,2010,Offenses Against Family,
+Center,271072,2010,Prostitution,
+Center,271072,2010,Rape,1
+Center,271072,2010,Robbery,10
+Center,271072,2010,Runaway,
+Center,271072,2010,Sex Offenses,2
+Center,271072,2010,Stolen Property,
+Center,271072,2010,Trespass,24
+Center,271072,2010,Vandalism,51
+Center,271072,2010,Weapons,1
+Center,271072,2011,Aggravated Assault,5
+Center,271072,2011,Arson,
+Center,271072,2011,"Assault, Simple",16
+Center,271072,2011,Burglary,61
+Center,271072,2011,Curfew,
+Center,271072,2011,Disorderly Conduct,28
+Center,271072,2011,Drugs,9
+Center,271072,2011,DUII,30
+Center,271072,2011,Embezzlement,1
+Center,271072,2011,Forgery,15
+Center,271072,2011,Fraud,20
+Center,271072,2011,Gambling,
+Center,271072,2011,Homicide,
+Center,271072,2011,Kidnap,
+Center,271072,2011,Larceny,268
+Center,271072,2011,Liquor Laws,13
+Center,271072,2011,Motor Vehicle Theft,40
+Center,271072,2011,Offenses Against Family,
+Center,271072,2011,Prostitution,
+Center,271072,2011,Rape,
+Center,271072,2011,Robbery,7
+Center,271072,2011,Runaway,
+Center,271072,2011,Sex Offenses,1
+Center,271072,2011,Stolen Property,
+Center,271072,2011,Trespass,14
+Center,271072,2011,Vandalism,51
+Center,271072,2011,Weapons,
+Center,271072,2012,Aggravated Assault,16
+Center,271072,2012,Arson,
+Center,271072,2012,"Assault, Simple",17
+Center,271072,2012,Burglary,64
+Center,271072,2012,Curfew,
+Center,271072,2012,Disorderly Conduct,20
+Center,271072,2012,Drugs,5
+Center,271072,2012,DUII,38
+Center,271072,2012,Embezzlement,1
+Center,271072,2012,Forgery,14
+Center,271072,2012,Fraud,20
+Center,271072,2012,Gambling,
+Center,271072,2012,Homicide,
+Center,271072,2012,Kidnap,
+Center,271072,2012,Larceny,240
+Center,271072,2012,Liquor Laws,6
+Center,271072,2012,Motor Vehicle Theft,34
+Center,271072,2012,Offenses Against Family,
+Center,271072,2012,Prostitution,
+Center,271072,2012,Rape,
+Center,271072,2012,Robbery,2
+Center,271072,2012,Runaway,1
+Center,271072,2012,Sex Offenses,
+Center,271072,2012,Stolen Property,
+Center,271072,2012,Trespass,19
+Center,271072,2012,Vandalism,50
+Center,271072,2012,Weapons,1
+Center,271072,2013,Aggravated Assault,4
+Center,271072,2013,Arson,
+Center,271072,2013,"Assault, Simple",15
+Center,271072,2013,Burglary,57
+Center,271072,2013,Curfew,
+Center,271072,2013,Disorderly Conduct,13
+Center,271072,2013,Drugs,11
+Center,271072,2013,DUII,27
+Center,271072,2013,Embezzlement,7
+Center,271072,2013,Forgery,13
+Center,271072,2013,Fraud,17
+Center,271072,2013,Gambling,
+Center,271072,2013,Homicide,
+Center,271072,2013,Kidnap,
+Center,271072,2013,Larceny,196
+Center,271072,2013,Liquor Laws,5
+Center,271072,2013,Motor Vehicle Theft,33
+Center,271072,2013,Offenses Against Family,
+Center,271072,2013,Prostitution,
+Center,271072,2013,Rape,
+Center,271072,2013,Robbery,2
+Center,271072,2013,Runaway,
+Center,271072,2013,Sex Offenses,1
+Center,271072,2013,Stolen Property,1
+Center,271072,2013,Trespass,19
+Center,271072,2013,Vandalism,100
+Center,271072,2013,Weapons,5
+Center,271072,2014,Aggravated Assault,9
+Center,271072,2014,Arson,
+Center,271072,2014,"Assault, Simple",19
+Center,271072,2014,Burglary,55
+Center,271072,2014,Curfew,
+Center,271072,2014,Disorderly Conduct,19
+Center,271072,2014,Drugs,9
+Center,271072,2014,DUII,23
+Center,271072,2014,Embezzlement,2
+Center,271072,2014,Forgery,1
+Center,271072,2014,Fraud,28
+Center,271072,2014,Gambling,
+Center,271072,2014,Homicide,
+Center,271072,2014,Kidnap,
+Center,271072,2014,Larceny,231
+Center,271072,2014,Liquor Laws,6
+Center,271072,2014,Motor Vehicle Theft,37
+Center,271072,2014,Offenses Against Family,
+Center,271072,2014,Prostitution,
+Center,271072,2014,Rape,1
+Center,271072,2014,Robbery,4
+Center,271072,2014,Runaway,
+Center,271072,2014,Sex Offenses,
+Center,271072,2014,Stolen Property,
+Center,271072,2014,Trespass,37
+Center,271072,2014,Vandalism,54
+Center,271072,2014,Weapons,
+Central Beaverton,273187,2004,Aggravated Assault,
+Central Beaverton,273187,2004,Arson,
+Central Beaverton,273187,2004,"Assault, Simple",
+Central Beaverton,273187,2004,Burglary,
+Central Beaverton,273187,2004,Curfew,
+Central Beaverton,273187,2004,Disorderly Conduct,
+Central Beaverton,273187,2004,Drugs,
+Central Beaverton,273187,2004,DUII,
+Central Beaverton,273187,2004,Embezzlement,
+Central Beaverton,273187,2004,Forgery,
+Central Beaverton,273187,2004,Fraud,
+Central Beaverton,273187,2004,Gambling,
+Central Beaverton,273187,2004,Homicide,
+Central Beaverton,273187,2004,Kidnap,
+Central Beaverton,273187,2004,Larceny,
+Central Beaverton,273187,2004,Liquor Laws,
+Central Beaverton,273187,2004,Motor Vehicle Theft,
+Central Beaverton,273187,2004,Offenses Against Family,
+Central Beaverton,273187,2004,Prostitution,
+Central Beaverton,273187,2004,Rape,
+Central Beaverton,273187,2004,Robbery,
+Central Beaverton,273187,2004,Runaway,
+Central Beaverton,273187,2004,Sex Offenses,
+Central Beaverton,273187,2004,Stolen Property,
+Central Beaverton,273187,2004,Trespass,
+Central Beaverton,273187,2004,Vandalism,
+Central Beaverton,273187,2004,Weapons,
+Central Beaverton,273187,2005,Aggravated Assault,
+Central Beaverton,273187,2005,Arson,
+Central Beaverton,273187,2005,"Assault, Simple",
+Central Beaverton,273187,2005,Burglary,
+Central Beaverton,273187,2005,Curfew,
+Central Beaverton,273187,2005,Disorderly Conduct,
+Central Beaverton,273187,2005,Drugs,
+Central Beaverton,273187,2005,DUII,
+Central Beaverton,273187,2005,Embezzlement,
+Central Beaverton,273187,2005,Forgery,
+Central Beaverton,273187,2005,Fraud,
+Central Beaverton,273187,2005,Gambling,
+Central Beaverton,273187,2005,Homicide,
+Central Beaverton,273187,2005,Kidnap,
+Central Beaverton,273187,2005,Larceny,
+Central Beaverton,273187,2005,Liquor Laws,1
+Central Beaverton,273187,2005,Motor Vehicle Theft,
+Central Beaverton,273187,2005,Offenses Against Family,
+Central Beaverton,273187,2005,Prostitution,
+Central Beaverton,273187,2005,Rape,
+Central Beaverton,273187,2005,Robbery,
+Central Beaverton,273187,2005,Runaway,
+Central Beaverton,273187,2005,Sex Offenses,
+Central Beaverton,273187,2005,Stolen Property,
+Central Beaverton,273187,2005,Trespass,
+Central Beaverton,273187,2005,Vandalism,
+Central Beaverton,273187,2005,Weapons,
+Central Beaverton,273187,2006,Aggravated Assault,
+Central Beaverton,273187,2006,Arson,
+Central Beaverton,273187,2006,"Assault, Simple",
+Central Beaverton,273187,2006,Burglary,
+Central Beaverton,273187,2006,Curfew,
+Central Beaverton,273187,2006,Disorderly Conduct,
+Central Beaverton,273187,2006,Drugs,
+Central Beaverton,273187,2006,DUII,
+Central Beaverton,273187,2006,Embezzlement,
+Central Beaverton,273187,2006,Forgery,
+Central Beaverton,273187,2006,Fraud,
+Central Beaverton,273187,2006,Gambling,
+Central Beaverton,273187,2006,Homicide,
+Central Beaverton,273187,2006,Kidnap,
+Central Beaverton,273187,2006,Larceny,
+Central Beaverton,273187,2006,Liquor Laws,
+Central Beaverton,273187,2006,Motor Vehicle Theft,
+Central Beaverton,273187,2006,Offenses Against Family,
+Central Beaverton,273187,2006,Prostitution,
+Central Beaverton,273187,2006,Rape,
+Central Beaverton,273187,2006,Robbery,
+Central Beaverton,273187,2006,Runaway,
+Central Beaverton,273187,2006,Sex Offenses,
+Central Beaverton,273187,2006,Stolen Property,
+Central Beaverton,273187,2006,Trespass,
+Central Beaverton,273187,2006,Vandalism,
+Central Beaverton,273187,2006,Weapons,
+Central Beaverton,273187,2007,Aggravated Assault,
+Central Beaverton,273187,2007,Arson,
+Central Beaverton,273187,2007,"Assault, Simple",
+Central Beaverton,273187,2007,Burglary,
+Central Beaverton,273187,2007,Curfew,
+Central Beaverton,273187,2007,Disorderly Conduct,
+Central Beaverton,273187,2007,Drugs,
+Central Beaverton,273187,2007,DUII,
+Central Beaverton,273187,2007,Embezzlement,
+Central Beaverton,273187,2007,Forgery,
+Central Beaverton,273187,2007,Fraud,
+Central Beaverton,273187,2007,Gambling,
+Central Beaverton,273187,2007,Homicide,
+Central Beaverton,273187,2007,Kidnap,
+Central Beaverton,273187,2007,Larceny,
+Central Beaverton,273187,2007,Liquor Laws,
+Central Beaverton,273187,2007,Motor Vehicle Theft,
+Central Beaverton,273187,2007,Offenses Against Family,
+Central Beaverton,273187,2007,Prostitution,
+Central Beaverton,273187,2007,Rape,
+Central Beaverton,273187,2007,Robbery,
+Central Beaverton,273187,2007,Runaway,
+Central Beaverton,273187,2007,Sex Offenses,
+Central Beaverton,273187,2007,Stolen Property,
+Central Beaverton,273187,2007,Trespass,
+Central Beaverton,273187,2007,Vandalism,
+Central Beaverton,273187,2007,Weapons,
+Central Beaverton,273187,2008,Aggravated Assault,
+Central Beaverton,273187,2008,Arson,
+Central Beaverton,273187,2008,"Assault, Simple",
+Central Beaverton,273187,2008,Burglary,
+Central Beaverton,273187,2008,Curfew,
+Central Beaverton,273187,2008,Disorderly Conduct,
+Central Beaverton,273187,2008,Drugs,
+Central Beaverton,273187,2008,DUII,
+Central Beaverton,273187,2008,Embezzlement,
+Central Beaverton,273187,2008,Forgery,
+Central Beaverton,273187,2008,Fraud,
+Central Beaverton,273187,2008,Gambling,
+Central Beaverton,273187,2008,Homicide,
+Central Beaverton,273187,2008,Kidnap,
+Central Beaverton,273187,2008,Larceny,
+Central Beaverton,273187,2008,Liquor Laws,1
+Central Beaverton,273187,2008,Motor Vehicle Theft,
+Central Beaverton,273187,2008,Offenses Against Family,
+Central Beaverton,273187,2008,Prostitution,
+Central Beaverton,273187,2008,Rape,
+Central Beaverton,273187,2008,Robbery,
+Central Beaverton,273187,2008,Runaway,
+Central Beaverton,273187,2008,Sex Offenses,
+Central Beaverton,273187,2008,Stolen Property,
+Central Beaverton,273187,2008,Trespass,
+Central Beaverton,273187,2008,Vandalism,
+Central Beaverton,273187,2008,Weapons,
+Central Beaverton,273187,2009,Aggravated Assault,
+Central Beaverton,273187,2009,Arson,
+Central Beaverton,273187,2009,"Assault, Simple",
+Central Beaverton,273187,2009,Burglary,
+Central Beaverton,273187,2009,Curfew,
+Central Beaverton,273187,2009,Disorderly Conduct,
+Central Beaverton,273187,2009,Drugs,
+Central Beaverton,273187,2009,DUII,
+Central Beaverton,273187,2009,Embezzlement,
+Central Beaverton,273187,2009,Forgery,
+Central Beaverton,273187,2009,Fraud,
+Central Beaverton,273187,2009,Gambling,
+Central Beaverton,273187,2009,Homicide,
+Central Beaverton,273187,2009,Kidnap,
+Central Beaverton,273187,2009,Larceny,
+Central Beaverton,273187,2009,Liquor Laws,
+Central Beaverton,273187,2009,Motor Vehicle Theft,
+Central Beaverton,273187,2009,Offenses Against Family,
+Central Beaverton,273187,2009,Prostitution,
+Central Beaverton,273187,2009,Rape,
+Central Beaverton,273187,2009,Robbery,
+Central Beaverton,273187,2009,Runaway,
+Central Beaverton,273187,2009,Sex Offenses,
+Central Beaverton,273187,2009,Stolen Property,
+Central Beaverton,273187,2009,Trespass,
+Central Beaverton,273187,2009,Vandalism,
+Central Beaverton,273187,2009,Weapons,
+Central Beaverton,273187,2010,Aggravated Assault,
+Central Beaverton,273187,2010,Arson,
+Central Beaverton,273187,2010,"Assault, Simple",
+Central Beaverton,273187,2010,Burglary,
+Central Beaverton,273187,2010,Curfew,
+Central Beaverton,273187,2010,Disorderly Conduct,
+Central Beaverton,273187,2010,Drugs,
+Central Beaverton,273187,2010,DUII,
+Central Beaverton,273187,2010,Embezzlement,
+Central Beaverton,273187,2010,Forgery,
+Central Beaverton,273187,2010,Fraud,
+Central Beaverton,273187,2010,Gambling,
+Central Beaverton,273187,2010,Homicide,
+Central Beaverton,273187,2010,Kidnap,
+Central Beaverton,273187,2010,Larceny,
+Central Beaverton,273187,2010,Liquor Laws,
+Central Beaverton,273187,2010,Motor Vehicle Theft,
+Central Beaverton,273187,2010,Offenses Against Family,
+Central Beaverton,273187,2010,Prostitution,
+Central Beaverton,273187,2010,Rape,
+Central Beaverton,273187,2010,Robbery,
+Central Beaverton,273187,2010,Runaway,
+Central Beaverton,273187,2010,Sex Offenses,
+Central Beaverton,273187,2010,Stolen Property,
+Central Beaverton,273187,2010,Trespass,
+Central Beaverton,273187,2010,Vandalism,
+Central Beaverton,273187,2010,Weapons,
+Central Beaverton,273187,2011,Aggravated Assault,
+Central Beaverton,273187,2011,Arson,
+Central Beaverton,273187,2011,"Assault, Simple",
+Central Beaverton,273187,2011,Burglary,
+Central Beaverton,273187,2011,Curfew,
+Central Beaverton,273187,2011,Disorderly Conduct,
+Central Beaverton,273187,2011,Drugs,
+Central Beaverton,273187,2011,DUII,
+Central Beaverton,273187,2011,Embezzlement,
+Central Beaverton,273187,2011,Forgery,
+Central Beaverton,273187,2011,Fraud,1
+Central Beaverton,273187,2011,Gambling,
+Central Beaverton,273187,2011,Homicide,
+Central Beaverton,273187,2011,Kidnap,
+Central Beaverton,273187,2011,Larceny,
+Central Beaverton,273187,2011,Liquor Laws,
+Central Beaverton,273187,2011,Motor Vehicle Theft,
+Central Beaverton,273187,2011,Offenses Against Family,
+Central Beaverton,273187,2011,Prostitution,
+Central Beaverton,273187,2011,Rape,
+Central Beaverton,273187,2011,Robbery,
+Central Beaverton,273187,2011,Runaway,
+Central Beaverton,273187,2011,Sex Offenses,
+Central Beaverton,273187,2011,Stolen Property,
+Central Beaverton,273187,2011,Trespass,
+Central Beaverton,273187,2011,Vandalism,
+Central Beaverton,273187,2011,Weapons,
+Central Beaverton,273187,2012,Aggravated Assault,
+Central Beaverton,273187,2012,Arson,
+Central Beaverton,273187,2012,"Assault, Simple",
+Central Beaverton,273187,2012,Burglary,
+Central Beaverton,273187,2012,Curfew,
+Central Beaverton,273187,2012,Disorderly Conduct,
+Central Beaverton,273187,2012,Drugs,
+Central Beaverton,273187,2012,DUII,
+Central Beaverton,273187,2012,Embezzlement,
+Central Beaverton,273187,2012,Forgery,4
+Central Beaverton,273187,2012,Fraud,3
+Central Beaverton,273187,2012,Gambling,
+Central Beaverton,273187,2012,Homicide,
+Central Beaverton,273187,2012,Kidnap,
+Central Beaverton,273187,2012,Larceny,
+Central Beaverton,273187,2012,Liquor Laws,
+Central Beaverton,273187,2012,Motor Vehicle Theft,
+Central Beaverton,273187,2012,Offenses Against Family,
+Central Beaverton,273187,2012,Prostitution,
+Central Beaverton,273187,2012,Rape,
+Central Beaverton,273187,2012,Robbery,
+Central Beaverton,273187,2012,Runaway,
+Central Beaverton,273187,2012,Sex Offenses,
+Central Beaverton,273187,2012,Stolen Property,
+Central Beaverton,273187,2012,Trespass,1
+Central Beaverton,273187,2012,Vandalism,
+Central Beaverton,273187,2012,Weapons,
+Central Beaverton,273187,2013,Aggravated Assault,
+Central Beaverton,273187,2013,Arson,
+Central Beaverton,273187,2013,"Assault, Simple",
+Central Beaverton,273187,2013,Burglary,
+Central Beaverton,273187,2013,Curfew,
+Central Beaverton,273187,2013,Disorderly Conduct,
+Central Beaverton,273187,2013,Drugs,
+Central Beaverton,273187,2013,DUII,
+Central Beaverton,273187,2013,Embezzlement,
+Central Beaverton,273187,2013,Forgery,5
+Central Beaverton,273187,2013,Fraud,
+Central Beaverton,273187,2013,Gambling,
+Central Beaverton,273187,2013,Homicide,
+Central Beaverton,273187,2013,Kidnap,
+Central Beaverton,273187,2013,Larceny,
+Central Beaverton,273187,2013,Liquor Laws,1
+Central Beaverton,273187,2013,Motor Vehicle Theft,
+Central Beaverton,273187,2013,Offenses Against Family,
+Central Beaverton,273187,2013,Prostitution,
+Central Beaverton,273187,2013,Rape,
+Central Beaverton,273187,2013,Robbery,
+Central Beaverton,273187,2013,Runaway,
+Central Beaverton,273187,2013,Sex Offenses,
+Central Beaverton,273187,2013,Stolen Property,
+Central Beaverton,273187,2013,Trespass,
+Central Beaverton,273187,2013,Vandalism,
+Central Beaverton,273187,2013,Weapons,
+Central Beaverton,273187,2014,Aggravated Assault,
+Central Beaverton,273187,2014,Arson,
+Central Beaverton,273187,2014,"Assault, Simple",
+Central Beaverton,273187,2014,Burglary,
+Central Beaverton,273187,2014,Curfew,
+Central Beaverton,273187,2014,Disorderly Conduct,
+Central Beaverton,273187,2014,Drugs,
+Central Beaverton,273187,2014,DUII,
+Central Beaverton,273187,2014,Embezzlement,
+Central Beaverton,273187,2014,Forgery,1
+Central Beaverton,273187,2014,Fraud,
+Central Beaverton,273187,2014,Gambling,
+Central Beaverton,273187,2014,Homicide,
+Central Beaverton,273187,2014,Kidnap,
+Central Beaverton,273187,2014,Larceny,
+Central Beaverton,273187,2014,Liquor Laws,
+Central Beaverton,273187,2014,Motor Vehicle Theft,
+Central Beaverton,273187,2014,Offenses Against Family,
+Central Beaverton,273187,2014,Prostitution,
+Central Beaverton,273187,2014,Rape,
+Central Beaverton,273187,2014,Robbery,
+Central Beaverton,273187,2014,Runaway,
+Central Beaverton,273187,2014,Sex Offenses,
+Central Beaverton,273187,2014,Stolen Property,
+Central Beaverton,273187,2014,Trespass,
+Central Beaverton,273187,2014,Vandalism,1
+Central Beaverton,273187,2014,Weapons,
+Concordia,271076,2004,Aggravated Assault,2
+Concordia,271076,2004,Arson,
+Concordia,271076,2004,"Assault, Simple",9
+Concordia,271076,2004,Burglary,31
+Concordia,271076,2004,Curfew,
+Concordia,271076,2004,Disorderly Conduct,3
+Concordia,271076,2004,Drugs,1
+Concordia,271076,2004,DUII,4
+Concordia,271076,2004,Embezzlement,
+Concordia,271076,2004,Forgery,1
+Concordia,271076,2004,Fraud,9
+Concordia,271076,2004,Gambling,
+Concordia,271076,2004,Homicide,
+Concordia,271076,2004,Kidnap,
+Concordia,271076,2004,Larceny,66
+Concordia,271076,2004,Liquor Laws,
+Concordia,271076,2004,Motor Vehicle Theft,14
+Concordia,271076,2004,Offenses Against Family,
+Concordia,271076,2004,Prostitution,
+Concordia,271076,2004,Rape,
+Concordia,271076,2004,Robbery,5
+Concordia,271076,2004,Runaway,
+Concordia,271076,2004,Sex Offenses,
+Concordia,271076,2004,Stolen Property,
+Concordia,271076,2004,Trespass,6
+Concordia,271076,2004,Vandalism,25
+Concordia,271076,2004,Weapons,
+Concordia,271076,2005,Aggravated Assault,19
+Concordia,271076,2005,Arson,
+Concordia,271076,2005,"Assault, Simple",22
+Concordia,271076,2005,Burglary,110
+Concordia,271076,2005,Curfew,2
+Concordia,271076,2005,Disorderly Conduct,17
+Concordia,271076,2005,Drugs,24
+Concordia,271076,2005,DUII,16
+Concordia,271076,2005,Embezzlement,1
+Concordia,271076,2005,Forgery,10
+Concordia,271076,2005,Fraud,34
+Concordia,271076,2005,Gambling,
+Concordia,271076,2005,Homicide,
+Concordia,271076,2005,Kidnap,
+Concordia,271076,2005,Larceny,296
+Concordia,271076,2005,Liquor Laws,1
+Concordia,271076,2005,Motor Vehicle Theft,43
+Concordia,271076,2005,Offenses Against Family,
+Concordia,271076,2005,Prostitution,
+Concordia,271076,2005,Rape,3
+Concordia,271076,2005,Robbery,13
+Concordia,271076,2005,Runaway,
+Concordia,271076,2005,Sex Offenses,1
+Concordia,271076,2005,Stolen Property,
+Concordia,271076,2005,Trespass,30
+Concordia,271076,2005,Vandalism,72
+Concordia,271076,2005,Weapons,5
+Concordia,271076,2006,Aggravated Assault,16
+Concordia,271076,2006,Arson,1
+Concordia,271076,2006,"Assault, Simple",12
+Concordia,271076,2006,Burglary,112
+Concordia,271076,2006,Curfew,2
+Concordia,271076,2006,Disorderly Conduct,19
+Concordia,271076,2006,Drugs,17
+Concordia,271076,2006,DUII,15
+Concordia,271076,2006,Embezzlement,1
+Concordia,271076,2006,Forgery,8
+Concordia,271076,2006,Fraud,26
+Concordia,271076,2006,Gambling,
+Concordia,271076,2006,Homicide,
+Concordia,271076,2006,Kidnap,
+Concordia,271076,2006,Larceny,237
+Concordia,271076,2006,Liquor Laws,3
+Concordia,271076,2006,Motor Vehicle Theft,35
+Concordia,271076,2006,Offenses Against Family,
+Concordia,271076,2006,Prostitution,
+Concordia,271076,2006,Rape,2
+Concordia,271076,2006,Robbery,10
+Concordia,271076,2006,Runaway,
+Concordia,271076,2006,Sex Offenses,
+Concordia,271076,2006,Stolen Property,
+Concordia,271076,2006,Trespass,18
+Concordia,271076,2006,Vandalism,123
+Concordia,271076,2006,Weapons,3
+Concordia,271076,2007,Aggravated Assault,17
+Concordia,271076,2007,Arson,1
+Concordia,271076,2007,"Assault, Simple",14
+Concordia,271076,2007,Burglary,85
+Concordia,271076,2007,Curfew,1
+Concordia,271076,2007,Disorderly Conduct,17
+Concordia,271076,2007,Drugs,20
+Concordia,271076,2007,DUII,21
+Concordia,271076,2007,Embezzlement,1
+Concordia,271076,2007,Forgery,2
+Concordia,271076,2007,Fraud,26
+Concordia,271076,2007,Gambling,
+Concordia,271076,2007,Homicide,
+Concordia,271076,2007,Kidnap,
+Concordia,271076,2007,Larceny,233
+Concordia,271076,2007,Liquor Laws,13
+Concordia,271076,2007,Motor Vehicle Theft,47
+Concordia,271076,2007,Offenses Against Family,
+Concordia,271076,2007,Prostitution,
+Concordia,271076,2007,Rape,1
+Concordia,271076,2007,Robbery,13
+Concordia,271076,2007,Runaway,1
+Concordia,271076,2007,Sex Offenses,
+Concordia,271076,2007,Stolen Property,
+Concordia,271076,2007,Trespass,14
+Concordia,271076,2007,Vandalism,126
+Concordia,271076,2007,Weapons,2
+Concordia,271076,2008,Aggravated Assault,11
+Concordia,271076,2008,Arson,
+Concordia,271076,2008,"Assault, Simple",22
+Concordia,271076,2008,Burglary,84
+Concordia,271076,2008,Curfew,
+Concordia,271076,2008,Disorderly Conduct,18
+Concordia,271076,2008,Drugs,7
+Concordia,271076,2008,DUII,21
+Concordia,271076,2008,Embezzlement,3
+Concordia,271076,2008,Forgery,2
+Concordia,271076,2008,Fraud,13
+Concordia,271076,2008,Gambling,
+Concordia,271076,2008,Homicide,
+Concordia,271076,2008,Kidnap,
+Concordia,271076,2008,Larceny,277
+Concordia,271076,2008,Liquor Laws,9
+Concordia,271076,2008,Motor Vehicle Theft,42
+Concordia,271076,2008,Offenses Against Family,
+Concordia,271076,2008,Prostitution,
+Concordia,271076,2008,Rape,
+Concordia,271076,2008,Robbery,6
+Concordia,271076,2008,Runaway,
+Concordia,271076,2008,Sex Offenses,
+Concordia,271076,2008,Stolen Property,
+Concordia,271076,2008,Trespass,13
+Concordia,271076,2008,Vandalism,128
+Concordia,271076,2008,Weapons,1
+Concordia,271076,2009,Aggravated Assault,16
+Concordia,271076,2009,Arson,1
+Concordia,271076,2009,"Assault, Simple",14
+Concordia,271076,2009,Burglary,61
+Concordia,271076,2009,Curfew,1
+Concordia,271076,2009,Disorderly Conduct,15
+Concordia,271076,2009,Drugs,4
+Concordia,271076,2009,DUII,25
+Concordia,271076,2009,Embezzlement,
+Concordia,271076,2009,Forgery,9
+Concordia,271076,2009,Fraud,22
+Concordia,271076,2009,Gambling,
+Concordia,271076,2009,Homicide,
+Concordia,271076,2009,Kidnap,
+Concordia,271076,2009,Larceny,184
+Concordia,271076,2009,Liquor Laws,4
+Concordia,271076,2009,Motor Vehicle Theft,42
+Concordia,271076,2009,Offenses Against Family,
+Concordia,271076,2009,Prostitution,
+Concordia,271076,2009,Rape,
+Concordia,271076,2009,Robbery,4
+Concordia,271076,2009,Runaway,1
+Concordia,271076,2009,Sex Offenses,1
+Concordia,271076,2009,Stolen Property,
+Concordia,271076,2009,Trespass,15
+Concordia,271076,2009,Vandalism,60
+Concordia,271076,2009,Weapons,1
+Concordia,271076,2010,Aggravated Assault,6
+Concordia,271076,2010,Arson,
+Concordia,271076,2010,"Assault, Simple",15
+Concordia,271076,2010,Burglary,73
+Concordia,271076,2010,Curfew,2
+Concordia,271076,2010,Disorderly Conduct,18
+Concordia,271076,2010,Drugs,8
+Concordia,271076,2010,DUII,9
+Concordia,271076,2010,Embezzlement,1
+Concordia,271076,2010,Forgery,3
+Concordia,271076,2010,Fraud,9
+Concordia,271076,2010,Gambling,
+Concordia,271076,2010,Homicide,1
+Concordia,271076,2010,Kidnap,
+Concordia,271076,2010,Larceny,158
+Concordia,271076,2010,Liquor Laws,2
+Concordia,271076,2010,Motor Vehicle Theft,28
+Concordia,271076,2010,Offenses Against Family,
+Concordia,271076,2010,Prostitution,1
+Concordia,271076,2010,Rape,1
+Concordia,271076,2010,Robbery,8
+Concordia,271076,2010,Runaway,
+Concordia,271076,2010,Sex Offenses,1
+Concordia,271076,2010,Stolen Property,
+Concordia,271076,2010,Trespass,15
+Concordia,271076,2010,Vandalism,68
+Concordia,271076,2010,Weapons,1
+Concordia,271076,2011,Aggravated Assault,9
+Concordia,271076,2011,Arson,3
+Concordia,271076,2011,"Assault, Simple",18
+Concordia,271076,2011,Burglary,38
+Concordia,271076,2011,Curfew,
+Concordia,271076,2011,Disorderly Conduct,18
+Concordia,271076,2011,Drugs,5
+Concordia,271076,2011,DUII,14
+Concordia,271076,2011,Embezzlement,1
+Concordia,271076,2011,Forgery,5
+Concordia,271076,2011,Fraud,11
+Concordia,271076,2011,Gambling,
+Concordia,271076,2011,Homicide,
+Concordia,271076,2011,Kidnap,
+Concordia,271076,2011,Larceny,178
+Concordia,271076,2011,Liquor Laws,4
+Concordia,271076,2011,Motor Vehicle Theft,32
+Concordia,271076,2011,Offenses Against Family,
+Concordia,271076,2011,Prostitution,
+Concordia,271076,2011,Rape,1
+Concordia,271076,2011,Robbery,6
+Concordia,271076,2011,Runaway,
+Concordia,271076,2011,Sex Offenses,1
+Concordia,271076,2011,Stolen Property,
+Concordia,271076,2011,Trespass,5
+Concordia,271076,2011,Vandalism,49
+Concordia,271076,2011,Weapons,3
+Concordia,271076,2012,Aggravated Assault,13
+Concordia,271076,2012,Arson,1
+Concordia,271076,2012,"Assault, Simple",16
+Concordia,271076,2012,Burglary,72
+Concordia,271076,2012,Curfew,
+Concordia,271076,2012,Disorderly Conduct,20
+Concordia,271076,2012,Drugs,5
+Concordia,271076,2012,DUII,17
+Concordia,271076,2012,Embezzlement,
+Concordia,271076,2012,Forgery,1
+Concordia,271076,2012,Fraud,12
+Concordia,271076,2012,Gambling,
+Concordia,271076,2012,Homicide,
+Concordia,271076,2012,Kidnap,
+Concordia,271076,2012,Larceny,189
+Concordia,271076,2012,Liquor Laws,2
+Concordia,271076,2012,Motor Vehicle Theft,31
+Concordia,271076,2012,Offenses Against Family,
+Concordia,271076,2012,Prostitution,
+Concordia,271076,2012,Rape,1
+Concordia,271076,2012,Robbery,7
+Concordia,271076,2012,Runaway,
+Concordia,271076,2012,Sex Offenses,
+Concordia,271076,2012,Stolen Property,
+Concordia,271076,2012,Trespass,18
+Concordia,271076,2012,Vandalism,33
+Concordia,271076,2012,Weapons,5
+Concordia,271076,2013,Aggravated Assault,14
+Concordia,271076,2013,Arson,
+Concordia,271076,2013,"Assault, Simple",6
+Concordia,271076,2013,Burglary,45
+Concordia,271076,2013,Curfew,
+Concordia,271076,2013,Disorderly Conduct,24
+Concordia,271076,2013,Drugs,7
+Concordia,271076,2013,DUII,18
+Concordia,271076,2013,Embezzlement,1
+Concordia,271076,2013,Forgery,4
+Concordia,271076,2013,Fraud,12
+Concordia,271076,2013,Gambling,
+Concordia,271076,2013,Homicide,
+Concordia,271076,2013,Kidnap,
+Concordia,271076,2013,Larceny,184
+Concordia,271076,2013,Liquor Laws,2
+Concordia,271076,2013,Motor Vehicle Theft,38
+Concordia,271076,2013,Offenses Against Family,
+Concordia,271076,2013,Prostitution,
+Concordia,271076,2013,Rape,
+Concordia,271076,2013,Robbery,5
+Concordia,271076,2013,Runaway,
+Concordia,271076,2013,Sex Offenses,
+Concordia,271076,2013,Stolen Property,
+Concordia,271076,2013,Trespass,16
+Concordia,271076,2013,Vandalism,52
+Concordia,271076,2013,Weapons,2
+Concordia,271076,2014,Aggravated Assault,3
+Concordia,271076,2014,Arson,
+Concordia,271076,2014,"Assault, Simple",15
+Concordia,271076,2014,Burglary,67
+Concordia,271076,2014,Curfew,
+Concordia,271076,2014,Disorderly Conduct,17
+Concordia,271076,2014,Drugs,11
+Concordia,271076,2014,DUII,11
+Concordia,271076,2014,Embezzlement,1
+Concordia,271076,2014,Forgery,6
+Concordia,271076,2014,Fraud,15
+Concordia,271076,2014,Gambling,
+Concordia,271076,2014,Homicide,
+Concordia,271076,2014,Kidnap,
+Concordia,271076,2014,Larceny,200
+Concordia,271076,2014,Liquor Laws,3
+Concordia,271076,2014,Motor Vehicle Theft,39
+Concordia,271076,2014,Offenses Against Family,
+Concordia,271076,2014,Prostitution,1
+Concordia,271076,2014,Rape,
+Concordia,271076,2014,Robbery,6
+Concordia,271076,2014,Runaway,
+Concordia,271076,2014,Sex Offenses,
+Concordia,271076,2014,Stolen Property,
+Concordia,271076,2014,Trespass,10
+Concordia,271076,2014,Vandalism,54
+Concordia,271076,2014,Weapons,2
+Corbett-Terwilliger-Lair Hill,273346,2004,Aggravated Assault,1
+Corbett-Terwilliger-Lair Hill,273346,2004,Arson,
+Corbett-Terwilliger-Lair Hill,273346,2004,"Assault, Simple",2
+Corbett-Terwilliger-Lair Hill,273346,2004,Burglary,16
+Corbett-Terwilliger-Lair Hill,273346,2004,Curfew,
+Corbett-Terwilliger-Lair Hill,273346,2004,Disorderly Conduct,1
+Corbett-Terwilliger-Lair Hill,273346,2004,Drugs,5
+Corbett-Terwilliger-Lair Hill,273346,2004,DUII,4
+Corbett-Terwilliger-Lair Hill,273346,2004,Embezzlement,
+Corbett-Terwilliger-Lair Hill,273346,2004,Forgery,
+Corbett-Terwilliger-Lair Hill,273346,2004,Fraud,8
+Corbett-Terwilliger-Lair Hill,273346,2004,Gambling,
+Corbett-Terwilliger-Lair Hill,273346,2004,Homicide,
+Corbett-Terwilliger-Lair Hill,273346,2004,Kidnap,
+Corbett-Terwilliger-Lair Hill,273346,2004,Larceny,56
+Corbett-Terwilliger-Lair Hill,273346,2004,Liquor Laws,4
+Corbett-Terwilliger-Lair Hill,273346,2004,Motor Vehicle Theft,5
+Corbett-Terwilliger-Lair Hill,273346,2004,Offenses Against Family,
+Corbett-Terwilliger-Lair Hill,273346,2004,Prostitution,
+Corbett-Terwilliger-Lair Hill,273346,2004,Rape,
+Corbett-Terwilliger-Lair Hill,273346,2004,Robbery,
+Corbett-Terwilliger-Lair Hill,273346,2004,Runaway,
+Corbett-Terwilliger-Lair Hill,273346,2004,Sex Offenses,
+Corbett-Terwilliger-Lair Hill,273346,2004,Stolen Property,
+Corbett-Terwilliger-Lair Hill,273346,2004,Trespass,2
+Corbett-Terwilliger-Lair Hill,273346,2004,Vandalism,16
+Corbett-Terwilliger-Lair Hill,273346,2004,Weapons,
+Corbett-Terwilliger-Lair Hill,273346,2005,Aggravated Assault,4
+Corbett-Terwilliger-Lair Hill,273346,2005,Arson,3
+Corbett-Terwilliger-Lair Hill,273346,2005,"Assault, Simple",8
+Corbett-Terwilliger-Lair Hill,273346,2005,Burglary,90
+Corbett-Terwilliger-Lair Hill,273346,2005,Curfew,
+Corbett-Terwilliger-Lair Hill,273346,2005,Disorderly Conduct,10
+Corbett-Terwilliger-Lair Hill,273346,2005,Drugs,5
+Corbett-Terwilliger-Lair Hill,273346,2005,DUII,20
+Corbett-Terwilliger-Lair Hill,273346,2005,Embezzlement,3
+Corbett-Terwilliger-Lair Hill,273346,2005,Forgery,12
+Corbett-Terwilliger-Lair Hill,273346,2005,Fraud,24
+Corbett-Terwilliger-Lair Hill,273346,2005,Gambling,
+Corbett-Terwilliger-Lair Hill,273346,2005,Homicide,
+Corbett-Terwilliger-Lair Hill,273346,2005,Kidnap,
+Corbett-Terwilliger-Lair Hill,273346,2005,Larceny,217
+Corbett-Terwilliger-Lair Hill,273346,2005,Liquor Laws,9
+Corbett-Terwilliger-Lair Hill,273346,2005,Motor Vehicle Theft,38
+Corbett-Terwilliger-Lair Hill,273346,2005,Offenses Against Family,
+Corbett-Terwilliger-Lair Hill,273346,2005,Prostitution,
+Corbett-Terwilliger-Lair Hill,273346,2005,Rape,
+Corbett-Terwilliger-Lair Hill,273346,2005,Robbery,4
+Corbett-Terwilliger-Lair Hill,273346,2005,Runaway,
+Corbett-Terwilliger-Lair Hill,273346,2005,Sex Offenses,1
+Corbett-Terwilliger-Lair Hill,273346,2005,Stolen Property,1
+Corbett-Terwilliger-Lair Hill,273346,2005,Trespass,12
+Corbett-Terwilliger-Lair Hill,273346,2005,Vandalism,38
+Corbett-Terwilliger-Lair Hill,273346,2005,Weapons,3
+Corbett-Terwilliger-Lair Hill,273346,2006,Aggravated Assault,3
+Corbett-Terwilliger-Lair Hill,273346,2006,Arson,
+Corbett-Terwilliger-Lair Hill,273346,2006,"Assault, Simple",7
+Corbett-Terwilliger-Lair Hill,273346,2006,Burglary,54
+Corbett-Terwilliger-Lair Hill,273346,2006,Curfew,
+Corbett-Terwilliger-Lair Hill,273346,2006,Disorderly Conduct,12
+Corbett-Terwilliger-Lair Hill,273346,2006,Drugs,4
+Corbett-Terwilliger-Lair Hill,273346,2006,DUII,16
+Corbett-Terwilliger-Lair Hill,273346,2006,Embezzlement,1
+Corbett-Terwilliger-Lair Hill,273346,2006,Forgery,9
+Corbett-Terwilliger-Lair Hill,273346,2006,Fraud,20
+Corbett-Terwilliger-Lair Hill,273346,2006,Gambling,
+Corbett-Terwilliger-Lair Hill,273346,2006,Homicide,
+Corbett-Terwilliger-Lair Hill,273346,2006,Kidnap,
+Corbett-Terwilliger-Lair Hill,273346,2006,Larceny,209
+Corbett-Terwilliger-Lair Hill,273346,2006,Liquor Laws,9
+Corbett-Terwilliger-Lair Hill,273346,2006,Motor Vehicle Theft,21
+Corbett-Terwilliger-Lair Hill,273346,2006,Offenses Against Family,
+Corbett-Terwilliger-Lair Hill,273346,2006,Prostitution,
+Corbett-Terwilliger-Lair Hill,273346,2006,Rape,
+Corbett-Terwilliger-Lair Hill,273346,2006,Robbery,
+Corbett-Terwilliger-Lair Hill,273346,2006,Runaway,1
+Corbett-Terwilliger-Lair Hill,273346,2006,Sex Offenses,1
+Corbett-Terwilliger-Lair Hill,273346,2006,Stolen Property,1
+Corbett-Terwilliger-Lair Hill,273346,2006,Trespass,9
+Corbett-Terwilliger-Lair Hill,273346,2006,Vandalism,59
+Corbett-Terwilliger-Lair Hill,273346,2006,Weapons,
+Corbett-Terwilliger-Lair Hill,273346,2007,Aggravated Assault,9
+Corbett-Terwilliger-Lair Hill,273346,2007,Arson,1
+Corbett-Terwilliger-Lair Hill,273346,2007,"Assault, Simple",10
+Corbett-Terwilliger-Lair Hill,273346,2007,Burglary,41
+Corbett-Terwilliger-Lair Hill,273346,2007,Curfew,
+Corbett-Terwilliger-Lair Hill,273346,2007,Disorderly Conduct,12
+Corbett-Terwilliger-Lair Hill,273346,2007,Drugs,5
+Corbett-Terwilliger-Lair Hill,273346,2007,DUII,34
+Corbett-Terwilliger-Lair Hill,273346,2007,Embezzlement,2
+Corbett-Terwilliger-Lair Hill,273346,2007,Forgery,7
+Corbett-Terwilliger-Lair Hill,273346,2007,Fraud,15
+Corbett-Terwilliger-Lair Hill,273346,2007,Gambling,
+Corbett-Terwilliger-Lair Hill,273346,2007,Homicide,
+Corbett-Terwilliger-Lair Hill,273346,2007,Kidnap,
+Corbett-Terwilliger-Lair Hill,273346,2007,Larceny,162
+Corbett-Terwilliger-Lair Hill,273346,2007,Liquor Laws,3
+Corbett-Terwilliger-Lair Hill,273346,2007,Motor Vehicle Theft,25
+Corbett-Terwilliger-Lair Hill,273346,2007,Offenses Against Family,
+Corbett-Terwilliger-Lair Hill,273346,2007,Prostitution,
+Corbett-Terwilliger-Lair Hill,273346,2007,Rape,
+Corbett-Terwilliger-Lair Hill,273346,2007,Robbery,
+Corbett-Terwilliger-Lair Hill,273346,2007,Runaway,
+Corbett-Terwilliger-Lair Hill,273346,2007,Sex Offenses,
+Corbett-Terwilliger-Lair Hill,273346,2007,Stolen Property,
+Corbett-Terwilliger-Lair Hill,273346,2007,Trespass,8
+Corbett-Terwilliger-Lair Hill,273346,2007,Vandalism,95
+Corbett-Terwilliger-Lair Hill,273346,2007,Weapons,
+Corbett-Terwilliger-Lair Hill,273346,2008,Aggravated Assault,1
+Corbett-Terwilliger-Lair Hill,273346,2008,Arson,1
+Corbett-Terwilliger-Lair Hill,273346,2008,"Assault, Simple",12
+Corbett-Terwilliger-Lair Hill,273346,2008,Burglary,33
+Corbett-Terwilliger-Lair Hill,273346,2008,Curfew,
+Corbett-Terwilliger-Lair Hill,273346,2008,Disorderly Conduct,13
+Corbett-Terwilliger-Lair Hill,273346,2008,Drugs,5
+Corbett-Terwilliger-Lair Hill,273346,2008,DUII,24
+Corbett-Terwilliger-Lair Hill,273346,2008,Embezzlement,2
+Corbett-Terwilliger-Lair Hill,273346,2008,Forgery,5
+Corbett-Terwilliger-Lair Hill,273346,2008,Fraud,11
+Corbett-Terwilliger-Lair Hill,273346,2008,Gambling,
+Corbett-Terwilliger-Lair Hill,273346,2008,Homicide,
+Corbett-Terwilliger-Lair Hill,273346,2008,Kidnap,
+Corbett-Terwilliger-Lair Hill,273346,2008,Larceny,148
+Corbett-Terwilliger-Lair Hill,273346,2008,Liquor Laws,2
+Corbett-Terwilliger-Lair Hill,273346,2008,Motor Vehicle Theft,13
+Corbett-Terwilliger-Lair Hill,273346,2008,Offenses Against Family,
+Corbett-Terwilliger-Lair Hill,273346,2008,Prostitution,
+Corbett-Terwilliger-Lair Hill,273346,2008,Rape,
+Corbett-Terwilliger-Lair Hill,273346,2008,Robbery,1
+Corbett-Terwilliger-Lair Hill,273346,2008,Runaway,
+Corbett-Terwilliger-Lair Hill,273346,2008,Sex Offenses,
+Corbett-Terwilliger-Lair Hill,273346,2008,Stolen Property,
+Corbett-Terwilliger-Lair Hill,273346,2008,Trespass,10
+Corbett-Terwilliger-Lair Hill,273346,2008,Vandalism,51
+Corbett-Terwilliger-Lair Hill,273346,2008,Weapons,2
+Corbett-Terwilliger-Lair Hill,273346,2009,Aggravated Assault,4
+Corbett-Terwilliger-Lair Hill,273346,2009,Arson,
+Corbett-Terwilliger-Lair Hill,273346,2009,"Assault, Simple",10
+Corbett-Terwilliger-Lair Hill,273346,2009,Burglary,38
+Corbett-Terwilliger-Lair Hill,273346,2009,Curfew,1
+Corbett-Terwilliger-Lair Hill,273346,2009,Disorderly Conduct,12
+Corbett-Terwilliger-Lair Hill,273346,2009,Drugs,10
+Corbett-Terwilliger-Lair Hill,273346,2009,DUII,24
+Corbett-Terwilliger-Lair Hill,273346,2009,Embezzlement,3
+Corbett-Terwilliger-Lair Hill,273346,2009,Forgery,2
+Corbett-Terwilliger-Lair Hill,273346,2009,Fraud,14
+Corbett-Terwilliger-Lair Hill,273346,2009,Gambling,
+Corbett-Terwilliger-Lair Hill,273346,2009,Homicide,1
+Corbett-Terwilliger-Lair Hill,273346,2009,Kidnap,
+Corbett-Terwilliger-Lair Hill,273346,2009,Larceny,140
+Corbett-Terwilliger-Lair Hill,273346,2009,Liquor Laws,3
+Corbett-Terwilliger-Lair Hill,273346,2009,Motor Vehicle Theft,15
+Corbett-Terwilliger-Lair Hill,273346,2009,Offenses Against Family,
+Corbett-Terwilliger-Lair Hill,273346,2009,Prostitution,
+Corbett-Terwilliger-Lair Hill,273346,2009,Rape,
+Corbett-Terwilliger-Lair Hill,273346,2009,Robbery,2
+Corbett-Terwilliger-Lair Hill,273346,2009,Runaway,
+Corbett-Terwilliger-Lair Hill,273346,2009,Sex Offenses,
+Corbett-Terwilliger-Lair Hill,273346,2009,Stolen Property,
+Corbett-Terwilliger-Lair Hill,273346,2009,Trespass,11
+Corbett-Terwilliger-Lair Hill,273346,2009,Vandalism,56
+Corbett-Terwilliger-Lair Hill,273346,2009,Weapons,
+Corbett-Terwilliger-Lair Hill,273346,2010,Aggravated Assault,2
+Corbett-Terwilliger-Lair Hill,273346,2010,Arson,
+Corbett-Terwilliger-Lair Hill,273346,2010,"Assault, Simple",6
+Corbett-Terwilliger-Lair Hill,273346,2010,Burglary,31
+Corbett-Terwilliger-Lair Hill,273346,2010,Curfew,
+Corbett-Terwilliger-Lair Hill,273346,2010,Disorderly Conduct,12
+Corbett-Terwilliger-Lair Hill,273346,2010,Drugs,3
+Corbett-Terwilliger-Lair Hill,273346,2010,DUII,27
+Corbett-Terwilliger-Lair Hill,273346,2010,Embezzlement,4
+Corbett-Terwilliger-Lair Hill,273346,2010,Forgery,4
+Corbett-Terwilliger-Lair Hill,273346,2010,Fraud,12
+Corbett-Terwilliger-Lair Hill,273346,2010,Gambling,
+Corbett-Terwilliger-Lair Hill,273346,2010,Homicide,1
+Corbett-Terwilliger-Lair Hill,273346,2010,Kidnap,
+Corbett-Terwilliger-Lair Hill,273346,2010,Larceny,193
+Corbett-Terwilliger-Lair Hill,273346,2010,Liquor Laws,16
+Corbett-Terwilliger-Lair Hill,273346,2010,Motor Vehicle Theft,25
+Corbett-Terwilliger-Lair Hill,273346,2010,Offenses Against Family,
+Corbett-Terwilliger-Lair Hill,273346,2010,Prostitution,
+Corbett-Terwilliger-Lair Hill,273346,2010,Rape,
+Corbett-Terwilliger-Lair Hill,273346,2010,Robbery,
+Corbett-Terwilliger-Lair Hill,273346,2010,Runaway,
+Corbett-Terwilliger-Lair Hill,273346,2010,Sex Offenses,
+Corbett-Terwilliger-Lair Hill,273346,2010,Stolen Property,
+Corbett-Terwilliger-Lair Hill,273346,2010,Trespass,28
+Corbett-Terwilliger-Lair Hill,273346,2010,Vandalism,35
+Corbett-Terwilliger-Lair Hill,273346,2010,Weapons,
+Corbett-Terwilliger-Lair Hill,273346,2011,Aggravated Assault,4
+Corbett-Terwilliger-Lair Hill,273346,2011,Arson,
+Corbett-Terwilliger-Lair Hill,273346,2011,"Assault, Simple",5
+Corbett-Terwilliger-Lair Hill,273346,2011,Burglary,19
+Corbett-Terwilliger-Lair Hill,273346,2011,Curfew,
+Corbett-Terwilliger-Lair Hill,273346,2011,Disorderly Conduct,12
+Corbett-Terwilliger-Lair Hill,273346,2011,Drugs,2
+Corbett-Terwilliger-Lair Hill,273346,2011,DUII,25
+Corbett-Terwilliger-Lair Hill,273346,2011,Embezzlement,2
+Corbett-Terwilliger-Lair Hill,273346,2011,Forgery,2
+Corbett-Terwilliger-Lair Hill,273346,2011,Fraud,11
+Corbett-Terwilliger-Lair Hill,273346,2011,Gambling,
+Corbett-Terwilliger-Lair Hill,273346,2011,Homicide,
+Corbett-Terwilliger-Lair Hill,273346,2011,Kidnap,
+Corbett-Terwilliger-Lair Hill,273346,2011,Larceny,170
+Corbett-Terwilliger-Lair Hill,273346,2011,Liquor Laws,5
+Corbett-Terwilliger-Lair Hill,273346,2011,Motor Vehicle Theft,23
+Corbett-Terwilliger-Lair Hill,273346,2011,Offenses Against Family,
+Corbett-Terwilliger-Lair Hill,273346,2011,Prostitution,
+Corbett-Terwilliger-Lair Hill,273346,2011,Rape,
+Corbett-Terwilliger-Lair Hill,273346,2011,Robbery,3
+Corbett-Terwilliger-Lair Hill,273346,2011,Runaway,
+Corbett-Terwilliger-Lair Hill,273346,2011,Sex Offenses,
+Corbett-Terwilliger-Lair Hill,273346,2011,Stolen Property,
+Corbett-Terwilliger-Lair Hill,273346,2011,Trespass,11
+Corbett-Terwilliger-Lair Hill,273346,2011,Vandalism,59
+Corbett-Terwilliger-Lair Hill,273346,2011,Weapons,
+Corbett-Terwilliger-Lair Hill,273346,2012,Aggravated Assault,
+Corbett-Terwilliger-Lair Hill,273346,2012,Arson,
+Corbett-Terwilliger-Lair Hill,273346,2012,"Assault, Simple",3
+Corbett-Terwilliger-Lair Hill,273346,2012,Burglary,33
+Corbett-Terwilliger-Lair Hill,273346,2012,Curfew,
+Corbett-Terwilliger-Lair Hill,273346,2012,Disorderly Conduct,13
+Corbett-Terwilliger-Lair Hill,273346,2012,Drugs,6
+Corbett-Terwilliger-Lair Hill,273346,2012,DUII,33
+Corbett-Terwilliger-Lair Hill,273346,2012,Embezzlement,1
+Corbett-Terwilliger-Lair Hill,273346,2012,Forgery,3
+Corbett-Terwilliger-Lair Hill,273346,2012,Fraud,8
+Corbett-Terwilliger-Lair Hill,273346,2012,Gambling,
+Corbett-Terwilliger-Lair Hill,273346,2012,Homicide,
+Corbett-Terwilliger-Lair Hill,273346,2012,Kidnap,
+Corbett-Terwilliger-Lair Hill,273346,2012,Larceny,184
+Corbett-Terwilliger-Lair Hill,273346,2012,Liquor Laws,4
+Corbett-Terwilliger-Lair Hill,273346,2012,Motor Vehicle Theft,32
+Corbett-Terwilliger-Lair Hill,273346,2012,Offenses Against Family,
+Corbett-Terwilliger-Lair Hill,273346,2012,Prostitution,
+Corbett-Terwilliger-Lair Hill,273346,2012,Rape,
+Corbett-Terwilliger-Lair Hill,273346,2012,Robbery,2
+Corbett-Terwilliger-Lair Hill,273346,2012,Runaway,
+Corbett-Terwilliger-Lair Hill,273346,2012,Sex Offenses,
+Corbett-Terwilliger-Lair Hill,273346,2012,Stolen Property,
+Corbett-Terwilliger-Lair Hill,273346,2012,Trespass,5
+Corbett-Terwilliger-Lair Hill,273346,2012,Vandalism,26
+Corbett-Terwilliger-Lair Hill,273346,2012,Weapons,
+Corbett-Terwilliger-Lair Hill,273346,2013,Aggravated Assault,3
+Corbett-Terwilliger-Lair Hill,273346,2013,Arson,
+Corbett-Terwilliger-Lair Hill,273346,2013,"Assault, Simple",4
+Corbett-Terwilliger-Lair Hill,273346,2013,Burglary,41
+Corbett-Terwilliger-Lair Hill,273346,2013,Curfew,
+Corbett-Terwilliger-Lair Hill,273346,2013,Disorderly Conduct,11
+Corbett-Terwilliger-Lair Hill,273346,2013,Drugs,2
+Corbett-Terwilliger-Lair Hill,273346,2013,DUII,22
+Corbett-Terwilliger-Lair Hill,273346,2013,Embezzlement,2
+Corbett-Terwilliger-Lair Hill,273346,2013,Forgery,3
+Corbett-Terwilliger-Lair Hill,273346,2013,Fraud,8
+Corbett-Terwilliger-Lair Hill,273346,2013,Gambling,
+Corbett-Terwilliger-Lair Hill,273346,2013,Homicide,
+Corbett-Terwilliger-Lair Hill,273346,2013,Kidnap,
+Corbett-Terwilliger-Lair Hill,273346,2013,Larceny,189
+Corbett-Terwilliger-Lair Hill,273346,2013,Liquor Laws,1
+Corbett-Terwilliger-Lair Hill,273346,2013,Motor Vehicle Theft,23
+Corbett-Terwilliger-Lair Hill,273346,2013,Offenses Against Family,
+Corbett-Terwilliger-Lair Hill,273346,2013,Prostitution,
+Corbett-Terwilliger-Lair Hill,273346,2013,Rape,
+Corbett-Terwilliger-Lair Hill,273346,2013,Robbery,3
+Corbett-Terwilliger-Lair Hill,273346,2013,Runaway,1
+Corbett-Terwilliger-Lair Hill,273346,2013,Sex Offenses,
+Corbett-Terwilliger-Lair Hill,273346,2013,Stolen Property,
+Corbett-Terwilliger-Lair Hill,273346,2013,Trespass,6
+Corbett-Terwilliger-Lair Hill,273346,2013,Vandalism,26
+Corbett-Terwilliger-Lair Hill,273346,2013,Weapons,1
+Corbett-Terwilliger-Lair Hill,273346,2014,Aggravated Assault,3
+Corbett-Terwilliger-Lair Hill,273346,2014,Arson,1
+Corbett-Terwilliger-Lair Hill,273346,2014,"Assault, Simple",6
+Corbett-Terwilliger-Lair Hill,273346,2014,Burglary,29
+Corbett-Terwilliger-Lair Hill,273346,2014,Curfew,
+Corbett-Terwilliger-Lair Hill,273346,2014,Disorderly Conduct,13
+Corbett-Terwilliger-Lair Hill,273346,2014,Drugs,2
+Corbett-Terwilliger-Lair Hill,273346,2014,DUII,24
+Corbett-Terwilliger-Lair Hill,273346,2014,Embezzlement,
+Corbett-Terwilliger-Lair Hill,273346,2014,Forgery,
+Corbett-Terwilliger-Lair Hill,273346,2014,Fraud,13
+Corbett-Terwilliger-Lair Hill,273346,2014,Gambling,
+Corbett-Terwilliger-Lair Hill,273346,2014,Homicide,
+Corbett-Terwilliger-Lair Hill,273346,2014,Kidnap,
+Corbett-Terwilliger-Lair Hill,273346,2014,Larceny,231
+Corbett-Terwilliger-Lair Hill,273346,2014,Liquor Laws,2
+Corbett-Terwilliger-Lair Hill,273346,2014,Motor Vehicle Theft,22
+Corbett-Terwilliger-Lair Hill,273346,2014,Offenses Against Family,
+Corbett-Terwilliger-Lair Hill,273346,2014,Prostitution,
+Corbett-Terwilliger-Lair Hill,273346,2014,Rape,
+Corbett-Terwilliger-Lair Hill,273346,2014,Robbery,4
+Corbett-Terwilliger-Lair Hill,273346,2014,Runaway,
+Corbett-Terwilliger-Lair Hill,273346,2014,Sex Offenses,
+Corbett-Terwilliger-Lair Hill,273346,2014,Stolen Property,1
+Corbett-Terwilliger-Lair Hill,273346,2014,Trespass,10
+Corbett-Terwilliger-Lair Hill,273346,2014,Vandalism,37
+Corbett-Terwilliger-Lair Hill,273346,2014,Weapons,1
+Creston-Kenilworth,273402,2004,Aggravated Assault,2
+Creston-Kenilworth,273402,2004,Arson,
+Creston-Kenilworth,273402,2004,"Assault, Simple",9
+Creston-Kenilworth,273402,2004,Burglary,33
+Creston-Kenilworth,273402,2004,Curfew,
+Creston-Kenilworth,273402,2004,Disorderly Conduct,3
+Creston-Kenilworth,273402,2004,Drugs,19
+Creston-Kenilworth,273402,2004,DUII,12
+Creston-Kenilworth,273402,2004,Embezzlement,2
+Creston-Kenilworth,273402,2004,Forgery,8
+Creston-Kenilworth,273402,2004,Fraud,8
+Creston-Kenilworth,273402,2004,Gambling,
+Creston-Kenilworth,273402,2004,Homicide,
+Creston-Kenilworth,273402,2004,Kidnap,
+Creston-Kenilworth,273402,2004,Larceny,70
+Creston-Kenilworth,273402,2004,Liquor Laws,2
+Creston-Kenilworth,273402,2004,Motor Vehicle Theft,23
+Creston-Kenilworth,273402,2004,Offenses Against Family,
+Creston-Kenilworth,273402,2004,Prostitution,
+Creston-Kenilworth,273402,2004,Rape,
+Creston-Kenilworth,273402,2004,Robbery,5
+Creston-Kenilworth,273402,2004,Runaway,
+Creston-Kenilworth,273402,2004,Sex Offenses,1
+Creston-Kenilworth,273402,2004,Stolen Property,
+Creston-Kenilworth,273402,2004,Trespass,13
+Creston-Kenilworth,273402,2004,Vandalism,26
+Creston-Kenilworth,273402,2004,Weapons,2
+Creston-Kenilworth,273402,2005,Aggravated Assault,21
+Creston-Kenilworth,273402,2005,Arson,1
+Creston-Kenilworth,273402,2005,"Assault, Simple",16
+Creston-Kenilworth,273402,2005,Burglary,72
+Creston-Kenilworth,273402,2005,Curfew,1
+Creston-Kenilworth,273402,2005,Disorderly Conduct,17
+Creston-Kenilworth,273402,2005,Drugs,42
+Creston-Kenilworth,273402,2005,DUII,13
+Creston-Kenilworth,273402,2005,Embezzlement,1
+Creston-Kenilworth,273402,2005,Forgery,29
+Creston-Kenilworth,273402,2005,Fraud,26
+Creston-Kenilworth,273402,2005,Gambling,
+Creston-Kenilworth,273402,2005,Homicide,
+Creston-Kenilworth,273402,2005,Kidnap,
+Creston-Kenilworth,273402,2005,Larceny,246
+Creston-Kenilworth,273402,2005,Liquor Laws,7
+Creston-Kenilworth,273402,2005,Motor Vehicle Theft,77
+Creston-Kenilworth,273402,2005,Offenses Against Family,
+Creston-Kenilworth,273402,2005,Prostitution,
+Creston-Kenilworth,273402,2005,Rape,
+Creston-Kenilworth,273402,2005,Robbery,5
+Creston-Kenilworth,273402,2005,Runaway,
+Creston-Kenilworth,273402,2005,Sex Offenses,1
+Creston-Kenilworth,273402,2005,Stolen Property,1
+Creston-Kenilworth,273402,2005,Trespass,22
+Creston-Kenilworth,273402,2005,Vandalism,63
+Creston-Kenilworth,273402,2005,Weapons,5
+Creston-Kenilworth,273402,2006,Aggravated Assault,24
+Creston-Kenilworth,273402,2006,Arson,
+Creston-Kenilworth,273402,2006,"Assault, Simple",20
+Creston-Kenilworth,273402,2006,Burglary,67
+Creston-Kenilworth,273402,2006,Curfew,
+Creston-Kenilworth,273402,2006,Disorderly Conduct,17
+Creston-Kenilworth,273402,2006,Drugs,28
+Creston-Kenilworth,273402,2006,DUII,21
+Creston-Kenilworth,273402,2006,Embezzlement,2
+Creston-Kenilworth,273402,2006,Forgery,6
+Creston-Kenilworth,273402,2006,Fraud,32
+Creston-Kenilworth,273402,2006,Gambling,
+Creston-Kenilworth,273402,2006,Homicide,
+Creston-Kenilworth,273402,2006,Kidnap,1
+Creston-Kenilworth,273402,2006,Larceny,174
+Creston-Kenilworth,273402,2006,Liquor Laws,15
+Creston-Kenilworth,273402,2006,Motor Vehicle Theft,62
+Creston-Kenilworth,273402,2006,Offenses Against Family,
+Creston-Kenilworth,273402,2006,Prostitution,
+Creston-Kenilworth,273402,2006,Rape,
+Creston-Kenilworth,273402,2006,Robbery,14
+Creston-Kenilworth,273402,2006,Runaway,
+Creston-Kenilworth,273402,2006,Sex Offenses,1
+Creston-Kenilworth,273402,2006,Stolen Property,1
+Creston-Kenilworth,273402,2006,Trespass,16
+Creston-Kenilworth,273402,2006,Vandalism,86
+Creston-Kenilworth,273402,2006,Weapons,4
+Creston-Kenilworth,273402,2007,Aggravated Assault,15
+Creston-Kenilworth,273402,2007,Arson,
+Creston-Kenilworth,273402,2007,"Assault, Simple",30
+Creston-Kenilworth,273402,2007,Burglary,60
+Creston-Kenilworth,273402,2007,Curfew,
+Creston-Kenilworth,273402,2007,Disorderly Conduct,14
+Creston-Kenilworth,273402,2007,Drugs,24
+Creston-Kenilworth,273402,2007,DUII,42
+Creston-Kenilworth,273402,2007,Embezzlement,1
+Creston-Kenilworth,273402,2007,Forgery,7
+Creston-Kenilworth,273402,2007,Fraud,50
+Creston-Kenilworth,273402,2007,Gambling,
+Creston-Kenilworth,273402,2007,Homicide,
+Creston-Kenilworth,273402,2007,Kidnap,
+Creston-Kenilworth,273402,2007,Larceny,169
+Creston-Kenilworth,273402,2007,Liquor Laws,8
+Creston-Kenilworth,273402,2007,Motor Vehicle Theft,62
+Creston-Kenilworth,273402,2007,Offenses Against Family,
+Creston-Kenilworth,273402,2007,Prostitution,
+Creston-Kenilworth,273402,2007,Rape,1
+Creston-Kenilworth,273402,2007,Robbery,10
+Creston-Kenilworth,273402,2007,Runaway,
+Creston-Kenilworth,273402,2007,Sex Offenses,1
+Creston-Kenilworth,273402,2007,Stolen Property,
+Creston-Kenilworth,273402,2007,Trespass,21
+Creston-Kenilworth,273402,2007,Vandalism,70
+Creston-Kenilworth,273402,2007,Weapons,5
+Creston-Kenilworth,273402,2008,Aggravated Assault,8
+Creston-Kenilworth,273402,2008,Arson,
+Creston-Kenilworth,273402,2008,"Assault, Simple",24
+Creston-Kenilworth,273402,2008,Burglary,31
+Creston-Kenilworth,273402,2008,Curfew,
+Creston-Kenilworth,273402,2008,Disorderly Conduct,13
+Creston-Kenilworth,273402,2008,Drugs,20
+Creston-Kenilworth,273402,2008,DUII,20
+Creston-Kenilworth,273402,2008,Embezzlement,
+Creston-Kenilworth,273402,2008,Forgery,14
+Creston-Kenilworth,273402,2008,Fraud,33
+Creston-Kenilworth,273402,2008,Gambling,
+Creston-Kenilworth,273402,2008,Homicide,
+Creston-Kenilworth,273402,2008,Kidnap,
+Creston-Kenilworth,273402,2008,Larceny,116
+Creston-Kenilworth,273402,2008,Liquor Laws,14
+Creston-Kenilworth,273402,2008,Motor Vehicle Theft,42
+Creston-Kenilworth,273402,2008,Offenses Against Family,
+Creston-Kenilworth,273402,2008,Prostitution,
+Creston-Kenilworth,273402,2008,Rape,
+Creston-Kenilworth,273402,2008,Robbery,6
+Creston-Kenilworth,273402,2008,Runaway,
+Creston-Kenilworth,273402,2008,Sex Offenses,
+Creston-Kenilworth,273402,2008,Stolen Property,
+Creston-Kenilworth,273402,2008,Trespass,13
+Creston-Kenilworth,273402,2008,Vandalism,50
+Creston-Kenilworth,273402,2008,Weapons,2
+Creston-Kenilworth,273402,2009,Aggravated Assault,8
+Creston-Kenilworth,273402,2009,Arson,1
+Creston-Kenilworth,273402,2009,"Assault, Simple",12
+Creston-Kenilworth,273402,2009,Burglary,30
+Creston-Kenilworth,273402,2009,Curfew,
+Creston-Kenilworth,273402,2009,Disorderly Conduct,18
+Creston-Kenilworth,273402,2009,Drugs,6
+Creston-Kenilworth,273402,2009,DUII,15
+Creston-Kenilworth,273402,2009,Embezzlement,1
+Creston-Kenilworth,273402,2009,Forgery,1
+Creston-Kenilworth,273402,2009,Fraud,13
+Creston-Kenilworth,273402,2009,Gambling,
+Creston-Kenilworth,273402,2009,Homicide,
+Creston-Kenilworth,273402,2009,Kidnap,
+Creston-Kenilworth,273402,2009,Larceny,118
+Creston-Kenilworth,273402,2009,Liquor Laws,17
+Creston-Kenilworth,273402,2009,Motor Vehicle Theft,30
+Creston-Kenilworth,273402,2009,Offenses Against Family,1
+Creston-Kenilworth,273402,2009,Prostitution,
+Creston-Kenilworth,273402,2009,Rape,1
+Creston-Kenilworth,273402,2009,Robbery,4
+Creston-Kenilworth,273402,2009,Runaway,
+Creston-Kenilworth,273402,2009,Sex Offenses,1
+Creston-Kenilworth,273402,2009,Stolen Property,
+Creston-Kenilworth,273402,2009,Trespass,20
+Creston-Kenilworth,273402,2009,Vandalism,38
+Creston-Kenilworth,273402,2009,Weapons,2
+Creston-Kenilworth,273402,2010,Aggravated Assault,10
+Creston-Kenilworth,273402,2010,Arson,
+Creston-Kenilworth,273402,2010,"Assault, Simple",23
+Creston-Kenilworth,273402,2010,Burglary,50
+Creston-Kenilworth,273402,2010,Curfew,1
+Creston-Kenilworth,273402,2010,Disorderly Conduct,16
+Creston-Kenilworth,273402,2010,Drugs,19
+Creston-Kenilworth,273402,2010,DUII,13
+Creston-Kenilworth,273402,2010,Embezzlement,
+Creston-Kenilworth,273402,2010,Forgery,4
+Creston-Kenilworth,273402,2010,Fraud,14
+Creston-Kenilworth,273402,2010,Gambling,
+Creston-Kenilworth,273402,2010,Homicide,
+Creston-Kenilworth,273402,2010,Kidnap,
+Creston-Kenilworth,273402,2010,Larceny,162
+Creston-Kenilworth,273402,2010,Liquor Laws,17
+Creston-Kenilworth,273402,2010,Motor Vehicle Theft,45
+Creston-Kenilworth,273402,2010,Offenses Against Family,
+Creston-Kenilworth,273402,2010,Prostitution,
+Creston-Kenilworth,273402,2010,Rape,
+Creston-Kenilworth,273402,2010,Robbery,11
+Creston-Kenilworth,273402,2010,Runaway,
+Creston-Kenilworth,273402,2010,Sex Offenses,2
+Creston-Kenilworth,273402,2010,Stolen Property,1
+Creston-Kenilworth,273402,2010,Trespass,10
+Creston-Kenilworth,273402,2010,Vandalism,45
+Creston-Kenilworth,273402,2010,Weapons,2
+Creston-Kenilworth,273402,2011,Aggravated Assault,6
+Creston-Kenilworth,273402,2011,Arson,
+Creston-Kenilworth,273402,2011,"Assault, Simple",14
+Creston-Kenilworth,273402,2011,Burglary,60
+Creston-Kenilworth,273402,2011,Curfew,
+Creston-Kenilworth,273402,2011,Disorderly Conduct,11
+Creston-Kenilworth,273402,2011,Drugs,2
+Creston-Kenilworth,273402,2011,DUII,10
+Creston-Kenilworth,273402,2011,Embezzlement,1
+Creston-Kenilworth,273402,2011,Forgery,2
+Creston-Kenilworth,273402,2011,Fraud,6
+Creston-Kenilworth,273402,2011,Gambling,
+Creston-Kenilworth,273402,2011,Homicide,
+Creston-Kenilworth,273402,2011,Kidnap,
+Creston-Kenilworth,273402,2011,Larceny,191
+Creston-Kenilworth,273402,2011,Liquor Laws,15
+Creston-Kenilworth,273402,2011,Motor Vehicle Theft,38
+Creston-Kenilworth,273402,2011,Offenses Against Family,
+Creston-Kenilworth,273402,2011,Prostitution,
+Creston-Kenilworth,273402,2011,Rape,
+Creston-Kenilworth,273402,2011,Robbery,5
+Creston-Kenilworth,273402,2011,Runaway,
+Creston-Kenilworth,273402,2011,Sex Offenses,1
+Creston-Kenilworth,273402,2011,Stolen Property,
+Creston-Kenilworth,273402,2011,Trespass,12
+Creston-Kenilworth,273402,2011,Vandalism,42
+Creston-Kenilworth,273402,2011,Weapons,3
+Creston-Kenilworth,273402,2012,Aggravated Assault,9
+Creston-Kenilworth,273402,2012,Arson,1
+Creston-Kenilworth,273402,2012,"Assault, Simple",12
+Creston-Kenilworth,273402,2012,Burglary,66
+Creston-Kenilworth,273402,2012,Curfew,
+Creston-Kenilworth,273402,2012,Disorderly Conduct,5
+Creston-Kenilworth,273402,2012,Drugs,3
+Creston-Kenilworth,273402,2012,DUII,18
+Creston-Kenilworth,273402,2012,Embezzlement,
+Creston-Kenilworth,273402,2012,Forgery,2
+Creston-Kenilworth,273402,2012,Fraud,18
+Creston-Kenilworth,273402,2012,Gambling,
+Creston-Kenilworth,273402,2012,Homicide,
+Creston-Kenilworth,273402,2012,Kidnap,
+Creston-Kenilworth,273402,2012,Larceny,185
+Creston-Kenilworth,273402,2012,Liquor Laws,8
+Creston-Kenilworth,273402,2012,Motor Vehicle Theft,35
+Creston-Kenilworth,273402,2012,Offenses Against Family,
+Creston-Kenilworth,273402,2012,Prostitution,
+Creston-Kenilworth,273402,2012,Rape,1
+Creston-Kenilworth,273402,2012,Robbery,6
+Creston-Kenilworth,273402,2012,Runaway,
+Creston-Kenilworth,273402,2012,Sex Offenses,1
+Creston-Kenilworth,273402,2012,Stolen Property,
+Creston-Kenilworth,273402,2012,Trespass,15
+Creston-Kenilworth,273402,2012,Vandalism,33
+Creston-Kenilworth,273402,2012,Weapons,1
+Creston-Kenilworth,273402,2013,Aggravated Assault,6
+Creston-Kenilworth,273402,2013,Arson,1
+Creston-Kenilworth,273402,2013,"Assault, Simple",12
+Creston-Kenilworth,273402,2013,Burglary,43
+Creston-Kenilworth,273402,2013,Curfew,
+Creston-Kenilworth,273402,2013,Disorderly Conduct,11
+Creston-Kenilworth,273402,2013,Drugs,5
+Creston-Kenilworth,273402,2013,DUII,11
+Creston-Kenilworth,273402,2013,Embezzlement,
+Creston-Kenilworth,273402,2013,Forgery,6
+Creston-Kenilworth,273402,2013,Fraud,10
+Creston-Kenilworth,273402,2013,Gambling,
+Creston-Kenilworth,273402,2013,Homicide,
+Creston-Kenilworth,273402,2013,Kidnap,
+Creston-Kenilworth,273402,2013,Larceny,191
+Creston-Kenilworth,273402,2013,Liquor Laws,9
+Creston-Kenilworth,273402,2013,Motor Vehicle Theft,36
+Creston-Kenilworth,273402,2013,Offenses Against Family,
+Creston-Kenilworth,273402,2013,Prostitution,2
+Creston-Kenilworth,273402,2013,Rape,
+Creston-Kenilworth,273402,2013,Robbery,4
+Creston-Kenilworth,273402,2013,Runaway,
+Creston-Kenilworth,273402,2013,Sex Offenses,
+Creston-Kenilworth,273402,2013,Stolen Property,
+Creston-Kenilworth,273402,2013,Trespass,5
+Creston-Kenilworth,273402,2013,Vandalism,33
+Creston-Kenilworth,273402,2013,Weapons,1
+Creston-Kenilworth,273402,2014,Aggravated Assault,5
+Creston-Kenilworth,273402,2014,Arson,6
+Creston-Kenilworth,273402,2014,"Assault, Simple",13
+Creston-Kenilworth,273402,2014,Burglary,44
+Creston-Kenilworth,273402,2014,Curfew,1
+Creston-Kenilworth,273402,2014,Disorderly Conduct,18
+Creston-Kenilworth,273402,2014,Drugs,6
+Creston-Kenilworth,273402,2014,DUII,12
+Creston-Kenilworth,273402,2014,Embezzlement,
+Creston-Kenilworth,273402,2014,Forgery,1
+Creston-Kenilworth,273402,2014,Fraud,13
+Creston-Kenilworth,273402,2014,Gambling,
+Creston-Kenilworth,273402,2014,Homicide,
+Creston-Kenilworth,273402,2014,Kidnap,
+Creston-Kenilworth,273402,2014,Larceny,209
+Creston-Kenilworth,273402,2014,Liquor Laws,4
+Creston-Kenilworth,273402,2014,Motor Vehicle Theft,40
+Creston-Kenilworth,273402,2014,Offenses Against Family,
+Creston-Kenilworth,273402,2014,Prostitution,
+Creston-Kenilworth,273402,2014,Rape,1
+Creston-Kenilworth,273402,2014,Robbery,5
+Creston-Kenilworth,273402,2014,Runaway,
+Creston-Kenilworth,273402,2014,Sex Offenses,1
+Creston-Kenilworth,273402,2014,Stolen Property,
+Creston-Kenilworth,273402,2014,Trespass,18
+Creston-Kenilworth,273402,2014,Vandalism,57
+Creston-Kenilworth,273402,2014,Weapons,1
+Cully,271079,2004,Aggravated Assault,9
+Cully,271079,2004,Arson,
+Cully,271079,2004,"Assault, Simple",20
+Cully,271079,2004,Burglary,70
+Cully,271079,2004,Curfew,
+Cully,271079,2004,Disorderly Conduct,12
+Cully,271079,2004,Drugs,24
+Cully,271079,2004,DUII,7
+Cully,271079,2004,Embezzlement,2
+Cully,271079,2004,Forgery,16
+Cully,271079,2004,Fraud,11
+Cully,271079,2004,Gambling,
+Cully,271079,2004,Homicide,
+Cully,271079,2004,Kidnap,1
+Cully,271079,2004,Larceny,150
+Cully,271079,2004,Liquor Laws,3
+Cully,271079,2004,Motor Vehicle Theft,46
+Cully,271079,2004,Offenses Against Family,
+Cully,271079,2004,Prostitution,3
+Cully,271079,2004,Rape,1
+Cully,271079,2004,Robbery,6
+Cully,271079,2004,Runaway,
+Cully,271079,2004,Sex Offenses,
+Cully,271079,2004,Stolen Property,1
+Cully,271079,2004,Trespass,16
+Cully,271079,2004,Vandalism,43
+Cully,271079,2004,Weapons,7
+Cully,271079,2005,Aggravated Assault,75
+Cully,271079,2005,Arson,
+Cully,271079,2005,"Assault, Simple",83
+Cully,271079,2005,Burglary,193
+Cully,271079,2005,Curfew,3
+Cully,271079,2005,Disorderly Conduct,59
+Cully,271079,2005,Drugs,75
+Cully,271079,2005,DUII,67
+Cully,271079,2005,Embezzlement,7
+Cully,271079,2005,Forgery,37
+Cully,271079,2005,Fraud,75
+Cully,271079,2005,Gambling,
+Cully,271079,2005,Homicide,1
+Cully,271079,2005,Kidnap,2
+Cully,271079,2005,Larceny,571
+Cully,271079,2005,Liquor Laws,14
+Cully,271079,2005,Motor Vehicle Theft,179
+Cully,271079,2005,Offenses Against Family,
+Cully,271079,2005,Prostitution,3
+Cully,271079,2005,Rape,3
+Cully,271079,2005,Robbery,24
+Cully,271079,2005,Runaway,
+Cully,271079,2005,Sex Offenses,3
+Cully,271079,2005,Stolen Property,4
+Cully,271079,2005,Trespass,82
+Cully,271079,2005,Vandalism,180
+Cully,271079,2005,Weapons,15
+Cully,271079,2006,Aggravated Assault,54
+Cully,271079,2006,Arson,
+Cully,271079,2006,"Assault, Simple",97
+Cully,271079,2006,Burglary,217
+Cully,271079,2006,Curfew,4
+Cully,271079,2006,Disorderly Conduct,63
+Cully,271079,2006,Drugs,100
+Cully,271079,2006,DUII,77
+Cully,271079,2006,Embezzlement,5
+Cully,271079,2006,Forgery,25
+Cully,271079,2006,Fraud,50
+Cully,271079,2006,Gambling,
+Cully,271079,2006,Homicide,
+Cully,271079,2006,Kidnap,
+Cully,271079,2006,Larceny,458
+Cully,271079,2006,Liquor Laws,16
+Cully,271079,2006,Motor Vehicle Theft,122
+Cully,271079,2006,Offenses Against Family,1
+Cully,271079,2006,Prostitution,3
+Cully,271079,2006,Rape,
+Cully,271079,2006,Robbery,27
+Cully,271079,2006,Runaway,
+Cully,271079,2006,Sex Offenses,1
+Cully,271079,2006,Stolen Property,6
+Cully,271079,2006,Trespass,69
+Cully,271079,2006,Vandalism,185
+Cully,271079,2006,Weapons,15
+Cully,271079,2007,Aggravated Assault,54
+Cully,271079,2007,Arson,3
+Cully,271079,2007,"Assault, Simple",75
+Cully,271079,2007,Burglary,189
+Cully,271079,2007,Curfew,7
+Cully,271079,2007,Disorderly Conduct,62
+Cully,271079,2007,Drugs,95
+Cully,271079,2007,DUII,64
+Cully,271079,2007,Embezzlement,8
+Cully,271079,2007,Forgery,19
+Cully,271079,2007,Fraud,54
+Cully,271079,2007,Gambling,
+Cully,271079,2007,Homicide,1
+Cully,271079,2007,Kidnap,5
+Cully,271079,2007,Larceny,516
+Cully,271079,2007,Liquor Laws,14
+Cully,271079,2007,Motor Vehicle Theft,125
+Cully,271079,2007,Offenses Against Family,
+Cully,271079,2007,Prostitution,11
+Cully,271079,2007,Rape,1
+Cully,271079,2007,Robbery,28
+Cully,271079,2007,Runaway,1
+Cully,271079,2007,Sex Offenses,3
+Cully,271079,2007,Stolen Property,7
+Cully,271079,2007,Trespass,48
+Cully,271079,2007,Vandalism,142
+Cully,271079,2007,Weapons,17
+Cully,271079,2008,Aggravated Assault,37
+Cully,271079,2008,Arson,
+Cully,271079,2008,"Assault, Simple",63
+Cully,271079,2008,Burglary,154
+Cully,271079,2008,Curfew,4
+Cully,271079,2008,Disorderly Conduct,50
+Cully,271079,2008,Drugs,85
+Cully,271079,2008,DUII,76
+Cully,271079,2008,Embezzlement,2
+Cully,271079,2008,Forgery,34
+Cully,271079,2008,Fraud,51
+Cully,271079,2008,Gambling,
+Cully,271079,2008,Homicide,
+Cully,271079,2008,Kidnap,
+Cully,271079,2008,Larceny,531
+Cully,271079,2008,Liquor Laws,18
+Cully,271079,2008,Motor Vehicle Theft,85
+Cully,271079,2008,Offenses Against Family,
+Cully,271079,2008,Prostitution,3
+Cully,271079,2008,Rape,1
+Cully,271079,2008,Robbery,23
+Cully,271079,2008,Runaway,
+Cully,271079,2008,Sex Offenses,1
+Cully,271079,2008,Stolen Property,4
+Cully,271079,2008,Trespass,53
+Cully,271079,2008,Vandalism,166
+Cully,271079,2008,Weapons,17
+Cully,271079,2009,Aggravated Assault,35
+Cully,271079,2009,Arson,1
+Cully,271079,2009,"Assault, Simple",57
+Cully,271079,2009,Burglary,113
+Cully,271079,2009,Curfew,
+Cully,271079,2009,Disorderly Conduct,50
+Cully,271079,2009,Drugs,47
+Cully,271079,2009,DUII,67
+Cully,271079,2009,Embezzlement,18
+Cully,271079,2009,Forgery,13
+Cully,271079,2009,Fraud,33
+Cully,271079,2009,Gambling,
+Cully,271079,2009,Homicide,
+Cully,271079,2009,Kidnap,
+Cully,271079,2009,Larceny,440
+Cully,271079,2009,Liquor Laws,16
+Cully,271079,2009,Motor Vehicle Theft,96
+Cully,271079,2009,Offenses Against Family,1
+Cully,271079,2009,Prostitution,10
+Cully,271079,2009,Rape,1
+Cully,271079,2009,Robbery,30
+Cully,271079,2009,Runaway,
+Cully,271079,2009,Sex Offenses,2
+Cully,271079,2009,Stolen Property,4
+Cully,271079,2009,Trespass,54
+Cully,271079,2009,Vandalism,141
+Cully,271079,2009,Weapons,5
+Cully,271079,2010,Aggravated Assault,42
+Cully,271079,2010,Arson,1
+Cully,271079,2010,"Assault, Simple",50
+Cully,271079,2010,Burglary,114
+Cully,271079,2010,Curfew,3
+Cully,271079,2010,Disorderly Conduct,64
+Cully,271079,2010,Drugs,34
+Cully,271079,2010,DUII,55
+Cully,271079,2010,Embezzlement,4
+Cully,271079,2010,Forgery,23
+Cully,271079,2010,Fraud,32
+Cully,271079,2010,Gambling,
+Cully,271079,2010,Homicide,
+Cully,271079,2010,Kidnap,
+Cully,271079,2010,Larceny,376
+Cully,271079,2010,Liquor Laws,9
+Cully,271079,2010,Motor Vehicle Theft,88
+Cully,271079,2010,Offenses Against Family,
+Cully,271079,2010,Prostitution,5
+Cully,271079,2010,Rape,2
+Cully,271079,2010,Robbery,28
+Cully,271079,2010,Runaway,1
+Cully,271079,2010,Sex Offenses,1
+Cully,271079,2010,Stolen Property,
+Cully,271079,2010,Trespass,46
+Cully,271079,2010,Vandalism,122
+Cully,271079,2010,Weapons,9
+Cully,271079,2011,Aggravated Assault,34
+Cully,271079,2011,Arson,
+Cully,271079,2011,"Assault, Simple",51
+Cully,271079,2011,Burglary,141
+Cully,271079,2011,Curfew,1
+Cully,271079,2011,Disorderly Conduct,44
+Cully,271079,2011,Drugs,41
+Cully,271079,2011,DUII,39
+Cully,271079,2011,Embezzlement,3
+Cully,271079,2011,Forgery,26
+Cully,271079,2011,Fraud,30
+Cully,271079,2011,Gambling,
+Cully,271079,2011,Homicide,2
+Cully,271079,2011,Kidnap,
+Cully,271079,2011,Larceny,499
+Cully,271079,2011,Liquor Laws,6
+Cully,271079,2011,Motor Vehicle Theft,109
+Cully,271079,2011,Offenses Against Family,
+Cully,271079,2011,Prostitution,3
+Cully,271079,2011,Rape,1
+Cully,271079,2011,Robbery,22
+Cully,271079,2011,Runaway,
+Cully,271079,2011,Sex Offenses,3
+Cully,271079,2011,Stolen Property,3
+Cully,271079,2011,Trespass,52
+Cully,271079,2011,Vandalism,116
+Cully,271079,2011,Weapons,6
+Cully,271079,2012,Aggravated Assault,50
+Cully,271079,2012,Arson,2
+Cully,271079,2012,"Assault, Simple",64
+Cully,271079,2012,Burglary,145
+Cully,271079,2012,Curfew,2
+Cully,271079,2012,Disorderly Conduct,46
+Cully,271079,2012,Drugs,76
+Cully,271079,2012,DUII,49
+Cully,271079,2012,Embezzlement,4
+Cully,271079,2012,Forgery,12
+Cully,271079,2012,Fraud,35
+Cully,271079,2012,Gambling,
+Cully,271079,2012,Homicide,
+Cully,271079,2012,Kidnap,
+Cully,271079,2012,Larceny,449
+Cully,271079,2012,Liquor Laws,4
+Cully,271079,2012,Motor Vehicle Theft,119
+Cully,271079,2012,Offenses Against Family,
+Cully,271079,2012,Prostitution,6
+Cully,271079,2012,Rape,2
+Cully,271079,2012,Robbery,22
+Cully,271079,2012,Runaway,
+Cully,271079,2012,Sex Offenses,1
+Cully,271079,2012,Stolen Property,3
+Cully,271079,2012,Trespass,41
+Cully,271079,2012,Vandalism,133
+Cully,271079,2012,Weapons,10
+Cully,271079,2013,Aggravated Assault,38
+Cully,271079,2013,Arson,
+Cully,271079,2013,"Assault, Simple",42
+Cully,271079,2013,Burglary,109
+Cully,271079,2013,Curfew,1
+Cully,271079,2013,Disorderly Conduct,50
+Cully,271079,2013,Drugs,118
+Cully,271079,2013,DUII,53
+Cully,271079,2013,Embezzlement,2
+Cully,271079,2013,Forgery,14
+Cully,271079,2013,Fraud,29
+Cully,271079,2013,Gambling,
+Cully,271079,2013,Homicide,3
+Cully,271079,2013,Kidnap,
+Cully,271079,2013,Larceny,360
+Cully,271079,2013,Liquor Laws,12
+Cully,271079,2013,Motor Vehicle Theft,96
+Cully,271079,2013,Offenses Against Family,
+Cully,271079,2013,Prostitution,8
+Cully,271079,2013,Rape,
+Cully,271079,2013,Robbery,24
+Cully,271079,2013,Runaway,
+Cully,271079,2013,Sex Offenses,1
+Cully,271079,2013,Stolen Property,2
+Cully,271079,2013,Trespass,44
+Cully,271079,2013,Vandalism,101
+Cully,271079,2013,Weapons,19
+Cully,271079,2014,Aggravated Assault,32
+Cully,271079,2014,Arson,
+Cully,271079,2014,"Assault, Simple",49
+Cully,271079,2014,Burglary,99
+Cully,271079,2014,Curfew,1
+Cully,271079,2014,Disorderly Conduct,52
+Cully,271079,2014,Drugs,64
+Cully,271079,2014,DUII,37
+Cully,271079,2014,Embezzlement,4
+Cully,271079,2014,Forgery,9
+Cully,271079,2014,Fraud,39
+Cully,271079,2014,Gambling,
+Cully,271079,2014,Homicide,1
+Cully,271079,2014,Kidnap,1
+Cully,271079,2014,Larceny,421
+Cully,271079,2014,Liquor Laws,5
+Cully,271079,2014,Motor Vehicle Theft,77
+Cully,271079,2014,Offenses Against Family,1
+Cully,271079,2014,Prostitution,7
+Cully,271079,2014,Rape,2
+Cully,271079,2014,Robbery,25
+Cully,271079,2014,Runaway,1
+Cully,271079,2014,Sex Offenses,3
+Cully,271079,2014,Stolen Property,2
+Cully,271079,2014,Trespass,29
+Cully,271079,2014,Vandalism,81
+Cully,271079,2014,Weapons,11
+Denny Whitford,276294,2004,Aggravated Assault,
+Denny Whitford,276294,2004,Arson,
+Denny Whitford,276294,2004,"Assault, Simple",
+Denny Whitford,276294,2004,Burglary,
+Denny Whitford,276294,2004,Curfew,
+Denny Whitford,276294,2004,Disorderly Conduct,
+Denny Whitford,276294,2004,Drugs,
+Denny Whitford,276294,2004,DUII,
+Denny Whitford,276294,2004,Embezzlement,
+Denny Whitford,276294,2004,Forgery,
+Denny Whitford,276294,2004,Fraud,
+Denny Whitford,276294,2004,Gambling,
+Denny Whitford,276294,2004,Homicide,
+Denny Whitford,276294,2004,Kidnap,
+Denny Whitford,276294,2004,Larceny,
+Denny Whitford,276294,2004,Liquor Laws,
+Denny Whitford,276294,2004,Motor Vehicle Theft,
+Denny Whitford,276294,2004,Offenses Against Family,
+Denny Whitford,276294,2004,Prostitution,
+Denny Whitford,276294,2004,Rape,
+Denny Whitford,276294,2004,Robbery,
+Denny Whitford,276294,2004,Runaway,
+Denny Whitford,276294,2004,Sex Offenses,
+Denny Whitford,276294,2004,Stolen Property,
+Denny Whitford,276294,2004,Trespass,
+Denny Whitford,276294,2004,Vandalism,
+Denny Whitford,276294,2004,Weapons,
+Denny Whitford,276294,2005,Aggravated Assault,
+Denny Whitford,276294,2005,Arson,
+Denny Whitford,276294,2005,"Assault, Simple",
+Denny Whitford,276294,2005,Burglary,
+Denny Whitford,276294,2005,Curfew,
+Denny Whitford,276294,2005,Disorderly Conduct,
+Denny Whitford,276294,2005,Drugs,
+Denny Whitford,276294,2005,DUII,
+Denny Whitford,276294,2005,Embezzlement,
+Denny Whitford,276294,2005,Forgery,
+Denny Whitford,276294,2005,Fraud,
+Denny Whitford,276294,2005,Gambling,
+Denny Whitford,276294,2005,Homicide,
+Denny Whitford,276294,2005,Kidnap,
+Denny Whitford,276294,2005,Larceny,
+Denny Whitford,276294,2005,Liquor Laws,
+Denny Whitford,276294,2005,Motor Vehicle Theft,
+Denny Whitford,276294,2005,Offenses Against Family,
+Denny Whitford,276294,2005,Prostitution,
+Denny Whitford,276294,2005,Rape,
+Denny Whitford,276294,2005,Robbery,
+Denny Whitford,276294,2005,Runaway,
+Denny Whitford,276294,2005,Sex Offenses,
+Denny Whitford,276294,2005,Stolen Property,
+Denny Whitford,276294,2005,Trespass,
+Denny Whitford,276294,2005,Vandalism,
+Denny Whitford,276294,2005,Weapons,
+Denny Whitford,276294,2006,Aggravated Assault,
+Denny Whitford,276294,2006,Arson,
+Denny Whitford,276294,2006,"Assault, Simple",
+Denny Whitford,276294,2006,Burglary,
+Denny Whitford,276294,2006,Curfew,
+Denny Whitford,276294,2006,Disorderly Conduct,
+Denny Whitford,276294,2006,Drugs,
+Denny Whitford,276294,2006,DUII,
+Denny Whitford,276294,2006,Embezzlement,
+Denny Whitford,276294,2006,Forgery,
+Denny Whitford,276294,2006,Fraud,
+Denny Whitford,276294,2006,Gambling,
+Denny Whitford,276294,2006,Homicide,
+Denny Whitford,276294,2006,Kidnap,
+Denny Whitford,276294,2006,Larceny,
+Denny Whitford,276294,2006,Liquor Laws,
+Denny Whitford,276294,2006,Motor Vehicle Theft,
+Denny Whitford,276294,2006,Offenses Against Family,
+Denny Whitford,276294,2006,Prostitution,
+Denny Whitford,276294,2006,Rape,
+Denny Whitford,276294,2006,Robbery,
+Denny Whitford,276294,2006,Runaway,
+Denny Whitford,276294,2006,Sex Offenses,
+Denny Whitford,276294,2006,Stolen Property,
+Denny Whitford,276294,2006,Trespass,
+Denny Whitford,276294,2006,Vandalism,
+Denny Whitford,276294,2006,Weapons,
+Denny Whitford,276294,2007,Aggravated Assault,
+Denny Whitford,276294,2007,Arson,
+Denny Whitford,276294,2007,"Assault, Simple",
+Denny Whitford,276294,2007,Burglary,
+Denny Whitford,276294,2007,Curfew,
+Denny Whitford,276294,2007,Disorderly Conduct,
+Denny Whitford,276294,2007,Drugs,
+Denny Whitford,276294,2007,DUII,
+Denny Whitford,276294,2007,Embezzlement,
+Denny Whitford,276294,2007,Forgery,
+Denny Whitford,276294,2007,Fraud,
+Denny Whitford,276294,2007,Gambling,
+Denny Whitford,276294,2007,Homicide,
+Denny Whitford,276294,2007,Kidnap,
+Denny Whitford,276294,2007,Larceny,
+Denny Whitford,276294,2007,Liquor Laws,
+Denny Whitford,276294,2007,Motor Vehicle Theft,
+Denny Whitford,276294,2007,Offenses Against Family,
+Denny Whitford,276294,2007,Prostitution,
+Denny Whitford,276294,2007,Rape,
+Denny Whitford,276294,2007,Robbery,
+Denny Whitford,276294,2007,Runaway,
+Denny Whitford,276294,2007,Sex Offenses,
+Denny Whitford,276294,2007,Stolen Property,
+Denny Whitford,276294,2007,Trespass,
+Denny Whitford,276294,2007,Vandalism,
+Denny Whitford,276294,2007,Weapons,
+Denny Whitford,276294,2008,Aggravated Assault,
+Denny Whitford,276294,2008,Arson,
+Denny Whitford,276294,2008,"Assault, Simple",
+Denny Whitford,276294,2008,Burglary,
+Denny Whitford,276294,2008,Curfew,
+Denny Whitford,276294,2008,Disorderly Conduct,
+Denny Whitford,276294,2008,Drugs,
+Denny Whitford,276294,2008,DUII,
+Denny Whitford,276294,2008,Embezzlement,
+Denny Whitford,276294,2008,Forgery,
+Denny Whitford,276294,2008,Fraud,
+Denny Whitford,276294,2008,Gambling,
+Denny Whitford,276294,2008,Homicide,
+Denny Whitford,276294,2008,Kidnap,
+Denny Whitford,276294,2008,Larceny,
+Denny Whitford,276294,2008,Liquor Laws,
+Denny Whitford,276294,2008,Motor Vehicle Theft,
+Denny Whitford,276294,2008,Offenses Against Family,
+Denny Whitford,276294,2008,Prostitution,
+Denny Whitford,276294,2008,Rape,
+Denny Whitford,276294,2008,Robbery,
+Denny Whitford,276294,2008,Runaway,
+Denny Whitford,276294,2008,Sex Offenses,
+Denny Whitford,276294,2008,Stolen Property,
+Denny Whitford,276294,2008,Trespass,
+Denny Whitford,276294,2008,Vandalism,
+Denny Whitford,276294,2008,Weapons,
+Denny Whitford,276294,2009,Aggravated Assault,
+Denny Whitford,276294,2009,Arson,
+Denny Whitford,276294,2009,"Assault, Simple",
+Denny Whitford,276294,2009,Burglary,
+Denny Whitford,276294,2009,Curfew,
+Denny Whitford,276294,2009,Disorderly Conduct,
+Denny Whitford,276294,2009,Drugs,
+Denny Whitford,276294,2009,DUII,
+Denny Whitford,276294,2009,Embezzlement,
+Denny Whitford,276294,2009,Forgery,
+Denny Whitford,276294,2009,Fraud,
+Denny Whitford,276294,2009,Gambling,
+Denny Whitford,276294,2009,Homicide,
+Denny Whitford,276294,2009,Kidnap,
+Denny Whitford,276294,2009,Larceny,
+Denny Whitford,276294,2009,Liquor Laws,
+Denny Whitford,276294,2009,Motor Vehicle Theft,
+Denny Whitford,276294,2009,Offenses Against Family,
+Denny Whitford,276294,2009,Prostitution,
+Denny Whitford,276294,2009,Rape,
+Denny Whitford,276294,2009,Robbery,
+Denny Whitford,276294,2009,Runaway,
+Denny Whitford,276294,2009,Sex Offenses,
+Denny Whitford,276294,2009,Stolen Property,
+Denny Whitford,276294,2009,Trespass,
+Denny Whitford,276294,2009,Vandalism,
+Denny Whitford,276294,2009,Weapons,
+Denny Whitford,276294,2010,Aggravated Assault,
+Denny Whitford,276294,2010,Arson,
+Denny Whitford,276294,2010,"Assault, Simple",
+Denny Whitford,276294,2010,Burglary,
+Denny Whitford,276294,2010,Curfew,
+Denny Whitford,276294,2010,Disorderly Conduct,
+Denny Whitford,276294,2010,Drugs,
+Denny Whitford,276294,2010,DUII,
+Denny Whitford,276294,2010,Embezzlement,
+Denny Whitford,276294,2010,Forgery,
+Denny Whitford,276294,2010,Fraud,
+Denny Whitford,276294,2010,Gambling,
+Denny Whitford,276294,2010,Homicide,
+Denny Whitford,276294,2010,Kidnap,
+Denny Whitford,276294,2010,Larceny,
+Denny Whitford,276294,2010,Liquor Laws,
+Denny Whitford,276294,2010,Motor Vehicle Theft,
+Denny Whitford,276294,2010,Offenses Against Family,
+Denny Whitford,276294,2010,Prostitution,
+Denny Whitford,276294,2010,Rape,
+Denny Whitford,276294,2010,Robbery,
+Denny Whitford,276294,2010,Runaway,
+Denny Whitford,276294,2010,Sex Offenses,
+Denny Whitford,276294,2010,Stolen Property,
+Denny Whitford,276294,2010,Trespass,
+Denny Whitford,276294,2010,Vandalism,
+Denny Whitford,276294,2010,Weapons,
+Denny Whitford,276294,2011,Aggravated Assault,
+Denny Whitford,276294,2011,Arson,
+Denny Whitford,276294,2011,"Assault, Simple",
+Denny Whitford,276294,2011,Burglary,
+Denny Whitford,276294,2011,Curfew,
+Denny Whitford,276294,2011,Disorderly Conduct,
+Denny Whitford,276294,2011,Drugs,
+Denny Whitford,276294,2011,DUII,
+Denny Whitford,276294,2011,Embezzlement,
+Denny Whitford,276294,2011,Forgery,
+Denny Whitford,276294,2011,Fraud,
+Denny Whitford,276294,2011,Gambling,
+Denny Whitford,276294,2011,Homicide,
+Denny Whitford,276294,2011,Kidnap,
+Denny Whitford,276294,2011,Larceny,
+Denny Whitford,276294,2011,Liquor Laws,
+Denny Whitford,276294,2011,Motor Vehicle Theft,
+Denny Whitford,276294,2011,Offenses Against Family,
+Denny Whitford,276294,2011,Prostitution,
+Denny Whitford,276294,2011,Rape,
+Denny Whitford,276294,2011,Robbery,
+Denny Whitford,276294,2011,Runaway,
+Denny Whitford,276294,2011,Sex Offenses,
+Denny Whitford,276294,2011,Stolen Property,
+Denny Whitford,276294,2011,Trespass,
+Denny Whitford,276294,2011,Vandalism,
+Denny Whitford,276294,2011,Weapons,
+Denny Whitford,276294,2012,Aggravated Assault,
+Denny Whitford,276294,2012,Arson,
+Denny Whitford,276294,2012,"Assault, Simple",
+Denny Whitford,276294,2012,Burglary,
+Denny Whitford,276294,2012,Curfew,
+Denny Whitford,276294,2012,Disorderly Conduct,
+Denny Whitford,276294,2012,Drugs,
+Denny Whitford,276294,2012,DUII,
+Denny Whitford,276294,2012,Embezzlement,
+Denny Whitford,276294,2012,Forgery,
+Denny Whitford,276294,2012,Fraud,
+Denny Whitford,276294,2012,Gambling,
+Denny Whitford,276294,2012,Homicide,
+Denny Whitford,276294,2012,Kidnap,
+Denny Whitford,276294,2012,Larceny,
+Denny Whitford,276294,2012,Liquor Laws,
+Denny Whitford,276294,2012,Motor Vehicle Theft,
+Denny Whitford,276294,2012,Offenses Against Family,
+Denny Whitford,276294,2012,Prostitution,
+Denny Whitford,276294,2012,Rape,
+Denny Whitford,276294,2012,Robbery,
+Denny Whitford,276294,2012,Runaway,
+Denny Whitford,276294,2012,Sex Offenses,
+Denny Whitford,276294,2012,Stolen Property,
+Denny Whitford,276294,2012,Trespass,
+Denny Whitford,276294,2012,Vandalism,
+Denny Whitford,276294,2012,Weapons,
+Denny Whitford,276294,2013,Aggravated Assault,
+Denny Whitford,276294,2013,Arson,
+Denny Whitford,276294,2013,"Assault, Simple",
+Denny Whitford,276294,2013,Burglary,
+Denny Whitford,276294,2013,Curfew,
+Denny Whitford,276294,2013,Disorderly Conduct,
+Denny Whitford,276294,2013,Drugs,
+Denny Whitford,276294,2013,DUII,
+Denny Whitford,276294,2013,Embezzlement,
+Denny Whitford,276294,2013,Forgery,
+Denny Whitford,276294,2013,Fraud,
+Denny Whitford,276294,2013,Gambling,
+Denny Whitford,276294,2013,Homicide,
+Denny Whitford,276294,2013,Kidnap,
+Denny Whitford,276294,2013,Larceny,
+Denny Whitford,276294,2013,Liquor Laws,
+Denny Whitford,276294,2013,Motor Vehicle Theft,
+Denny Whitford,276294,2013,Offenses Against Family,
+Denny Whitford,276294,2013,Prostitution,
+Denny Whitford,276294,2013,Rape,
+Denny Whitford,276294,2013,Robbery,
+Denny Whitford,276294,2013,Runaway,
+Denny Whitford,276294,2013,Sex Offenses,
+Denny Whitford,276294,2013,Stolen Property,
+Denny Whitford,276294,2013,Trespass,
+Denny Whitford,276294,2013,Vandalism,
+Denny Whitford,276294,2013,Weapons,
+Denny Whitford,276294,2014,Aggravated Assault,
+Denny Whitford,276294,2014,Arson,
+Denny Whitford,276294,2014,"Assault, Simple",
+Denny Whitford,276294,2014,Burglary,
+Denny Whitford,276294,2014,Curfew,
+Denny Whitford,276294,2014,Disorderly Conduct,
+Denny Whitford,276294,2014,Drugs,
+Denny Whitford,276294,2014,DUII,
+Denny Whitford,276294,2014,Embezzlement,
+Denny Whitford,276294,2014,Forgery,
+Denny Whitford,276294,2014,Fraud,
+Denny Whitford,276294,2014,Gambling,
+Denny Whitford,276294,2014,Homicide,
+Denny Whitford,276294,2014,Kidnap,
+Denny Whitford,276294,2014,Larceny,
+Denny Whitford,276294,2014,Liquor Laws,
+Denny Whitford,276294,2014,Motor Vehicle Theft,
+Denny Whitford,276294,2014,Offenses Against Family,
+Denny Whitford,276294,2014,Prostitution,
+Denny Whitford,276294,2014,Rape,
+Denny Whitford,276294,2014,Robbery,
+Denny Whitford,276294,2014,Runaway,
+Denny Whitford,276294,2014,Sex Offenses,
+Denny Whitford,276294,2014,Stolen Property,
+Denny Whitford,276294,2014,Trespass,
+Denny Whitford,276294,2014,Vandalism,
+Denny Whitford,276294,2014,Weapons,
+Downtown,271082,2004,Aggravated Assault,34
+Downtown,271082,2004,Arson,
+Downtown,271082,2004,"Assault, Simple",62
+Downtown,271082,2004,Burglary,65
+Downtown,271082,2004,Curfew,12
+Downtown,271082,2004,Disorderly Conduct,105
+Downtown,271082,2004,Drugs,108
+Downtown,271082,2004,DUII,42
+Downtown,271082,2004,Embezzlement,8
+Downtown,271082,2004,Forgery,49
+Downtown,271082,2004,Fraud,49
+Downtown,271082,2004,Gambling,
+Downtown,271082,2004,Homicide,2
+Downtown,271082,2004,Kidnap,
+Downtown,271082,2004,Larceny,854
+Downtown,271082,2004,Liquor Laws,102
+Downtown,271082,2004,Motor Vehicle Theft,90
+Downtown,271082,2004,Offenses Against Family,
+Downtown,271082,2004,Prostitution,
+Downtown,271082,2004,Rape,
+Downtown,271082,2004,Robbery,42
+Downtown,271082,2004,Runaway,
+Downtown,271082,2004,Sex Offenses,5
+Downtown,271082,2004,Stolen Property,4
+Downtown,271082,2004,Trespass,154
+Downtown,271082,2004,Vandalism,78
+Downtown,271082,2004,Weapons,8
+Downtown,271082,2005,Aggravated Assault,102
+Downtown,271082,2005,Arson,1
+Downtown,271082,2005,"Assault, Simple",270
+Downtown,271082,2005,Burglary,190
+Downtown,271082,2005,Curfew,21
+Downtown,271082,2005,Disorderly Conduct,350
+Downtown,271082,2005,Drugs,857
+Downtown,271082,2005,DUII,121
+Downtown,271082,2005,Embezzlement,21
+Downtown,271082,2005,Forgery,153
+Downtown,271082,2005,Fraud,137
+Downtown,271082,2005,Gambling,
+Downtown,271082,2005,Homicide,3
+Downtown,271082,2005,Kidnap,
+Downtown,271082,2005,Larceny,1964
+Downtown,271082,2005,Liquor Laws,451
+Downtown,271082,2005,Motor Vehicle Theft,235
+Downtown,271082,2005,Offenses Against Family,
+Downtown,271082,2005,Prostitution,3
+Downtown,271082,2005,Rape,2
+Downtown,271082,2005,Robbery,108
+Downtown,271082,2005,Runaway,4
+Downtown,271082,2005,Sex Offenses,14
+Downtown,271082,2005,Stolen Property,12
+Downtown,271082,2005,Trespass,1016
+Downtown,271082,2005,Vandalism,297
+Downtown,271082,2005,Weapons,47
+Downtown,271082,2006,Aggravated Assault,123
+Downtown,271082,2006,Arson,5
+Downtown,271082,2006,"Assault, Simple",308
+Downtown,271082,2006,Burglary,181
+Downtown,271082,2006,Curfew,7
+Downtown,271082,2006,Disorderly Conduct,340
+Downtown,271082,2006,Drugs,657
+Downtown,271082,2006,DUII,150
+Downtown,271082,2006,Embezzlement,21
+Downtown,271082,2006,Forgery,114
+Downtown,271082,2006,Fraud,114
+Downtown,271082,2006,Gambling,
+Downtown,271082,2006,Homicide,2
+Downtown,271082,2006,Kidnap,2
+Downtown,271082,2006,Larceny,1858
+Downtown,271082,2006,Liquor Laws,482
+Downtown,271082,2006,Motor Vehicle Theft,199
+Downtown,271082,2006,Offenses Against Family,1
+Downtown,271082,2006,Prostitution,4
+Downtown,271082,2006,Rape,
+Downtown,271082,2006,Robbery,135
+Downtown,271082,2006,Runaway,2
+Downtown,271082,2006,Sex Offenses,6
+Downtown,271082,2006,Stolen Property,18
+Downtown,271082,2006,Trespass,543
+Downtown,271082,2006,Vandalism,305
+Downtown,271082,2006,Weapons,34
+Downtown,271082,2007,Aggravated Assault,104
+Downtown,271082,2007,Arson,8
+Downtown,271082,2007,"Assault, Simple",227
+Downtown,271082,2007,Burglary,114
+Downtown,271082,2007,Curfew,13
+Downtown,271082,2007,Disorderly Conduct,260
+Downtown,271082,2007,Drugs,248
+Downtown,271082,2007,DUII,139
+Downtown,271082,2007,Embezzlement,17
+Downtown,271082,2007,Forgery,52
+Downtown,271082,2007,Fraud,140
+Downtown,271082,2007,Gambling,2
+Downtown,271082,2007,Homicide,2
+Downtown,271082,2007,Kidnap,1
+Downtown,271082,2007,Larceny,1781
+Downtown,271082,2007,Liquor Laws,372
+Downtown,271082,2007,Motor Vehicle Theft,198
+Downtown,271082,2007,Offenses Against Family,
+Downtown,271082,2007,Prostitution,25
+Downtown,271082,2007,Rape,2
+Downtown,271082,2007,Robbery,101
+Downtown,271082,2007,Runaway,
+Downtown,271082,2007,Sex Offenses,3
+Downtown,271082,2007,Stolen Property,3
+Downtown,271082,2007,Trespass,323
+Downtown,271082,2007,Vandalism,383
+Downtown,271082,2007,Weapons,22
+Downtown,271082,2008,Aggravated Assault,74
+Downtown,271082,2008,Arson,7
+Downtown,271082,2008,"Assault, Simple",230
+Downtown,271082,2008,Burglary,120
+Downtown,271082,2008,Curfew,11
+Downtown,271082,2008,Disorderly Conduct,279
+Downtown,271082,2008,Drugs,209
+Downtown,271082,2008,DUII,108
+Downtown,271082,2008,Embezzlement,29
+Downtown,271082,2008,Forgery,34
+Downtown,271082,2008,Fraud,119
+Downtown,271082,2008,Gambling,1
+Downtown,271082,2008,Homicide,
+Downtown,271082,2008,Kidnap,1
+Downtown,271082,2008,Larceny,1637
+Downtown,271082,2008,Liquor Laws,513
+Downtown,271082,2008,Motor Vehicle Theft,121
+Downtown,271082,2008,Offenses Against Family,
+Downtown,271082,2008,Prostitution,
+Downtown,271082,2008,Rape,1
+Downtown,271082,2008,Robbery,96
+Downtown,271082,2008,Runaway,1
+Downtown,271082,2008,Sex Offenses,5
+Downtown,271082,2008,Stolen Property,6
+Downtown,271082,2008,Trespass,340
+Downtown,271082,2008,Vandalism,280
+Downtown,271082,2008,Weapons,17
+Downtown,271082,2009,Aggravated Assault,72
+Downtown,271082,2009,Arson,1
+Downtown,271082,2009,"Assault, Simple",211
+Downtown,271082,2009,Burglary,66
+Downtown,271082,2009,Curfew,2
+Downtown,271082,2009,Disorderly Conduct,314
+Downtown,271082,2009,Drugs,240
+Downtown,271082,2009,DUII,91
+Downtown,271082,2009,Embezzlement,11
+Downtown,271082,2009,Forgery,41
+Downtown,271082,2009,Fraud,98
+Downtown,271082,2009,Gambling,
+Downtown,271082,2009,Homicide,1
+Downtown,271082,2009,Kidnap,1
+Downtown,271082,2009,Larceny,1284
+Downtown,271082,2009,Liquor Laws,589
+Downtown,271082,2009,Motor Vehicle Theft,94
+Downtown,271082,2009,Offenses Against Family,
+Downtown,271082,2009,Prostitution,8
+Downtown,271082,2009,Rape,1
+Downtown,271082,2009,Robbery,89
+Downtown,271082,2009,Runaway,
+Downtown,271082,2009,Sex Offenses,7
+Downtown,271082,2009,Stolen Property,9
+Downtown,271082,2009,Trespass,250
+Downtown,271082,2009,Vandalism,205
+Downtown,271082,2009,Weapons,16
+Downtown,271082,2010,Aggravated Assault,101
+Downtown,271082,2010,Arson,4
+Downtown,271082,2010,"Assault, Simple",178
+Downtown,271082,2010,Burglary,83
+Downtown,271082,2010,Curfew,1
+Downtown,271082,2010,Disorderly Conduct,270
+Downtown,271082,2010,Drugs,264
+Downtown,271082,2010,DUII,63
+Downtown,271082,2010,Embezzlement,17
+Downtown,271082,2010,Forgery,45
+Downtown,271082,2010,Fraud,93
+Downtown,271082,2010,Gambling,
+Downtown,271082,2010,Homicide,
+Downtown,271082,2010,Kidnap,2
+Downtown,271082,2010,Larceny,1377
+Downtown,271082,2010,Liquor Laws,525
+Downtown,271082,2010,Motor Vehicle Theft,100
+Downtown,271082,2010,Offenses Against Family,
+Downtown,271082,2010,Prostitution,2
+Downtown,271082,2010,Rape,2
+Downtown,271082,2010,Robbery,78
+Downtown,271082,2010,Runaway,1
+Downtown,271082,2010,Sex Offenses,9
+Downtown,271082,2010,Stolen Property,5
+Downtown,271082,2010,Trespass,249
+Downtown,271082,2010,Vandalism,224
+Downtown,271082,2010,Weapons,24
+Downtown,271082,2011,Aggravated Assault,74
+Downtown,271082,2011,Arson,6
+Downtown,271082,2011,"Assault, Simple",209
+Downtown,271082,2011,Burglary,66
+Downtown,271082,2011,Curfew,2
+Downtown,271082,2011,Disorderly Conduct,421
+Downtown,271082,2011,Drugs,370
+Downtown,271082,2011,DUII,91
+Downtown,271082,2011,Embezzlement,16
+Downtown,271082,2011,Forgery,51
+Downtown,271082,2011,Fraud,71
+Downtown,271082,2011,Gambling,
+Downtown,271082,2011,Homicide,2
+Downtown,271082,2011,Kidnap,1
+Downtown,271082,2011,Larceny,1540
+Downtown,271082,2011,Liquor Laws,602
+Downtown,271082,2011,Motor Vehicle Theft,84
+Downtown,271082,2011,Offenses Against Family,
+Downtown,271082,2011,Prostitution,
+Downtown,271082,2011,Rape,1
+Downtown,271082,2011,Robbery,88
+Downtown,271082,2011,Runaway,
+Downtown,271082,2011,Sex Offenses,6
+Downtown,271082,2011,Stolen Property,2
+Downtown,271082,2011,Trespass,383
+Downtown,271082,2011,Vandalism,225
+Downtown,271082,2011,Weapons,28
+Downtown,271082,2012,Aggravated Assault,94
+Downtown,271082,2012,Arson,7
+Downtown,271082,2012,"Assault, Simple",228
+Downtown,271082,2012,Burglary,57
+Downtown,271082,2012,Curfew,
+Downtown,271082,2012,Disorderly Conduct,326
+Downtown,271082,2012,Drugs,510
+Downtown,271082,2012,DUII,90
+Downtown,271082,2012,Embezzlement,9
+Downtown,271082,2012,Forgery,34
+Downtown,271082,2012,Fraud,98
+Downtown,271082,2012,Gambling,
+Downtown,271082,2012,Homicide,1
+Downtown,271082,2012,Kidnap,2
+Downtown,271082,2012,Larceny,1396
+Downtown,271082,2012,Liquor Laws,810
+Downtown,271082,2012,Motor Vehicle Theft,71
+Downtown,271082,2012,Offenses Against Family,1
+Downtown,271082,2012,Prostitution,1
+Downtown,271082,2012,Rape,3
+Downtown,271082,2012,Robbery,83
+Downtown,271082,2012,Runaway,
+Downtown,271082,2012,Sex Offenses,10
+Downtown,271082,2012,Stolen Property,6
+Downtown,271082,2012,Trespass,353
+Downtown,271082,2012,Vandalism,219
+Downtown,271082,2012,Weapons,20
+Downtown,271082,2013,Aggravated Assault,78
+Downtown,271082,2013,Arson,1
+Downtown,271082,2013,"Assault, Simple",194
+Downtown,271082,2013,Burglary,79
+Downtown,271082,2013,Curfew,2
+Downtown,271082,2013,Disorderly Conduct,451
+Downtown,271082,2013,Drugs,492
+Downtown,271082,2013,DUII,75
+Downtown,271082,2013,Embezzlement,12
+Downtown,271082,2013,Forgery,42
+Downtown,271082,2013,Fraud,91
+Downtown,271082,2013,Gambling,
+Downtown,271082,2013,Homicide,
+Downtown,271082,2013,Kidnap,
+Downtown,271082,2013,Larceny,1425
+Downtown,271082,2013,Liquor Laws,714
+Downtown,271082,2013,Motor Vehicle Theft,87
+Downtown,271082,2013,Offenses Against Family,1
+Downtown,271082,2013,Prostitution,8
+Downtown,271082,2013,Rape,1
+Downtown,271082,2013,Robbery,68
+Downtown,271082,2013,Runaway,
+Downtown,271082,2013,Sex Offenses,4
+Downtown,271082,2013,Stolen Property,8
+Downtown,271082,2013,Trespass,344
+Downtown,271082,2013,Vandalism,202
+Downtown,271082,2013,Weapons,21
+Downtown,271082,2014,Aggravated Assault,69
+Downtown,271082,2014,Arson,
+Downtown,271082,2014,"Assault, Simple",228
+Downtown,271082,2014,Burglary,99
+Downtown,271082,2014,Curfew,3
+Downtown,271082,2014,Disorderly Conduct,482
+Downtown,271082,2014,Drugs,377
+Downtown,271082,2014,DUII,54
+Downtown,271082,2014,Embezzlement,12
+Downtown,271082,2014,Forgery,34
+Downtown,271082,2014,Fraud,131
+Downtown,271082,2014,Gambling,
+Downtown,271082,2014,Homicide,1
+Downtown,271082,2014,Kidnap,
+Downtown,271082,2014,Larceny,2027
+Downtown,271082,2014,Liquor Laws,615
+Downtown,271082,2014,Motor Vehicle Theft,84
+Downtown,271082,2014,Offenses Against Family,1
+Downtown,271082,2014,Prostitution,
+Downtown,271082,2014,Rape,4
+Downtown,271082,2014,Robbery,66
+Downtown,271082,2014,Runaway,1
+Downtown,271082,2014,Sex Offenses,14
+Downtown,271082,2014,Stolen Property,8
+Downtown,271082,2014,Trespass,281
+Downtown,271082,2014,Vandalism,218
+Downtown,271082,2014,Weapons,24
+Eastmoreland,206780,2004,Aggravated Assault,
+Eastmoreland,206780,2004,Arson,
+Eastmoreland,206780,2004,"Assault, Simple",
+Eastmoreland,206780,2004,Burglary,17
+Eastmoreland,206780,2004,Curfew,
+Eastmoreland,206780,2004,Disorderly Conduct,
+Eastmoreland,206780,2004,Drugs,
+Eastmoreland,206780,2004,DUII,2
+Eastmoreland,206780,2004,Embezzlement,
+Eastmoreland,206780,2004,Forgery,
+Eastmoreland,206780,2004,Fraud,4
+Eastmoreland,206780,2004,Gambling,
+Eastmoreland,206780,2004,Homicide,
+Eastmoreland,206780,2004,Kidnap,
+Eastmoreland,206780,2004,Larceny,35
+Eastmoreland,206780,2004,Liquor Laws,1
+Eastmoreland,206780,2004,Motor Vehicle Theft,3
+Eastmoreland,206780,2004,Offenses Against Family,
+Eastmoreland,206780,2004,Prostitution,
+Eastmoreland,206780,2004,Rape,
+Eastmoreland,206780,2004,Robbery,
+Eastmoreland,206780,2004,Runaway,
+Eastmoreland,206780,2004,Sex Offenses,
+Eastmoreland,206780,2004,Stolen Property,
+Eastmoreland,206780,2004,Trespass,2
+Eastmoreland,206780,2004,Vandalism,7
+Eastmoreland,206780,2004,Weapons,
+Eastmoreland,206780,2005,Aggravated Assault,5
+Eastmoreland,206780,2005,Arson,
+Eastmoreland,206780,2005,"Assault, Simple",1
+Eastmoreland,206780,2005,Burglary,43
+Eastmoreland,206780,2005,Curfew,
+Eastmoreland,206780,2005,Disorderly Conduct,7
+Eastmoreland,206780,2005,Drugs,3
+Eastmoreland,206780,2005,DUII,5
+Eastmoreland,206780,2005,Embezzlement,1
+Eastmoreland,206780,2005,Forgery,1
+Eastmoreland,206780,2005,Fraud,7
+Eastmoreland,206780,2005,Gambling,
+Eastmoreland,206780,2005,Homicide,
+Eastmoreland,206780,2005,Kidnap,
+Eastmoreland,206780,2005,Larceny,215
+Eastmoreland,206780,2005,Liquor Laws,6
+Eastmoreland,206780,2005,Motor Vehicle Theft,17
+Eastmoreland,206780,2005,Offenses Against Family,
+Eastmoreland,206780,2005,Prostitution,
+Eastmoreland,206780,2005,Rape,
+Eastmoreland,206780,2005,Robbery,
+Eastmoreland,206780,2005,Runaway,
+Eastmoreland,206780,2005,Sex Offenses,1
+Eastmoreland,206780,2005,Stolen Property,
+Eastmoreland,206780,2005,Trespass,2
+Eastmoreland,206780,2005,Vandalism,38
+Eastmoreland,206780,2005,Weapons,
+Eastmoreland,206780,2006,Aggravated Assault,3
+Eastmoreland,206780,2006,Arson,1
+Eastmoreland,206780,2006,"Assault, Simple",2
+Eastmoreland,206780,2006,Burglary,36
+Eastmoreland,206780,2006,Curfew,
+Eastmoreland,206780,2006,Disorderly Conduct,3
+Eastmoreland,206780,2006,Drugs,2
+Eastmoreland,206780,2006,DUII,5
+Eastmoreland,206780,2006,Embezzlement,
+Eastmoreland,206780,2006,Forgery,1
+Eastmoreland,206780,2006,Fraud,11
+Eastmoreland,206780,2006,Gambling,
+Eastmoreland,206780,2006,Homicide,
+Eastmoreland,206780,2006,Kidnap,
+Eastmoreland,206780,2006,Larceny,141
+Eastmoreland,206780,2006,Liquor Laws,7
+Eastmoreland,206780,2006,Motor Vehicle Theft,25
+Eastmoreland,206780,2006,Offenses Against Family,
+Eastmoreland,206780,2006,Prostitution,
+Eastmoreland,206780,2006,Rape,
+Eastmoreland,206780,2006,Robbery,1
+Eastmoreland,206780,2006,Runaway,
+Eastmoreland,206780,2006,Sex Offenses,
+Eastmoreland,206780,2006,Stolen Property,
+Eastmoreland,206780,2006,Trespass,10
+Eastmoreland,206780,2006,Vandalism,40
+Eastmoreland,206780,2006,Weapons,
+Eastmoreland,206780,2007,Aggravated Assault,3
+Eastmoreland,206780,2007,Arson,
+Eastmoreland,206780,2007,"Assault, Simple",
+Eastmoreland,206780,2007,Burglary,32
+Eastmoreland,206780,2007,Curfew,
+Eastmoreland,206780,2007,Disorderly Conduct,1
+Eastmoreland,206780,2007,Drugs,2
+Eastmoreland,206780,2007,DUII,7
+Eastmoreland,206780,2007,Embezzlement,
+Eastmoreland,206780,2007,Forgery,1
+Eastmoreland,206780,2007,Fraud,6
+Eastmoreland,206780,2007,Gambling,
+Eastmoreland,206780,2007,Homicide,
+Eastmoreland,206780,2007,Kidnap,
+Eastmoreland,206780,2007,Larceny,159
+Eastmoreland,206780,2007,Liquor Laws,1
+Eastmoreland,206780,2007,Motor Vehicle Theft,27
+Eastmoreland,206780,2007,Offenses Against Family,
+Eastmoreland,206780,2007,Prostitution,
+Eastmoreland,206780,2007,Rape,
+Eastmoreland,206780,2007,Robbery,
+Eastmoreland,206780,2007,Runaway,
+Eastmoreland,206780,2007,Sex Offenses,
+Eastmoreland,206780,2007,Stolen Property,
+Eastmoreland,206780,2007,Trespass,2
+Eastmoreland,206780,2007,Vandalism,39
+Eastmoreland,206780,2007,Weapons,1
+Eastmoreland,206780,2008,Aggravated Assault,5
+Eastmoreland,206780,2008,Arson,
+Eastmoreland,206780,2008,"Assault, Simple",3
+Eastmoreland,206780,2008,Burglary,22
+Eastmoreland,206780,2008,Curfew,
+Eastmoreland,206780,2008,Disorderly Conduct,7
+Eastmoreland,206780,2008,Drugs,4
+Eastmoreland,206780,2008,DUII,7
+Eastmoreland,206780,2008,Embezzlement,
+Eastmoreland,206780,2008,Forgery,2
+Eastmoreland,206780,2008,Fraud,8
+Eastmoreland,206780,2008,Gambling,
+Eastmoreland,206780,2008,Homicide,
+Eastmoreland,206780,2008,Kidnap,
+Eastmoreland,206780,2008,Larceny,111
+Eastmoreland,206780,2008,Liquor Laws,
+Eastmoreland,206780,2008,Motor Vehicle Theft,10
+Eastmoreland,206780,2008,Offenses Against Family,
+Eastmoreland,206780,2008,Prostitution,
+Eastmoreland,206780,2008,Rape,
+Eastmoreland,206780,2008,Robbery,1
+Eastmoreland,206780,2008,Runaway,
+Eastmoreland,206780,2008,Sex Offenses,
+Eastmoreland,206780,2008,Stolen Property,1
+Eastmoreland,206780,2008,Trespass,3
+Eastmoreland,206780,2008,Vandalism,26
+Eastmoreland,206780,2008,Weapons,
+Eastmoreland,206780,2009,Aggravated Assault,2
+Eastmoreland,206780,2009,Arson,
+Eastmoreland,206780,2009,"Assault, Simple",3
+Eastmoreland,206780,2009,Burglary,30
+Eastmoreland,206780,2009,Curfew,
+Eastmoreland,206780,2009,Disorderly Conduct,7
+Eastmoreland,206780,2009,Drugs,3
+Eastmoreland,206780,2009,DUII,5
+Eastmoreland,206780,2009,Embezzlement,
+Eastmoreland,206780,2009,Forgery,
+Eastmoreland,206780,2009,Fraud,6
+Eastmoreland,206780,2009,Gambling,
+Eastmoreland,206780,2009,Homicide,
+Eastmoreland,206780,2009,Kidnap,
+Eastmoreland,206780,2009,Larceny,88
+Eastmoreland,206780,2009,Liquor Laws,
+Eastmoreland,206780,2009,Motor Vehicle Theft,5
+Eastmoreland,206780,2009,Offenses Against Family,
+Eastmoreland,206780,2009,Prostitution,
+Eastmoreland,206780,2009,Rape,
+Eastmoreland,206780,2009,Robbery,
+Eastmoreland,206780,2009,Runaway,
+Eastmoreland,206780,2009,Sex Offenses,1
+Eastmoreland,206780,2009,Stolen Property,
+Eastmoreland,206780,2009,Trespass,2
+Eastmoreland,206780,2009,Vandalism,19
+Eastmoreland,206780,2009,Weapons,
+Eastmoreland,206780,2010,Aggravated Assault,
+Eastmoreland,206780,2010,Arson,
+Eastmoreland,206780,2010,"Assault, Simple",2
+Eastmoreland,206780,2010,Burglary,35
+Eastmoreland,206780,2010,Curfew,
+Eastmoreland,206780,2010,Disorderly Conduct,3
+Eastmoreland,206780,2010,Drugs,1
+Eastmoreland,206780,2010,DUII,6
+Eastmoreland,206780,2010,Embezzlement,
+Eastmoreland,206780,2010,Forgery,
+Eastmoreland,206780,2010,Fraud,4
+Eastmoreland,206780,2010,Gambling,
+Eastmoreland,206780,2010,Homicide,
+Eastmoreland,206780,2010,Kidnap,
+Eastmoreland,206780,2010,Larceny,120
+Eastmoreland,206780,2010,Liquor Laws,
+Eastmoreland,206780,2010,Motor Vehicle Theft,14
+Eastmoreland,206780,2010,Offenses Against Family,
+Eastmoreland,206780,2010,Prostitution,
+Eastmoreland,206780,2010,Rape,
+Eastmoreland,206780,2010,Robbery,2
+Eastmoreland,206780,2010,Runaway,
+Eastmoreland,206780,2010,Sex Offenses,1
+Eastmoreland,206780,2010,Stolen Property,
+Eastmoreland,206780,2010,Trespass,1
+Eastmoreland,206780,2010,Vandalism,13
+Eastmoreland,206780,2010,Weapons,
+Eastmoreland,206780,2011,Aggravated Assault,1
+Eastmoreland,206780,2011,Arson,
+Eastmoreland,206780,2011,"Assault, Simple",1
+Eastmoreland,206780,2011,Burglary,46
+Eastmoreland,206780,2011,Curfew,
+Eastmoreland,206780,2011,Disorderly Conduct,3
+Eastmoreland,206780,2011,Drugs,1
+Eastmoreland,206780,2011,DUII,9
+Eastmoreland,206780,2011,Embezzlement,
+Eastmoreland,206780,2011,Forgery,
+Eastmoreland,206780,2011,Fraud,3
+Eastmoreland,206780,2011,Gambling,
+Eastmoreland,206780,2011,Homicide,
+Eastmoreland,206780,2011,Kidnap,
+Eastmoreland,206780,2011,Larceny,134
+Eastmoreland,206780,2011,Liquor Laws,
+Eastmoreland,206780,2011,Motor Vehicle Theft,6
+Eastmoreland,206780,2011,Offenses Against Family,
+Eastmoreland,206780,2011,Prostitution,
+Eastmoreland,206780,2011,Rape,
+Eastmoreland,206780,2011,Robbery,3
+Eastmoreland,206780,2011,Runaway,
+Eastmoreland,206780,2011,Sex Offenses,
+Eastmoreland,206780,2011,Stolen Property,
+Eastmoreland,206780,2011,Trespass,4
+Eastmoreland,206780,2011,Vandalism,29
+Eastmoreland,206780,2011,Weapons,
+Eastmoreland,206780,2012,Aggravated Assault,
+Eastmoreland,206780,2012,Arson,
+Eastmoreland,206780,2012,"Assault, Simple",2
+Eastmoreland,206780,2012,Burglary,35
+Eastmoreland,206780,2012,Curfew,
+Eastmoreland,206780,2012,Disorderly Conduct,6
+Eastmoreland,206780,2012,Drugs,
+Eastmoreland,206780,2012,DUII,5
+Eastmoreland,206780,2012,Embezzlement,
+Eastmoreland,206780,2012,Forgery,1
+Eastmoreland,206780,2012,Fraud,1
+Eastmoreland,206780,2012,Gambling,
+Eastmoreland,206780,2012,Homicide,
+Eastmoreland,206780,2012,Kidnap,
+Eastmoreland,206780,2012,Larceny,101
+Eastmoreland,206780,2012,Liquor Laws,1
+Eastmoreland,206780,2012,Motor Vehicle Theft,15
+Eastmoreland,206780,2012,Offenses Against Family,
+Eastmoreland,206780,2012,Prostitution,
+Eastmoreland,206780,2012,Rape,
+Eastmoreland,206780,2012,Robbery,
+Eastmoreland,206780,2012,Runaway,
+Eastmoreland,206780,2012,Sex Offenses,
+Eastmoreland,206780,2012,Stolen Property,
+Eastmoreland,206780,2012,Trespass,3
+Eastmoreland,206780,2012,Vandalism,20
+Eastmoreland,206780,2012,Weapons,
+Eastmoreland,206780,2013,Aggravated Assault,
+Eastmoreland,206780,2013,Arson,
+Eastmoreland,206780,2013,"Assault, Simple",1
+Eastmoreland,206780,2013,Burglary,49
+Eastmoreland,206780,2013,Curfew,
+Eastmoreland,206780,2013,Disorderly Conduct,3
+Eastmoreland,206780,2013,Drugs,2
+Eastmoreland,206780,2013,DUII,3
+Eastmoreland,206780,2013,Embezzlement,
+Eastmoreland,206780,2013,Forgery,
+Eastmoreland,206780,2013,Fraud,
+Eastmoreland,206780,2013,Gambling,
+Eastmoreland,206780,2013,Homicide,
+Eastmoreland,206780,2013,Kidnap,
+Eastmoreland,206780,2013,Larceny,116
+Eastmoreland,206780,2013,Liquor Laws,
+Eastmoreland,206780,2013,Motor Vehicle Theft,5
+Eastmoreland,206780,2013,Offenses Against Family,
+Eastmoreland,206780,2013,Prostitution,
+Eastmoreland,206780,2013,Rape,
+Eastmoreland,206780,2013,Robbery,
+Eastmoreland,206780,2013,Runaway,
+Eastmoreland,206780,2013,Sex Offenses,
+Eastmoreland,206780,2013,Stolen Property,
+Eastmoreland,206780,2013,Trespass,4
+Eastmoreland,206780,2013,Vandalism,15
+Eastmoreland,206780,2013,Weapons,
+Eastmoreland,206780,2014,Aggravated Assault,
+Eastmoreland,206780,2014,Arson,
+Eastmoreland,206780,2014,"Assault, Simple",3
+Eastmoreland,206780,2014,Burglary,47
+Eastmoreland,206780,2014,Curfew,
+Eastmoreland,206780,2014,Disorderly Conduct,3
+Eastmoreland,206780,2014,Drugs,
+Eastmoreland,206780,2014,DUII,3
+Eastmoreland,206780,2014,Embezzlement,
+Eastmoreland,206780,2014,Forgery,
+Eastmoreland,206780,2014,Fraud,8
+Eastmoreland,206780,2014,Gambling,
+Eastmoreland,206780,2014,Homicide,1
+Eastmoreland,206780,2014,Kidnap,
+Eastmoreland,206780,2014,Larceny,118
+Eastmoreland,206780,2014,Liquor Laws,
+Eastmoreland,206780,2014,Motor Vehicle Theft,14
+Eastmoreland,206780,2014,Offenses Against Family,
+Eastmoreland,206780,2014,Prostitution,
+Eastmoreland,206780,2014,Rape,
+Eastmoreland,206780,2014,Robbery,
+Eastmoreland,206780,2014,Runaway,
+Eastmoreland,206780,2014,Sex Offenses,
+Eastmoreland,206780,2014,Stolen Property,
+Eastmoreland,206780,2014,Trespass,4
+Eastmoreland,206780,2014,Vandalism,8
+Eastmoreland,206780,2014,Weapons,
+Eliot,271085,2004,Aggravated Assault,6
+Eliot,271085,2004,Arson,
+Eliot,271085,2004,"Assault, Simple",10
+Eliot,271085,2004,Burglary,23
+Eliot,271085,2004,Curfew,
+Eliot,271085,2004,Disorderly Conduct,6
+Eliot,271085,2004,Drugs,6
+Eliot,271085,2004,DUII,8
+Eliot,271085,2004,Embezzlement,2
+Eliot,271085,2004,Forgery,5
+Eliot,271085,2004,Fraud,10
+Eliot,271085,2004,Gambling,
+Eliot,271085,2004,Homicide,
+Eliot,271085,2004,Kidnap,
+Eliot,271085,2004,Larceny,96
+Eliot,271085,2004,Liquor Laws,
+Eliot,271085,2004,Motor Vehicle Theft,20
+Eliot,271085,2004,Offenses Against Family,
+Eliot,271085,2004,Prostitution,
+Eliot,271085,2004,Rape,
+Eliot,271085,2004,Robbery,4
+Eliot,271085,2004,Runaway,
+Eliot,271085,2004,Sex Offenses,
+Eliot,271085,2004,Stolen Property,
+Eliot,271085,2004,Trespass,15
+Eliot,271085,2004,Vandalism,16
+Eliot,271085,2004,Weapons,2
+Eliot,271085,2005,Aggravated Assault,16
+Eliot,271085,2005,Arson,1
+Eliot,271085,2005,"Assault, Simple",49
+Eliot,271085,2005,Burglary,67
+Eliot,271085,2005,Curfew,1
+Eliot,271085,2005,Disorderly Conduct,33
+Eliot,271085,2005,Drugs,41
+Eliot,271085,2005,DUII,30
+Eliot,271085,2005,Embezzlement,5
+Eliot,271085,2005,Forgery,14
+Eliot,271085,2005,Fraud,62
+Eliot,271085,2005,Gambling,
+Eliot,271085,2005,Homicide,
+Eliot,271085,2005,Kidnap,1
+Eliot,271085,2005,Larceny,281
+Eliot,271085,2005,Liquor Laws,22
+Eliot,271085,2005,Motor Vehicle Theft,56
+Eliot,271085,2005,Offenses Against Family,
+Eliot,271085,2005,Prostitution,1
+Eliot,271085,2005,Rape,2
+Eliot,271085,2005,Robbery,20
+Eliot,271085,2005,Runaway,
+Eliot,271085,2005,Sex Offenses,1
+Eliot,271085,2005,Stolen Property,
+Eliot,271085,2005,Trespass,28
+Eliot,271085,2005,Vandalism,72
+Eliot,271085,2005,Weapons,6
+Eliot,271085,2006,Aggravated Assault,28
+Eliot,271085,2006,Arson,
+Eliot,271085,2006,"Assault, Simple",37
+Eliot,271085,2006,Burglary,86
+Eliot,271085,2006,Curfew,2
+Eliot,271085,2006,Disorderly Conduct,38
+Eliot,271085,2006,Drugs,34
+Eliot,271085,2006,DUII,30
+Eliot,271085,2006,Embezzlement,2
+Eliot,271085,2006,Forgery,12
+Eliot,271085,2006,Fraud,51
+Eliot,271085,2006,Gambling,1
+Eliot,271085,2006,Homicide,
+Eliot,271085,2006,Kidnap,
+Eliot,271085,2006,Larceny,289
+Eliot,271085,2006,Liquor Laws,10
+Eliot,271085,2006,Motor Vehicle Theft,53
+Eliot,271085,2006,Offenses Against Family,
+Eliot,271085,2006,Prostitution,
+Eliot,271085,2006,Rape,2
+Eliot,271085,2006,Robbery,8
+Eliot,271085,2006,Runaway,
+Eliot,271085,2006,Sex Offenses,
+Eliot,271085,2006,Stolen Property,
+Eliot,271085,2006,Trespass,47
+Eliot,271085,2006,Vandalism,91
+Eliot,271085,2006,Weapons,
+Eliot,271085,2007,Aggravated Assault,18
+Eliot,271085,2007,Arson,4
+Eliot,271085,2007,"Assault, Simple",36
+Eliot,271085,2007,Burglary,80
+Eliot,271085,2007,Curfew,2
+Eliot,271085,2007,Disorderly Conduct,29
+Eliot,271085,2007,Drugs,38
+Eliot,271085,2007,DUII,35
+Eliot,271085,2007,Embezzlement,3
+Eliot,271085,2007,Forgery,23
+Eliot,271085,2007,Fraud,26
+Eliot,271085,2007,Gambling,
+Eliot,271085,2007,Homicide,1
+Eliot,271085,2007,Kidnap,
+Eliot,271085,2007,Larceny,218
+Eliot,271085,2007,Liquor Laws,23
+Eliot,271085,2007,Motor Vehicle Theft,64
+Eliot,271085,2007,Offenses Against Family,
+Eliot,271085,2007,Prostitution,
+Eliot,271085,2007,Rape,
+Eliot,271085,2007,Robbery,20
+Eliot,271085,2007,Runaway,1
+Eliot,271085,2007,Sex Offenses,1
+Eliot,271085,2007,Stolen Property,
+Eliot,271085,2007,Trespass,35
+Eliot,271085,2007,Vandalism,88
+Eliot,271085,2007,Weapons,1
+Eliot,271085,2008,Aggravated Assault,23
+Eliot,271085,2008,Arson,
+Eliot,271085,2008,"Assault, Simple",39
+Eliot,271085,2008,Burglary,47
+Eliot,271085,2008,Curfew,1
+Eliot,271085,2008,Disorderly Conduct,25
+Eliot,271085,2008,Drugs,36
+Eliot,271085,2008,DUII,43
+Eliot,271085,2008,Embezzlement,5
+Eliot,271085,2008,Forgery,8
+Eliot,271085,2008,Fraud,34
+Eliot,271085,2008,Gambling,
+Eliot,271085,2008,Homicide,
+Eliot,271085,2008,Kidnap,
+Eliot,271085,2008,Larceny,214
+Eliot,271085,2008,Liquor Laws,39
+Eliot,271085,2008,Motor Vehicle Theft,54
+Eliot,271085,2008,Offenses Against Family,
+Eliot,271085,2008,Prostitution,
+Eliot,271085,2008,Rape,
+Eliot,271085,2008,Robbery,15
+Eliot,271085,2008,Runaway,
+Eliot,271085,2008,Sex Offenses,
+Eliot,271085,2008,Stolen Property,
+Eliot,271085,2008,Trespass,37
+Eliot,271085,2008,Vandalism,59
+Eliot,271085,2008,Weapons,2
+Eliot,271085,2009,Aggravated Assault,13
+Eliot,271085,2009,Arson,
+Eliot,271085,2009,"Assault, Simple",34
+Eliot,271085,2009,Burglary,67
+Eliot,271085,2009,Curfew,2
+Eliot,271085,2009,Disorderly Conduct,45
+Eliot,271085,2009,Drugs,37
+Eliot,271085,2009,DUII,30
+Eliot,271085,2009,Embezzlement,6
+Eliot,271085,2009,Forgery,9
+Eliot,271085,2009,Fraud,20
+Eliot,271085,2009,Gambling,
+Eliot,271085,2009,Homicide,
+Eliot,271085,2009,Kidnap,
+Eliot,271085,2009,Larceny,296
+Eliot,271085,2009,Liquor Laws,71
+Eliot,271085,2009,Motor Vehicle Theft,37
+Eliot,271085,2009,Offenses Against Family,
+Eliot,271085,2009,Prostitution,
+Eliot,271085,2009,Rape,
+Eliot,271085,2009,Robbery,14
+Eliot,271085,2009,Runaway,1
+Eliot,271085,2009,Sex Offenses,1
+Eliot,271085,2009,Stolen Property,1
+Eliot,271085,2009,Trespass,31
+Eliot,271085,2009,Vandalism,70
+Eliot,271085,2009,Weapons,7
+Eliot,271085,2010,Aggravated Assault,22
+Eliot,271085,2010,Arson,
+Eliot,271085,2010,"Assault, Simple",35
+Eliot,271085,2010,Burglary,27
+Eliot,271085,2010,Curfew,
+Eliot,271085,2010,Disorderly Conduct,58
+Eliot,271085,2010,Drugs,29
+Eliot,271085,2010,DUII,24
+Eliot,271085,2010,Embezzlement,2
+Eliot,271085,2010,Forgery,10
+Eliot,271085,2010,Fraud,15
+Eliot,271085,2010,Gambling,
+Eliot,271085,2010,Homicide,
+Eliot,271085,2010,Kidnap,
+Eliot,271085,2010,Larceny,314
+Eliot,271085,2010,Liquor Laws,143
+Eliot,271085,2010,Motor Vehicle Theft,39
+Eliot,271085,2010,Offenses Against Family,
+Eliot,271085,2010,Prostitution,
+Eliot,271085,2010,Rape,
+Eliot,271085,2010,Robbery,12
+Eliot,271085,2010,Runaway,
+Eliot,271085,2010,Sex Offenses,1
+Eliot,271085,2010,Stolen Property,1
+Eliot,271085,2010,Trespass,36
+Eliot,271085,2010,Vandalism,60
+Eliot,271085,2010,Weapons,4
+Eliot,271085,2011,Aggravated Assault,17
+Eliot,271085,2011,Arson,1
+Eliot,271085,2011,"Assault, Simple",40
+Eliot,271085,2011,Burglary,42
+Eliot,271085,2011,Curfew,
+Eliot,271085,2011,Disorderly Conduct,35
+Eliot,271085,2011,Drugs,33
+Eliot,271085,2011,DUII,21
+Eliot,271085,2011,Embezzlement,2
+Eliot,271085,2011,Forgery,9
+Eliot,271085,2011,Fraud,16
+Eliot,271085,2011,Gambling,
+Eliot,271085,2011,Homicide,
+Eliot,271085,2011,Kidnap,
+Eliot,271085,2011,Larceny,278
+Eliot,271085,2011,Liquor Laws,87
+Eliot,271085,2011,Motor Vehicle Theft,39
+Eliot,271085,2011,Offenses Against Family,
+Eliot,271085,2011,Prostitution,
+Eliot,271085,2011,Rape,
+Eliot,271085,2011,Robbery,10
+Eliot,271085,2011,Runaway,1
+Eliot,271085,2011,Sex Offenses,
+Eliot,271085,2011,Stolen Property,
+Eliot,271085,2011,Trespass,52
+Eliot,271085,2011,Vandalism,51
+Eliot,271085,2011,Weapons,4
+Eliot,271085,2012,Aggravated Assault,21
+Eliot,271085,2012,Arson,
+Eliot,271085,2012,"Assault, Simple",45
+Eliot,271085,2012,Burglary,42
+Eliot,271085,2012,Curfew,1
+Eliot,271085,2012,Disorderly Conduct,62
+Eliot,271085,2012,Drugs,36
+Eliot,271085,2012,DUII,32
+Eliot,271085,2012,Embezzlement,4
+Eliot,271085,2012,Forgery,7
+Eliot,271085,2012,Fraud,28
+Eliot,271085,2012,Gambling,
+Eliot,271085,2012,Homicide,
+Eliot,271085,2012,Kidnap,1
+Eliot,271085,2012,Larceny,351
+Eliot,271085,2012,Liquor Laws,123
+Eliot,271085,2012,Motor Vehicle Theft,32
+Eliot,271085,2012,Offenses Against Family,
+Eliot,271085,2012,Prostitution,
+Eliot,271085,2012,Rape,
+Eliot,271085,2012,Robbery,20
+Eliot,271085,2012,Runaway,
+Eliot,271085,2012,Sex Offenses,
+Eliot,271085,2012,Stolen Property,
+Eliot,271085,2012,Trespass,69
+Eliot,271085,2012,Vandalism,72
+Eliot,271085,2012,Weapons,4
+Eliot,271085,2013,Aggravated Assault,17
+Eliot,271085,2013,Arson,2
+Eliot,271085,2013,"Assault, Simple",37
+Eliot,271085,2013,Burglary,63
+Eliot,271085,2013,Curfew,
+Eliot,271085,2013,Disorderly Conduct,50
+Eliot,271085,2013,Drugs,26
+Eliot,271085,2013,DUII,27
+Eliot,271085,2013,Embezzlement,1
+Eliot,271085,2013,Forgery,4
+Eliot,271085,2013,Fraud,22
+Eliot,271085,2013,Gambling,
+Eliot,271085,2013,Homicide,1
+Eliot,271085,2013,Kidnap,
+Eliot,271085,2013,Larceny,322
+Eliot,271085,2013,Liquor Laws,80
+Eliot,271085,2013,Motor Vehicle Theft,50
+Eliot,271085,2013,Offenses Against Family,1
+Eliot,271085,2013,Prostitution,
+Eliot,271085,2013,Rape,1
+Eliot,271085,2013,Robbery,5
+Eliot,271085,2013,Runaway,1
+Eliot,271085,2013,Sex Offenses,
+Eliot,271085,2013,Stolen Property,
+Eliot,271085,2013,Trespass,41
+Eliot,271085,2013,Vandalism,72
+Eliot,271085,2013,Weapons,5
+Eliot,271085,2014,Aggravated Assault,18
+Eliot,271085,2014,Arson,
+Eliot,271085,2014,"Assault, Simple",39
+Eliot,271085,2014,Burglary,80
+Eliot,271085,2014,Curfew,
+Eliot,271085,2014,Disorderly Conduct,34
+Eliot,271085,2014,Drugs,23
+Eliot,271085,2014,DUII,17
+Eliot,271085,2014,Embezzlement,2
+Eliot,271085,2014,Forgery,5
+Eliot,271085,2014,Fraud,27
+Eliot,271085,2014,Gambling,
+Eliot,271085,2014,Homicide,
+Eliot,271085,2014,Kidnap,
+Eliot,271085,2014,Larceny,470
+Eliot,271085,2014,Liquor Laws,40
+Eliot,271085,2014,Motor Vehicle Theft,37
+Eliot,271085,2014,Offenses Against Family,
+Eliot,271085,2014,Prostitution,1
+Eliot,271085,2014,Rape,1
+Eliot,271085,2014,Robbery,10
+Eliot,271085,2014,Runaway,
+Eliot,271085,2014,Sex Offenses,
+Eliot,271085,2014,Stolen Property,1
+Eliot,271085,2014,Trespass,54
+Eliot,271085,2014,Vandalism,70
+Eliot,271085,2014,Weapons,1
+Far Southwest,271087,2004,Aggravated Assault,3
+Far Southwest,271087,2004,Arson,
+Far Southwest,271087,2004,"Assault, Simple",1
+Far Southwest,271087,2004,Burglary,10
+Far Southwest,271087,2004,Curfew,1
+Far Southwest,271087,2004,Disorderly Conduct,5
+Far Southwest,271087,2004,Drugs,1
+Far Southwest,271087,2004,DUII,5
+Far Southwest,271087,2004,Embezzlement,
+Far Southwest,271087,2004,Forgery,
+Far Southwest,271087,2004,Fraud,5
+Far Southwest,271087,2004,Gambling,
+Far Southwest,271087,2004,Homicide,
+Far Southwest,271087,2004,Kidnap,
+Far Southwest,271087,2004,Larceny,49
+Far Southwest,271087,2004,Liquor Laws,
+Far Southwest,271087,2004,Motor Vehicle Theft,6
+Far Southwest,271087,2004,Offenses Against Family,
+Far Southwest,271087,2004,Prostitution,
+Far Southwest,271087,2004,Rape,
+Far Southwest,271087,2004,Robbery,2
+Far Southwest,271087,2004,Runaway,
+Far Southwest,271087,2004,Sex Offenses,
+Far Southwest,271087,2004,Stolen Property,
+Far Southwest,271087,2004,Trespass,1
+Far Southwest,271087,2004,Vandalism,13
+Far Southwest,271087,2004,Weapons,
+Far Southwest,271087,2005,Aggravated Assault,9
+Far Southwest,271087,2005,Arson,
+Far Southwest,271087,2005,"Assault, Simple",19
+Far Southwest,271087,2005,Burglary,61
+Far Southwest,271087,2005,Curfew,1
+Far Southwest,271087,2005,Disorderly Conduct,36
+Far Southwest,271087,2005,Drugs,16
+Far Southwest,271087,2005,DUII,17
+Far Southwest,271087,2005,Embezzlement,2
+Far Southwest,271087,2005,Forgery,7
+Far Southwest,271087,2005,Fraud,33
+Far Southwest,271087,2005,Gambling,
+Far Southwest,271087,2005,Homicide,
+Far Southwest,271087,2005,Kidnap,
+Far Southwest,271087,2005,Larceny,317
+Far Southwest,271087,2005,Liquor Laws,5
+Far Southwest,271087,2005,Motor Vehicle Theft,17
+Far Southwest,271087,2005,Offenses Against Family,
+Far Southwest,271087,2005,Prostitution,1
+Far Southwest,271087,2005,Rape,1
+Far Southwest,271087,2005,Robbery,2
+Far Southwest,271087,2005,Runaway,
+Far Southwest,271087,2005,Sex Offenses,
+Far Southwest,271087,2005,Stolen Property,
+Far Southwest,271087,2005,Trespass,22
+Far Southwest,271087,2005,Vandalism,121
+Far Southwest,271087,2005,Weapons,2
+Far Southwest,271087,2006,Aggravated Assault,9
+Far Southwest,271087,2006,Arson,
+Far Southwest,271087,2006,"Assault, Simple",17
+Far Southwest,271087,2006,Burglary,67
+Far Southwest,271087,2006,Curfew,
+Far Southwest,271087,2006,Disorderly Conduct,24
+Far Southwest,271087,2006,Drugs,20
+Far Southwest,271087,2006,DUII,28
+Far Southwest,271087,2006,Embezzlement,2
+Far Southwest,271087,2006,Forgery,19
+Far Southwest,271087,2006,Fraud,27
+Far Southwest,271087,2006,Gambling,
+Far Southwest,271087,2006,Homicide,1
+Far Southwest,271087,2006,Kidnap,
+Far Southwest,271087,2006,Larceny,347
+Far Southwest,271087,2006,Liquor Laws,5
+Far Southwest,271087,2006,Motor Vehicle Theft,16
+Far Southwest,271087,2006,Offenses Against Family,
+Far Southwest,271087,2006,Prostitution,
+Far Southwest,271087,2006,Rape,
+Far Southwest,271087,2006,Robbery,6
+Far Southwest,271087,2006,Runaway,
+Far Southwest,271087,2006,Sex Offenses,
+Far Southwest,271087,2006,Stolen Property,
+Far Southwest,271087,2006,Trespass,24
+Far Southwest,271087,2006,Vandalism,126
+Far Southwest,271087,2006,Weapons,1
+Far Southwest,271087,2007,Aggravated Assault,11
+Far Southwest,271087,2007,Arson,1
+Far Southwest,271087,2007,"Assault, Simple",10
+Far Southwest,271087,2007,Burglary,73
+Far Southwest,271087,2007,Curfew,1
+Far Southwest,271087,2007,Disorderly Conduct,18
+Far Southwest,271087,2007,Drugs,11
+Far Southwest,271087,2007,DUII,34
+Far Southwest,271087,2007,Embezzlement,
+Far Southwest,271087,2007,Forgery,5
+Far Southwest,271087,2007,Fraud,14
+Far Southwest,271087,2007,Gambling,
+Far Southwest,271087,2007,Homicide,
+Far Southwest,271087,2007,Kidnap,1
+Far Southwest,271087,2007,Larceny,221
+Far Southwest,271087,2007,Liquor Laws,6
+Far Southwest,271087,2007,Motor Vehicle Theft,25
+Far Southwest,271087,2007,Offenses Against Family,
+Far Southwest,271087,2007,Prostitution,
+Far Southwest,271087,2007,Rape,1
+Far Southwest,271087,2007,Robbery,8
+Far Southwest,271087,2007,Runaway,
+Far Southwest,271087,2007,Sex Offenses,
+Far Southwest,271087,2007,Stolen Property,
+Far Southwest,271087,2007,Trespass,23
+Far Southwest,271087,2007,Vandalism,128
+Far Southwest,271087,2007,Weapons,1
+Far Southwest,271087,2008,Aggravated Assault,6
+Far Southwest,271087,2008,Arson,
+Far Southwest,271087,2008,"Assault, Simple",18
+Far Southwest,271087,2008,Burglary,38
+Far Southwest,271087,2008,Curfew,
+Far Southwest,271087,2008,Disorderly Conduct,26
+Far Southwest,271087,2008,Drugs,10
+Far Southwest,271087,2008,DUII,21
+Far Southwest,271087,2008,Embezzlement,5
+Far Southwest,271087,2008,Forgery,4
+Far Southwest,271087,2008,Fraud,21
+Far Southwest,271087,2008,Gambling,
+Far Southwest,271087,2008,Homicide,
+Far Southwest,271087,2008,Kidnap,
+Far Southwest,271087,2008,Larceny,254
+Far Southwest,271087,2008,Liquor Laws,4
+Far Southwest,271087,2008,Motor Vehicle Theft,9
+Far Southwest,271087,2008,Offenses Against Family,
+Far Southwest,271087,2008,Prostitution,
+Far Southwest,271087,2008,Rape,
+Far Southwest,271087,2008,Robbery,4
+Far Southwest,271087,2008,Runaway,
+Far Southwest,271087,2008,Sex Offenses,1
+Far Southwest,271087,2008,Stolen Property,
+Far Southwest,271087,2008,Trespass,21
+Far Southwest,271087,2008,Vandalism,123
+Far Southwest,271087,2008,Weapons,1
+Far Southwest,271087,2009,Aggravated Assault,15
+Far Southwest,271087,2009,Arson,
+Far Southwest,271087,2009,"Assault, Simple",11
+Far Southwest,271087,2009,Burglary,47
+Far Southwest,271087,2009,Curfew,
+Far Southwest,271087,2009,Disorderly Conduct,23
+Far Southwest,271087,2009,Drugs,9
+Far Southwest,271087,2009,DUII,20
+Far Southwest,271087,2009,Embezzlement,
+Far Southwest,271087,2009,Forgery,4
+Far Southwest,271087,2009,Fraud,19
+Far Southwest,271087,2009,Gambling,
+Far Southwest,271087,2009,Homicide,
+Far Southwest,271087,2009,Kidnap,
+Far Southwest,271087,2009,Larceny,236
+Far Southwest,271087,2009,Liquor Laws,4
+Far Southwest,271087,2009,Motor Vehicle Theft,16
+Far Southwest,271087,2009,Offenses Against Family,
+Far Southwest,271087,2009,Prostitution,
+Far Southwest,271087,2009,Rape,
+Far Southwest,271087,2009,Robbery,5
+Far Southwest,271087,2009,Runaway,
+Far Southwest,271087,2009,Sex Offenses,
+Far Southwest,271087,2009,Stolen Property,1
+Far Southwest,271087,2009,Trespass,14
+Far Southwest,271087,2009,Vandalism,134
+Far Southwest,271087,2009,Weapons,
+Far Southwest,271087,2010,Aggravated Assault,9
+Far Southwest,271087,2010,Arson,
+Far Southwest,271087,2010,"Assault, Simple",12
+Far Southwest,271087,2010,Burglary,33
+Far Southwest,271087,2010,Curfew,1
+Far Southwest,271087,2010,Disorderly Conduct,19
+Far Southwest,271087,2010,Drugs,11
+Far Southwest,271087,2010,DUII,19
+Far Southwest,271087,2010,Embezzlement,3
+Far Southwest,271087,2010,Forgery,6
+Far Southwest,271087,2010,Fraud,15
+Far Southwest,271087,2010,Gambling,
+Far Southwest,271087,2010,Homicide,
+Far Southwest,271087,2010,Kidnap,
+Far Southwest,271087,2010,Larceny,238
+Far Southwest,271087,2010,Liquor Laws,3
+Far Southwest,271087,2010,Motor Vehicle Theft,13
+Far Southwest,271087,2010,Offenses Against Family,
+Far Southwest,271087,2010,Prostitution,
+Far Southwest,271087,2010,Rape,
+Far Southwest,271087,2010,Robbery,9
+Far Southwest,271087,2010,Runaway,
+Far Southwest,271087,2010,Sex Offenses,1
+Far Southwest,271087,2010,Stolen Property,1
+Far Southwest,271087,2010,Trespass,16
+Far Southwest,271087,2010,Vandalism,132
+Far Southwest,271087,2010,Weapons,3
+Far Southwest,271087,2011,Aggravated Assault,10
+Far Southwest,271087,2011,Arson,1
+Far Southwest,271087,2011,"Assault, Simple",15
+Far Southwest,271087,2011,Burglary,56
+Far Southwest,271087,2011,Curfew,
+Far Southwest,271087,2011,Disorderly Conduct,20
+Far Southwest,271087,2011,Drugs,9
+Far Southwest,271087,2011,DUII,20
+Far Southwest,271087,2011,Embezzlement,2
+Far Southwest,271087,2011,Forgery,11
+Far Southwest,271087,2011,Fraud,16
+Far Southwest,271087,2011,Gambling,
+Far Southwest,271087,2011,Homicide,
+Far Southwest,271087,2011,Kidnap,
+Far Southwest,271087,2011,Larceny,254
+Far Southwest,271087,2011,Liquor Laws,11
+Far Southwest,271087,2011,Motor Vehicle Theft,12
+Far Southwest,271087,2011,Offenses Against Family,
+Far Southwest,271087,2011,Prostitution,
+Far Southwest,271087,2011,Rape,1
+Far Southwest,271087,2011,Robbery,7
+Far Southwest,271087,2011,Runaway,
+Far Southwest,271087,2011,Sex Offenses,
+Far Southwest,271087,2011,Stolen Property,
+Far Southwest,271087,2011,Trespass,23
+Far Southwest,271087,2011,Vandalism,119
+Far Southwest,271087,2011,Weapons,
+Far Southwest,271087,2012,Aggravated Assault,9
+Far Southwest,271087,2012,Arson,
+Far Southwest,271087,2012,"Assault, Simple",5
+Far Southwest,271087,2012,Burglary,85
+Far Southwest,271087,2012,Curfew,
+Far Southwest,271087,2012,Disorderly Conduct,24
+Far Southwest,271087,2012,Drugs,5
+Far Southwest,271087,2012,DUII,30
+Far Southwest,271087,2012,Embezzlement,2
+Far Southwest,271087,2012,Forgery,8
+Far Southwest,271087,2012,Fraud,13
+Far Southwest,271087,2012,Gambling,
+Far Southwest,271087,2012,Homicide,
+Far Southwest,271087,2012,Kidnap,
+Far Southwest,271087,2012,Larceny,258
+Far Southwest,271087,2012,Liquor Laws,1
+Far Southwest,271087,2012,Motor Vehicle Theft,44
+Far Southwest,271087,2012,Offenses Against Family,
+Far Southwest,271087,2012,Prostitution,
+Far Southwest,271087,2012,Rape,
+Far Southwest,271087,2012,Robbery,6
+Far Southwest,271087,2012,Runaway,
+Far Southwest,271087,2012,Sex Offenses,
+Far Southwest,271087,2012,Stolen Property,
+Far Southwest,271087,2012,Trespass,22
+Far Southwest,271087,2012,Vandalism,152
+Far Southwest,271087,2012,Weapons,
+Far Southwest,271087,2013,Aggravated Assault,5
+Far Southwest,271087,2013,Arson,
+Far Southwest,271087,2013,"Assault, Simple",8
+Far Southwest,271087,2013,Burglary,56
+Far Southwest,271087,2013,Curfew,
+Far Southwest,271087,2013,Disorderly Conduct,26
+Far Southwest,271087,2013,Drugs,9
+Far Southwest,271087,2013,DUII,12
+Far Southwest,271087,2013,Embezzlement,2
+Far Southwest,271087,2013,Forgery,8
+Far Southwest,271087,2013,Fraud,27
+Far Southwest,271087,2013,Gambling,
+Far Southwest,271087,2013,Homicide,1
+Far Southwest,271087,2013,Kidnap,
+Far Southwest,271087,2013,Larceny,223
+Far Southwest,271087,2013,Liquor Laws,2
+Far Southwest,271087,2013,Motor Vehicle Theft,26
+Far Southwest,271087,2013,Offenses Against Family,
+Far Southwest,271087,2013,Prostitution,
+Far Southwest,271087,2013,Rape,
+Far Southwest,271087,2013,Robbery,3
+Far Southwest,271087,2013,Runaway,
+Far Southwest,271087,2013,Sex Offenses,1
+Far Southwest,271087,2013,Stolen Property,
+Far Southwest,271087,2013,Trespass,14
+Far Southwest,271087,2013,Vandalism,142
+Far Southwest,271087,2013,Weapons,
+Far Southwest,271087,2014,Aggravated Assault,7
+Far Southwest,271087,2014,Arson,
+Far Southwest,271087,2014,"Assault, Simple",9
+Far Southwest,271087,2014,Burglary,38
+Far Southwest,271087,2014,Curfew,
+Far Southwest,271087,2014,Disorderly Conduct,15
+Far Southwest,271087,2014,Drugs,5
+Far Southwest,271087,2014,DUII,13
+Far Southwest,271087,2014,Embezzlement,3
+Far Southwest,271087,2014,Forgery,4
+Far Southwest,271087,2014,Fraud,41
+Far Southwest,271087,2014,Gambling,
+Far Southwest,271087,2014,Homicide,
+Far Southwest,271087,2014,Kidnap,
+Far Southwest,271087,2014,Larceny,169
+Far Southwest,271087,2014,Liquor Laws,1
+Far Southwest,271087,2014,Motor Vehicle Theft,12
+Far Southwest,271087,2014,Offenses Against Family,
+Far Southwest,271087,2014,Prostitution,
+Far Southwest,271087,2014,Rape,
+Far Southwest,271087,2014,Robbery,1
+Far Southwest,271087,2014,Runaway,1
+Far Southwest,271087,2014,Sex Offenses,
+Far Southwest,271087,2014,Stolen Property,
+Far Southwest,271087,2014,Trespass,13
+Far Southwest,271087,2014,Vandalism,84
+Far Southwest,271087,2014,Weapons,
+Five Oaks,271089,2004,Aggravated Assault,
+Five Oaks,271089,2004,Arson,
+Five Oaks,271089,2004,"Assault, Simple",
+Five Oaks,271089,2004,Burglary,
+Five Oaks,271089,2004,Curfew,
+Five Oaks,271089,2004,Disorderly Conduct,
+Five Oaks,271089,2004,Drugs,
+Five Oaks,271089,2004,DUII,
+Five Oaks,271089,2004,Embezzlement,
+Five Oaks,271089,2004,Forgery,
+Five Oaks,271089,2004,Fraud,
+Five Oaks,271089,2004,Gambling,
+Five Oaks,271089,2004,Homicide,
+Five Oaks,271089,2004,Kidnap,
+Five Oaks,271089,2004,Larceny,
+Five Oaks,271089,2004,Liquor Laws,
+Five Oaks,271089,2004,Motor Vehicle Theft,
+Five Oaks,271089,2004,Offenses Against Family,
+Five Oaks,271089,2004,Prostitution,
+Five Oaks,271089,2004,Rape,
+Five Oaks,271089,2004,Robbery,
+Five Oaks,271089,2004,Runaway,
+Five Oaks,271089,2004,Sex Offenses,
+Five Oaks,271089,2004,Stolen Property,
+Five Oaks,271089,2004,Trespass,
+Five Oaks,271089,2004,Vandalism,
+Five Oaks,271089,2004,Weapons,
+Five Oaks,271089,2005,Aggravated Assault,
+Five Oaks,271089,2005,Arson,
+Five Oaks,271089,2005,"Assault, Simple",
+Five Oaks,271089,2005,Burglary,
+Five Oaks,271089,2005,Curfew,
+Five Oaks,271089,2005,Disorderly Conduct,
+Five Oaks,271089,2005,Drugs,
+Five Oaks,271089,2005,DUII,
+Five Oaks,271089,2005,Embezzlement,
+Five Oaks,271089,2005,Forgery,
+Five Oaks,271089,2005,Fraud,
+Five Oaks,271089,2005,Gambling,
+Five Oaks,271089,2005,Homicide,
+Five Oaks,271089,2005,Kidnap,
+Five Oaks,271089,2005,Larceny,
+Five Oaks,271089,2005,Liquor Laws,
+Five Oaks,271089,2005,Motor Vehicle Theft,
+Five Oaks,271089,2005,Offenses Against Family,
+Five Oaks,271089,2005,Prostitution,
+Five Oaks,271089,2005,Rape,
+Five Oaks,271089,2005,Robbery,
+Five Oaks,271089,2005,Runaway,
+Five Oaks,271089,2005,Sex Offenses,
+Five Oaks,271089,2005,Stolen Property,
+Five Oaks,271089,2005,Trespass,
+Five Oaks,271089,2005,Vandalism,
+Five Oaks,271089,2005,Weapons,
+Five Oaks,271089,2006,Aggravated Assault,
+Five Oaks,271089,2006,Arson,
+Five Oaks,271089,2006,"Assault, Simple",
+Five Oaks,271089,2006,Burglary,
+Five Oaks,271089,2006,Curfew,
+Five Oaks,271089,2006,Disorderly Conduct,
+Five Oaks,271089,2006,Drugs,
+Five Oaks,271089,2006,DUII,
+Five Oaks,271089,2006,Embezzlement,
+Five Oaks,271089,2006,Forgery,
+Five Oaks,271089,2006,Fraud,
+Five Oaks,271089,2006,Gambling,
+Five Oaks,271089,2006,Homicide,
+Five Oaks,271089,2006,Kidnap,
+Five Oaks,271089,2006,Larceny,
+Five Oaks,271089,2006,Liquor Laws,
+Five Oaks,271089,2006,Motor Vehicle Theft,
+Five Oaks,271089,2006,Offenses Against Family,
+Five Oaks,271089,2006,Prostitution,
+Five Oaks,271089,2006,Rape,
+Five Oaks,271089,2006,Robbery,
+Five Oaks,271089,2006,Runaway,
+Five Oaks,271089,2006,Sex Offenses,
+Five Oaks,271089,2006,Stolen Property,
+Five Oaks,271089,2006,Trespass,
+Five Oaks,271089,2006,Vandalism,
+Five Oaks,271089,2006,Weapons,
+Five Oaks,271089,2007,Aggravated Assault,
+Five Oaks,271089,2007,Arson,
+Five Oaks,271089,2007,"Assault, Simple",
+Five Oaks,271089,2007,Burglary,
+Five Oaks,271089,2007,Curfew,
+Five Oaks,271089,2007,Disorderly Conduct,
+Five Oaks,271089,2007,Drugs,
+Five Oaks,271089,2007,DUII,
+Five Oaks,271089,2007,Embezzlement,
+Five Oaks,271089,2007,Forgery,
+Five Oaks,271089,2007,Fraud,
+Five Oaks,271089,2007,Gambling,
+Five Oaks,271089,2007,Homicide,
+Five Oaks,271089,2007,Kidnap,
+Five Oaks,271089,2007,Larceny,
+Five Oaks,271089,2007,Liquor Laws,
+Five Oaks,271089,2007,Motor Vehicle Theft,
+Five Oaks,271089,2007,Offenses Against Family,
+Five Oaks,271089,2007,Prostitution,
+Five Oaks,271089,2007,Rape,
+Five Oaks,271089,2007,Robbery,
+Five Oaks,271089,2007,Runaway,
+Five Oaks,271089,2007,Sex Offenses,
+Five Oaks,271089,2007,Stolen Property,
+Five Oaks,271089,2007,Trespass,
+Five Oaks,271089,2007,Vandalism,
+Five Oaks,271089,2007,Weapons,
+Five Oaks,271089,2008,Aggravated Assault,
+Five Oaks,271089,2008,Arson,
+Five Oaks,271089,2008,"Assault, Simple",
+Five Oaks,271089,2008,Burglary,
+Five Oaks,271089,2008,Curfew,
+Five Oaks,271089,2008,Disorderly Conduct,
+Five Oaks,271089,2008,Drugs,
+Five Oaks,271089,2008,DUII,
+Five Oaks,271089,2008,Embezzlement,
+Five Oaks,271089,2008,Forgery,
+Five Oaks,271089,2008,Fraud,
+Five Oaks,271089,2008,Gambling,
+Five Oaks,271089,2008,Homicide,
+Five Oaks,271089,2008,Kidnap,
+Five Oaks,271089,2008,Larceny,
+Five Oaks,271089,2008,Liquor Laws,
+Five Oaks,271089,2008,Motor Vehicle Theft,
+Five Oaks,271089,2008,Offenses Against Family,
+Five Oaks,271089,2008,Prostitution,
+Five Oaks,271089,2008,Rape,
+Five Oaks,271089,2008,Robbery,
+Five Oaks,271089,2008,Runaway,
+Five Oaks,271089,2008,Sex Offenses,
+Five Oaks,271089,2008,Stolen Property,
+Five Oaks,271089,2008,Trespass,
+Five Oaks,271089,2008,Vandalism,
+Five Oaks,271089,2008,Weapons,
+Five Oaks,271089,2009,Aggravated Assault,
+Five Oaks,271089,2009,Arson,
+Five Oaks,271089,2009,"Assault, Simple",
+Five Oaks,271089,2009,Burglary,
+Five Oaks,271089,2009,Curfew,
+Five Oaks,271089,2009,Disorderly Conduct,
+Five Oaks,271089,2009,Drugs,
+Five Oaks,271089,2009,DUII,
+Five Oaks,271089,2009,Embezzlement,
+Five Oaks,271089,2009,Forgery,
+Five Oaks,271089,2009,Fraud,
+Five Oaks,271089,2009,Gambling,
+Five Oaks,271089,2009,Homicide,
+Five Oaks,271089,2009,Kidnap,
+Five Oaks,271089,2009,Larceny,
+Five Oaks,271089,2009,Liquor Laws,
+Five Oaks,271089,2009,Motor Vehicle Theft,
+Five Oaks,271089,2009,Offenses Against Family,
+Five Oaks,271089,2009,Prostitution,
+Five Oaks,271089,2009,Rape,
+Five Oaks,271089,2009,Robbery,
+Five Oaks,271089,2009,Runaway,
+Five Oaks,271089,2009,Sex Offenses,
+Five Oaks,271089,2009,Stolen Property,
+Five Oaks,271089,2009,Trespass,
+Five Oaks,271089,2009,Vandalism,
+Five Oaks,271089,2009,Weapons,
+Five Oaks,271089,2010,Aggravated Assault,
+Five Oaks,271089,2010,Arson,
+Five Oaks,271089,2010,"Assault, Simple",
+Five Oaks,271089,2010,Burglary,
+Five Oaks,271089,2010,Curfew,
+Five Oaks,271089,2010,Disorderly Conduct,
+Five Oaks,271089,2010,Drugs,
+Five Oaks,271089,2010,DUII,
+Five Oaks,271089,2010,Embezzlement,
+Five Oaks,271089,2010,Forgery,
+Five Oaks,271089,2010,Fraud,
+Five Oaks,271089,2010,Gambling,
+Five Oaks,271089,2010,Homicide,
+Five Oaks,271089,2010,Kidnap,
+Five Oaks,271089,2010,Larceny,
+Five Oaks,271089,2010,Liquor Laws,
+Five Oaks,271089,2010,Motor Vehicle Theft,
+Five Oaks,271089,2010,Offenses Against Family,
+Five Oaks,271089,2010,Prostitution,
+Five Oaks,271089,2010,Rape,
+Five Oaks,271089,2010,Robbery,
+Five Oaks,271089,2010,Runaway,
+Five Oaks,271089,2010,Sex Offenses,
+Five Oaks,271089,2010,Stolen Property,
+Five Oaks,271089,2010,Trespass,
+Five Oaks,271089,2010,Vandalism,
+Five Oaks,271089,2010,Weapons,
+Five Oaks,271089,2011,Aggravated Assault,
+Five Oaks,271089,2011,Arson,
+Five Oaks,271089,2011,"Assault, Simple",
+Five Oaks,271089,2011,Burglary,
+Five Oaks,271089,2011,Curfew,
+Five Oaks,271089,2011,Disorderly Conduct,
+Five Oaks,271089,2011,Drugs,
+Five Oaks,271089,2011,DUII,
+Five Oaks,271089,2011,Embezzlement,
+Five Oaks,271089,2011,Forgery,
+Five Oaks,271089,2011,Fraud,2
+Five Oaks,271089,2011,Gambling,
+Five Oaks,271089,2011,Homicide,
+Five Oaks,271089,2011,Kidnap,
+Five Oaks,271089,2011,Larceny,
+Five Oaks,271089,2011,Liquor Laws,
+Five Oaks,271089,2011,Motor Vehicle Theft,
+Five Oaks,271089,2011,Offenses Against Family,
+Five Oaks,271089,2011,Prostitution,
+Five Oaks,271089,2011,Rape,
+Five Oaks,271089,2011,Robbery,
+Five Oaks,271089,2011,Runaway,
+Five Oaks,271089,2011,Sex Offenses,
+Five Oaks,271089,2011,Stolen Property,
+Five Oaks,271089,2011,Trespass,
+Five Oaks,271089,2011,Vandalism,
+Five Oaks,271089,2011,Weapons,
+Five Oaks,271089,2012,Aggravated Assault,
+Five Oaks,271089,2012,Arson,
+Five Oaks,271089,2012,"Assault, Simple",
+Five Oaks,271089,2012,Burglary,
+Five Oaks,271089,2012,Curfew,
+Five Oaks,271089,2012,Disorderly Conduct,
+Five Oaks,271089,2012,Drugs,1
+Five Oaks,271089,2012,DUII,
+Five Oaks,271089,2012,Embezzlement,
+Five Oaks,271089,2012,Forgery,
+Five Oaks,271089,2012,Fraud,
+Five Oaks,271089,2012,Gambling,
+Five Oaks,271089,2012,Homicide,
+Five Oaks,271089,2012,Kidnap,
+Five Oaks,271089,2012,Larceny,
+Five Oaks,271089,2012,Liquor Laws,
+Five Oaks,271089,2012,Motor Vehicle Theft,
+Five Oaks,271089,2012,Offenses Against Family,
+Five Oaks,271089,2012,Prostitution,
+Five Oaks,271089,2012,Rape,
+Five Oaks,271089,2012,Robbery,
+Five Oaks,271089,2012,Runaway,
+Five Oaks,271089,2012,Sex Offenses,
+Five Oaks,271089,2012,Stolen Property,
+Five Oaks,271089,2012,Trespass,
+Five Oaks,271089,2012,Vandalism,
+Five Oaks,271089,2012,Weapons,
+Five Oaks,271089,2013,Aggravated Assault,
+Five Oaks,271089,2013,Arson,
+Five Oaks,271089,2013,"Assault, Simple",
+Five Oaks,271089,2013,Burglary,
+Five Oaks,271089,2013,Curfew,
+Five Oaks,271089,2013,Disorderly Conduct,
+Five Oaks,271089,2013,Drugs,1
+Five Oaks,271089,2013,DUII,
+Five Oaks,271089,2013,Embezzlement,
+Five Oaks,271089,2013,Forgery,
+Five Oaks,271089,2013,Fraud,
+Five Oaks,271089,2013,Gambling,
+Five Oaks,271089,2013,Homicide,
+Five Oaks,271089,2013,Kidnap,
+Five Oaks,271089,2013,Larceny,
+Five Oaks,271089,2013,Liquor Laws,
+Five Oaks,271089,2013,Motor Vehicle Theft,
+Five Oaks,271089,2013,Offenses Against Family,
+Five Oaks,271089,2013,Prostitution,
+Five Oaks,271089,2013,Rape,
+Five Oaks,271089,2013,Robbery,
+Five Oaks,271089,2013,Runaway,
+Five Oaks,271089,2013,Sex Offenses,
+Five Oaks,271089,2013,Stolen Property,
+Five Oaks,271089,2013,Trespass,
+Five Oaks,271089,2013,Vandalism,
+Five Oaks,271089,2013,Weapons,
+Five Oaks,271089,2014,Aggravated Assault,
+Five Oaks,271089,2014,Arson,
+Five Oaks,271089,2014,"Assault, Simple",
+Five Oaks,271089,2014,Burglary,
+Five Oaks,271089,2014,Curfew,
+Five Oaks,271089,2014,Disorderly Conduct,
+Five Oaks,271089,2014,Drugs,
+Five Oaks,271089,2014,DUII,
+Five Oaks,271089,2014,Embezzlement,
+Five Oaks,271089,2014,Forgery,
+Five Oaks,271089,2014,Fraud,
+Five Oaks,271089,2014,Gambling,
+Five Oaks,271089,2014,Homicide,
+Five Oaks,271089,2014,Kidnap,
+Five Oaks,271089,2014,Larceny,
+Five Oaks,271089,2014,Liquor Laws,
+Five Oaks,271089,2014,Motor Vehicle Theft,
+Five Oaks,271089,2014,Offenses Against Family,
+Five Oaks,271089,2014,Prostitution,
+Five Oaks,271089,2014,Rape,
+Five Oaks,271089,2014,Robbery,
+Five Oaks,271089,2014,Runaway,
+Five Oaks,271089,2014,Sex Offenses,
+Five Oaks,271089,2014,Stolen Property,
+Five Oaks,271089,2014,Trespass,
+Five Oaks,271089,2014,Vandalism,
+Five Oaks,271089,2014,Weapons,
+Forest Park,271090,2004,Aggravated Assault,
+Forest Park,271090,2004,Arson,
+Forest Park,271090,2004,"Assault, Simple",
+Forest Park,271090,2004,Burglary,6
+Forest Park,271090,2004,Curfew,
+Forest Park,271090,2004,Disorderly Conduct,
+Forest Park,271090,2004,Drugs,
+Forest Park,271090,2004,DUII,1
+Forest Park,271090,2004,Embezzlement,
+Forest Park,271090,2004,Forgery,1
+Forest Park,271090,2004,Fraud,2
+Forest Park,271090,2004,Gambling,
+Forest Park,271090,2004,Homicide,
+Forest Park,271090,2004,Kidnap,
+Forest Park,271090,2004,Larceny,14
+Forest Park,271090,2004,Liquor Laws,
+Forest Park,271090,2004,Motor Vehicle Theft,1
+Forest Park,271090,2004,Offenses Against Family,
+Forest Park,271090,2004,Prostitution,
+Forest Park,271090,2004,Rape,
+Forest Park,271090,2004,Robbery,
+Forest Park,271090,2004,Runaway,
+Forest Park,271090,2004,Sex Offenses,
+Forest Park,271090,2004,Stolen Property,
+Forest Park,271090,2004,Trespass,2
+Forest Park,271090,2004,Vandalism,2
+Forest Park,271090,2004,Weapons,
+Forest Park,271090,2005,Aggravated Assault,1
+Forest Park,271090,2005,Arson,
+Forest Park,271090,2005,"Assault, Simple",2
+Forest Park,271090,2005,Burglary,62
+Forest Park,271090,2005,Curfew,
+Forest Park,271090,2005,Disorderly Conduct,11
+Forest Park,271090,2005,Drugs,1
+Forest Park,271090,2005,DUII,13
+Forest Park,271090,2005,Embezzlement,1
+Forest Park,271090,2005,Forgery,2
+Forest Park,271090,2005,Fraud,20
+Forest Park,271090,2005,Gambling,
+Forest Park,271090,2005,Homicide,
+Forest Park,271090,2005,Kidnap,
+Forest Park,271090,2005,Larceny,114
+Forest Park,271090,2005,Liquor Laws,2
+Forest Park,271090,2005,Motor Vehicle Theft,9
+Forest Park,271090,2005,Offenses Against Family,
+Forest Park,271090,2005,Prostitution,
+Forest Park,271090,2005,Rape,
+Forest Park,271090,2005,Robbery,1
+Forest Park,271090,2005,Runaway,
+Forest Park,271090,2005,Sex Offenses,1
+Forest Park,271090,2005,Stolen Property,
+Forest Park,271090,2005,Trespass,8
+Forest Park,271090,2005,Vandalism,40
+Forest Park,271090,2005,Weapons,1
+Forest Park,271090,2006,Aggravated Assault,
+Forest Park,271090,2006,Arson,
+Forest Park,271090,2006,"Assault, Simple",4
+Forest Park,271090,2006,Burglary,46
+Forest Park,271090,2006,Curfew,
+Forest Park,271090,2006,Disorderly Conduct,13
+Forest Park,271090,2006,Drugs,3
+Forest Park,271090,2006,DUII,23
+Forest Park,271090,2006,Embezzlement,2
+Forest Park,271090,2006,Forgery,5
+Forest Park,271090,2006,Fraud,26
+Forest Park,271090,2006,Gambling,
+Forest Park,271090,2006,Homicide,
+Forest Park,271090,2006,Kidnap,
+Forest Park,271090,2006,Larceny,148
+Forest Park,271090,2006,Liquor Laws,4
+Forest Park,271090,2006,Motor Vehicle Theft,8
+Forest Park,271090,2006,Offenses Against Family,
+Forest Park,271090,2006,Prostitution,
+Forest Park,271090,2006,Rape,
+Forest Park,271090,2006,Robbery,2
+Forest Park,271090,2006,Runaway,
+Forest Park,271090,2006,Sex Offenses,1
+Forest Park,271090,2006,Stolen Property,
+Forest Park,271090,2006,Trespass,6
+Forest Park,271090,2006,Vandalism,33
+Forest Park,271090,2006,Weapons,1
+Forest Park,271090,2007,Aggravated Assault,5
+Forest Park,271090,2007,Arson,
+Forest Park,271090,2007,"Assault, Simple",5
+Forest Park,271090,2007,Burglary,26
+Forest Park,271090,2007,Curfew,
+Forest Park,271090,2007,Disorderly Conduct,11
+Forest Park,271090,2007,Drugs,2
+Forest Park,271090,2007,DUII,19
+Forest Park,271090,2007,Embezzlement,3
+Forest Park,271090,2007,Forgery,3
+Forest Park,271090,2007,Fraud,16
+Forest Park,271090,2007,Gambling,
+Forest Park,271090,2007,Homicide,
+Forest Park,271090,2007,Kidnap,
+Forest Park,271090,2007,Larceny,121
+Forest Park,271090,2007,Liquor Laws,
+Forest Park,271090,2007,Motor Vehicle Theft,9
+Forest Park,271090,2007,Offenses Against Family,
+Forest Park,271090,2007,Prostitution,
+Forest Park,271090,2007,Rape,
+Forest Park,271090,2007,Robbery,
+Forest Park,271090,2007,Runaway,
+Forest Park,271090,2007,Sex Offenses,1
+Forest Park,271090,2007,Stolen Property,1
+Forest Park,271090,2007,Trespass,10
+Forest Park,271090,2007,Vandalism,32
+Forest Park,271090,2007,Weapons,1
+Forest Park,271090,2008,Aggravated Assault,4
+Forest Park,271090,2008,Arson,
+Forest Park,271090,2008,"Assault, Simple",2
+Forest Park,271090,2008,Burglary,31
+Forest Park,271090,2008,Curfew,
+Forest Park,271090,2008,Disorderly Conduct,7
+Forest Park,271090,2008,Drugs,
+Forest Park,271090,2008,DUII,19
+Forest Park,271090,2008,Embezzlement,
+Forest Park,271090,2008,Forgery,2
+Forest Park,271090,2008,Fraud,11
+Forest Park,271090,2008,Gambling,
+Forest Park,271090,2008,Homicide,
+Forest Park,271090,2008,Kidnap,
+Forest Park,271090,2008,Larceny,180
+Forest Park,271090,2008,Liquor Laws,2
+Forest Park,271090,2008,Motor Vehicle Theft,12
+Forest Park,271090,2008,Offenses Against Family,
+Forest Park,271090,2008,Prostitution,
+Forest Park,271090,2008,Rape,
+Forest Park,271090,2008,Robbery,1
+Forest Park,271090,2008,Runaway,
+Forest Park,271090,2008,Sex Offenses,
+Forest Park,271090,2008,Stolen Property,
+Forest Park,271090,2008,Trespass,6
+Forest Park,271090,2008,Vandalism,24
+Forest Park,271090,2008,Weapons,
+Forest Park,271090,2009,Aggravated Assault,3
+Forest Park,271090,2009,Arson,
+Forest Park,271090,2009,"Assault, Simple",5
+Forest Park,271090,2009,Burglary,37
+Forest Park,271090,2009,Curfew,1
+Forest Park,271090,2009,Disorderly Conduct,17
+Forest Park,271090,2009,Drugs,2
+Forest Park,271090,2009,DUII,18
+Forest Park,271090,2009,Embezzlement,1
+Forest Park,271090,2009,Forgery,3
+Forest Park,271090,2009,Fraud,13
+Forest Park,271090,2009,Gambling,
+Forest Park,271090,2009,Homicide,
+Forest Park,271090,2009,Kidnap,
+Forest Park,271090,2009,Larceny,170
+Forest Park,271090,2009,Liquor Laws,2
+Forest Park,271090,2009,Motor Vehicle Theft,7
+Forest Park,271090,2009,Offenses Against Family,
+Forest Park,271090,2009,Prostitution,
+Forest Park,271090,2009,Rape,1
+Forest Park,271090,2009,Robbery,
+Forest Park,271090,2009,Runaway,
+Forest Park,271090,2009,Sex Offenses,
+Forest Park,271090,2009,Stolen Property,1
+Forest Park,271090,2009,Trespass,8
+Forest Park,271090,2009,Vandalism,34
+Forest Park,271090,2009,Weapons,1
+Forest Park,271090,2010,Aggravated Assault,3
+Forest Park,271090,2010,Arson,1
+Forest Park,271090,2010,"Assault, Simple",4
+Forest Park,271090,2010,Burglary,31
+Forest Park,271090,2010,Curfew,
+Forest Park,271090,2010,Disorderly Conduct,11
+Forest Park,271090,2010,Drugs,5
+Forest Park,271090,2010,DUII,14
+Forest Park,271090,2010,Embezzlement,1
+Forest Park,271090,2010,Forgery,4
+Forest Park,271090,2010,Fraud,5
+Forest Park,271090,2010,Gambling,
+Forest Park,271090,2010,Homicide,
+Forest Park,271090,2010,Kidnap,
+Forest Park,271090,2010,Larceny,182
+Forest Park,271090,2010,Liquor Laws,1
+Forest Park,271090,2010,Motor Vehicle Theft,11
+Forest Park,271090,2010,Offenses Against Family,
+Forest Park,271090,2010,Prostitution,
+Forest Park,271090,2010,Rape,
+Forest Park,271090,2010,Robbery,
+Forest Park,271090,2010,Runaway,
+Forest Park,271090,2010,Sex Offenses,
+Forest Park,271090,2010,Stolen Property,
+Forest Park,271090,2010,Trespass,4
+Forest Park,271090,2010,Vandalism,25
+Forest Park,271090,2010,Weapons,
+Forest Park,271090,2011,Aggravated Assault,3
+Forest Park,271090,2011,Arson,
+Forest Park,271090,2011,"Assault, Simple",5
+Forest Park,271090,2011,Burglary,44
+Forest Park,271090,2011,Curfew,
+Forest Park,271090,2011,Disorderly Conduct,6
+Forest Park,271090,2011,Drugs,4
+Forest Park,271090,2011,DUII,21
+Forest Park,271090,2011,Embezzlement,1
+Forest Park,271090,2011,Forgery,1
+Forest Park,271090,2011,Fraud,7
+Forest Park,271090,2011,Gambling,
+Forest Park,271090,2011,Homicide,
+Forest Park,271090,2011,Kidnap,
+Forest Park,271090,2011,Larceny,155
+Forest Park,271090,2011,Liquor Laws,
+Forest Park,271090,2011,Motor Vehicle Theft,8
+Forest Park,271090,2011,Offenses Against Family,
+Forest Park,271090,2011,Prostitution,
+Forest Park,271090,2011,Rape,
+Forest Park,271090,2011,Robbery,
+Forest Park,271090,2011,Runaway,
+Forest Park,271090,2011,Sex Offenses,
+Forest Park,271090,2011,Stolen Property,1
+Forest Park,271090,2011,Trespass,6
+Forest Park,271090,2011,Vandalism,31
+Forest Park,271090,2011,Weapons,
+Forest Park,271090,2012,Aggravated Assault,3
+Forest Park,271090,2012,Arson,
+Forest Park,271090,2012,"Assault, Simple",5
+Forest Park,271090,2012,Burglary,21
+Forest Park,271090,2012,Curfew,
+Forest Park,271090,2012,Disorderly Conduct,6
+Forest Park,271090,2012,Drugs,1
+Forest Park,271090,2012,DUII,32
+Forest Park,271090,2012,Embezzlement,1
+Forest Park,271090,2012,Forgery,
+Forest Park,271090,2012,Fraud,9
+Forest Park,271090,2012,Gambling,
+Forest Park,271090,2012,Homicide,
+Forest Park,271090,2012,Kidnap,
+Forest Park,271090,2012,Larceny,180
+Forest Park,271090,2012,Liquor Laws,3
+Forest Park,271090,2012,Motor Vehicle Theft,6
+Forest Park,271090,2012,Offenses Against Family,
+Forest Park,271090,2012,Prostitution,
+Forest Park,271090,2012,Rape,
+Forest Park,271090,2012,Robbery,1
+Forest Park,271090,2012,Runaway,
+Forest Park,271090,2012,Sex Offenses,
+Forest Park,271090,2012,Stolen Property,
+Forest Park,271090,2012,Trespass,7
+Forest Park,271090,2012,Vandalism,25
+Forest Park,271090,2012,Weapons,
+Forest Park,271090,2013,Aggravated Assault,1
+Forest Park,271090,2013,Arson,
+Forest Park,271090,2013,"Assault, Simple",5
+Forest Park,271090,2013,Burglary,20
+Forest Park,271090,2013,Curfew,
+Forest Park,271090,2013,Disorderly Conduct,6
+Forest Park,271090,2013,Drugs,2
+Forest Park,271090,2013,DUII,23
+Forest Park,271090,2013,Embezzlement,
+Forest Park,271090,2013,Forgery,1
+Forest Park,271090,2013,Fraud,5
+Forest Park,271090,2013,Gambling,
+Forest Park,271090,2013,Homicide,
+Forest Park,271090,2013,Kidnap,
+Forest Park,271090,2013,Larceny,131
+Forest Park,271090,2013,Liquor Laws,
+Forest Park,271090,2013,Motor Vehicle Theft,7
+Forest Park,271090,2013,Offenses Against Family,
+Forest Park,271090,2013,Prostitution,
+Forest Park,271090,2013,Rape,
+Forest Park,271090,2013,Robbery,3
+Forest Park,271090,2013,Runaway,
+Forest Park,271090,2013,Sex Offenses,1
+Forest Park,271090,2013,Stolen Property,
+Forest Park,271090,2013,Trespass,8
+Forest Park,271090,2013,Vandalism,14
+Forest Park,271090,2013,Weapons,2
+Forest Park,271090,2014,Aggravated Assault,4
+Forest Park,271090,2014,Arson,
+Forest Park,271090,2014,"Assault, Simple",9
+Forest Park,271090,2014,Burglary,30
+Forest Park,271090,2014,Curfew,
+Forest Park,271090,2014,Disorderly Conduct,8
+Forest Park,271090,2014,Drugs,4
+Forest Park,271090,2014,DUII,18
+Forest Park,271090,2014,Embezzlement,
+Forest Park,271090,2014,Forgery,1
+Forest Park,271090,2014,Fraud,19
+Forest Park,271090,2014,Gambling,
+Forest Park,271090,2014,Homicide,
+Forest Park,271090,2014,Kidnap,
+Forest Park,271090,2014,Larceny,176
+Forest Park,271090,2014,Liquor Laws,
+Forest Park,271090,2014,Motor Vehicle Theft,7
+Forest Park,271090,2014,Offenses Against Family,
+Forest Park,271090,2014,Prostitution,
+Forest Park,271090,2014,Rape,1
+Forest Park,271090,2014,Robbery,2
+Forest Park,271090,2014,Runaway,
+Forest Park,271090,2014,Sex Offenses,
+Forest Park,271090,2014,Stolen Property,
+Forest Park,271090,2014,Trespass,2
+Forest Park,271090,2014,Vandalism,17
+Forest Park,271090,2014,Weapons,
+Foster Powell,344054,2004,Aggravated Assault,9
+Foster Powell,344054,2004,Arson,1
+Foster Powell,344054,2004,"Assault, Simple",22
+Foster Powell,344054,2004,Burglary,35
+Foster Powell,344054,2004,Curfew,1
+Foster Powell,344054,2004,Disorderly Conduct,11
+Foster Powell,344054,2004,Drugs,26
+Foster Powell,344054,2004,DUII,13
+Foster Powell,344054,2004,Embezzlement,2
+Foster Powell,344054,2004,Forgery,32
+Foster Powell,344054,2004,Fraud,21
+Foster Powell,344054,2004,Gambling,
+Foster Powell,344054,2004,Homicide,
+Foster Powell,344054,2004,Kidnap,
+Foster Powell,344054,2004,Larceny,184
+Foster Powell,344054,2004,Liquor Laws,7
+Foster Powell,344054,2004,Motor Vehicle Theft,42
+Foster Powell,344054,2004,Offenses Against Family,
+Foster Powell,344054,2004,Prostitution,18
+Foster Powell,344054,2004,Rape,1
+Foster Powell,344054,2004,Robbery,10
+Foster Powell,344054,2004,Runaway,
+Foster Powell,344054,2004,Sex Offenses,
+Foster Powell,344054,2004,Stolen Property,1
+Foster Powell,344054,2004,Trespass,17
+Foster Powell,344054,2004,Vandalism,41
+Foster Powell,344054,2004,Weapons,5
+Foster Powell,344054,2005,Aggravated Assault,36
+Foster Powell,344054,2005,Arson,3
+Foster Powell,344054,2005,"Assault, Simple",49
+Foster Powell,344054,2005,Burglary,88
+Foster Powell,344054,2005,Curfew,7
+Foster Powell,344054,2005,Disorderly Conduct,43
+Foster Powell,344054,2005,Drugs,132
+Foster Powell,344054,2005,DUII,37
+Foster Powell,344054,2005,Embezzlement,9
+Foster Powell,344054,2005,Forgery,152
+Foster Powell,344054,2005,Fraud,77
+Foster Powell,344054,2005,Gambling,
+Foster Powell,344054,2005,Homicide,1
+Foster Powell,344054,2005,Kidnap,
+Foster Powell,344054,2005,Larceny,716
+Foster Powell,344054,2005,Liquor Laws,8
+Foster Powell,344054,2005,Motor Vehicle Theft,157
+Foster Powell,344054,2005,Offenses Against Family,
+Foster Powell,344054,2005,Prostitution,32
+Foster Powell,344054,2005,Rape,
+Foster Powell,344054,2005,Robbery,46
+Foster Powell,344054,2005,Runaway,
+Foster Powell,344054,2005,Sex Offenses,1
+Foster Powell,344054,2005,Stolen Property,2
+Foster Powell,344054,2005,Trespass,57
+Foster Powell,344054,2005,Vandalism,152
+Foster Powell,344054,2005,Weapons,11
+Foster Powell,344054,2006,Aggravated Assault,46
+Foster Powell,344054,2006,Arson,1
+Foster Powell,344054,2006,"Assault, Simple",66
+Foster Powell,344054,2006,Burglary,83
+Foster Powell,344054,2006,Curfew,6
+Foster Powell,344054,2006,Disorderly Conduct,54
+Foster Powell,344054,2006,Drugs,111
+Foster Powell,344054,2006,DUII,34
+Foster Powell,344054,2006,Embezzlement,10
+Foster Powell,344054,2006,Forgery,121
+Foster Powell,344054,2006,Fraud,169
+Foster Powell,344054,2006,Gambling,
+Foster Powell,344054,2006,Homicide,
+Foster Powell,344054,2006,Kidnap,
+Foster Powell,344054,2006,Larceny,609
+Foster Powell,344054,2006,Liquor Laws,17
+Foster Powell,344054,2006,Motor Vehicle Theft,135
+Foster Powell,344054,2006,Offenses Against Family,
+Foster Powell,344054,2006,Prostitution,14
+Foster Powell,344054,2006,Rape,
+Foster Powell,344054,2006,Robbery,47
+Foster Powell,344054,2006,Runaway,
+Foster Powell,344054,2006,Sex Offenses,1
+Foster Powell,344054,2006,Stolen Property,8
+Foster Powell,344054,2006,Trespass,49
+Foster Powell,344054,2006,Vandalism,158
+Foster Powell,344054,2006,Weapons,15
+Foster Powell,344054,2007,Aggravated Assault,33
+Foster Powell,344054,2007,Arson,1
+Foster Powell,344054,2007,"Assault, Simple",69
+Foster Powell,344054,2007,Burglary,91
+Foster Powell,344054,2007,Curfew,4
+Foster Powell,344054,2007,Disorderly Conduct,41
+Foster Powell,344054,2007,Drugs,83
+Foster Powell,344054,2007,DUII,53
+Foster Powell,344054,2007,Embezzlement,6
+Foster Powell,344054,2007,Forgery,98
+Foster Powell,344054,2007,Fraud,57
+Foster Powell,344054,2007,Gambling,
+Foster Powell,344054,2007,Homicide,1
+Foster Powell,344054,2007,Kidnap,1
+Foster Powell,344054,2007,Larceny,699
+Foster Powell,344054,2007,Liquor Laws,27
+Foster Powell,344054,2007,Motor Vehicle Theft,147
+Foster Powell,344054,2007,Offenses Against Family,
+Foster Powell,344054,2007,Prostitution,22
+Foster Powell,344054,2007,Rape,1
+Foster Powell,344054,2007,Robbery,50
+Foster Powell,344054,2007,Runaway,1
+Foster Powell,344054,2007,Sex Offenses,1
+Foster Powell,344054,2007,Stolen Property,1
+Foster Powell,344054,2007,Trespass,40
+Foster Powell,344054,2007,Vandalism,137
+Foster Powell,344054,2007,Weapons,10
+Foster Powell,344054,2008,Aggravated Assault,31
+Foster Powell,344054,2008,Arson,
+Foster Powell,344054,2008,"Assault, Simple",59
+Foster Powell,344054,2008,Burglary,78
+Foster Powell,344054,2008,Curfew,7
+Foster Powell,344054,2008,Disorderly Conduct,50
+Foster Powell,344054,2008,Drugs,70
+Foster Powell,344054,2008,DUII,47
+Foster Powell,344054,2008,Embezzlement,5
+Foster Powell,344054,2008,Forgery,61
+Foster Powell,344054,2008,Fraud,63
+Foster Powell,344054,2008,Gambling,
+Foster Powell,344054,2008,Homicide,1
+Foster Powell,344054,2008,Kidnap,2
+Foster Powell,344054,2008,Larceny,756
+Foster Powell,344054,2008,Liquor Laws,46
+Foster Powell,344054,2008,Motor Vehicle Theft,62
+Foster Powell,344054,2008,Offenses Against Family,
+Foster Powell,344054,2008,Prostitution,28
+Foster Powell,344054,2008,Rape,1
+Foster Powell,344054,2008,Robbery,29
+Foster Powell,344054,2008,Runaway,
+Foster Powell,344054,2008,Sex Offenses,2
+Foster Powell,344054,2008,Stolen Property,1
+Foster Powell,344054,2008,Trespass,56
+Foster Powell,344054,2008,Vandalism,79
+Foster Powell,344054,2008,Weapons,9
+Foster Powell,344054,2009,Aggravated Assault,19
+Foster Powell,344054,2009,Arson,
+Foster Powell,344054,2009,"Assault, Simple",48
+Foster Powell,344054,2009,Burglary,46
+Foster Powell,344054,2009,Curfew,3
+Foster Powell,344054,2009,Disorderly Conduct,68
+Foster Powell,344054,2009,Drugs,43
+Foster Powell,344054,2009,DUII,23
+Foster Powell,344054,2009,Embezzlement,3
+Foster Powell,344054,2009,Forgery,67
+Foster Powell,344054,2009,Fraud,59
+Foster Powell,344054,2009,Gambling,
+Foster Powell,344054,2009,Homicide,
+Foster Powell,344054,2009,Kidnap,
+Foster Powell,344054,2009,Larceny,794
+Foster Powell,344054,2009,Liquor Laws,36
+Foster Powell,344054,2009,Motor Vehicle Theft,55
+Foster Powell,344054,2009,Offenses Against Family,
+Foster Powell,344054,2009,Prostitution,20
+Foster Powell,344054,2009,Rape,
+Foster Powell,344054,2009,Robbery,27
+Foster Powell,344054,2009,Runaway,1
+Foster Powell,344054,2009,Sex Offenses,2
+Foster Powell,344054,2009,Stolen Property,1
+Foster Powell,344054,2009,Trespass,40
+Foster Powell,344054,2009,Vandalism,84
+Foster Powell,344054,2009,Weapons,11
+Foster Powell,344054,2010,Aggravated Assault,24
+Foster Powell,344054,2010,Arson,
+Foster Powell,344054,2010,"Assault, Simple",37
+Foster Powell,344054,2010,Burglary,56
+Foster Powell,344054,2010,Curfew,1
+Foster Powell,344054,2010,Disorderly Conduct,43
+Foster Powell,344054,2010,Drugs,41
+Foster Powell,344054,2010,DUII,30
+Foster Powell,344054,2010,Embezzlement,2
+Foster Powell,344054,2010,Forgery,60
+Foster Powell,344054,2010,Fraud,68
+Foster Powell,344054,2010,Gambling,
+Foster Powell,344054,2010,Homicide,1
+Foster Powell,344054,2010,Kidnap,1
+Foster Powell,344054,2010,Larceny,800
+Foster Powell,344054,2010,Liquor Laws,15
+Foster Powell,344054,2010,Motor Vehicle Theft,87
+Foster Powell,344054,2010,Offenses Against Family,
+Foster Powell,344054,2010,Prostitution,8
+Foster Powell,344054,2010,Rape,1
+Foster Powell,344054,2010,Robbery,24
+Foster Powell,344054,2010,Runaway,
+Foster Powell,344054,2010,Sex Offenses,
+Foster Powell,344054,2010,Stolen Property,4
+Foster Powell,344054,2010,Trespass,33
+Foster Powell,344054,2010,Vandalism,89
+Foster Powell,344054,2010,Weapons,7
+Foster Powell,344054,2011,Aggravated Assault,22
+Foster Powell,344054,2011,Arson,
+Foster Powell,344054,2011,"Assault, Simple",36
+Foster Powell,344054,2011,Burglary,99
+Foster Powell,344054,2011,Curfew,1
+Foster Powell,344054,2011,Disorderly Conduct,32
+Foster Powell,344054,2011,Drugs,36
+Foster Powell,344054,2011,DUII,40
+Foster Powell,344054,2011,Embezzlement,4
+Foster Powell,344054,2011,Forgery,160
+Foster Powell,344054,2011,Fraud,55
+Foster Powell,344054,2011,Gambling,
+Foster Powell,344054,2011,Homicide,
+Foster Powell,344054,2011,Kidnap,2
+Foster Powell,344054,2011,Larceny,721
+Foster Powell,344054,2011,Liquor Laws,13
+Foster Powell,344054,2011,Motor Vehicle Theft,78
+Foster Powell,344054,2011,Offenses Against Family,
+Foster Powell,344054,2011,Prostitution,5
+Foster Powell,344054,2011,Rape,1
+Foster Powell,344054,2011,Robbery,39
+Foster Powell,344054,2011,Runaway,2
+Foster Powell,344054,2011,Sex Offenses,4
+Foster Powell,344054,2011,Stolen Property,3
+Foster Powell,344054,2011,Trespass,29
+Foster Powell,344054,2011,Vandalism,77
+Foster Powell,344054,2011,Weapons,2
+Foster Powell,344054,2012,Aggravated Assault,28
+Foster Powell,344054,2012,Arson,1
+Foster Powell,344054,2012,"Assault, Simple",49
+Foster Powell,344054,2012,Burglary,97
+Foster Powell,344054,2012,Curfew,
+Foster Powell,344054,2012,Disorderly Conduct,50
+Foster Powell,344054,2012,Drugs,53
+Foster Powell,344054,2012,DUII,22
+Foster Powell,344054,2012,Embezzlement,5
+Foster Powell,344054,2012,Forgery,143
+Foster Powell,344054,2012,Fraud,67
+Foster Powell,344054,2012,Gambling,
+Foster Powell,344054,2012,Homicide,
+Foster Powell,344054,2012,Kidnap,
+Foster Powell,344054,2012,Larceny,773
+Foster Powell,344054,2012,Liquor Laws,6
+Foster Powell,344054,2012,Motor Vehicle Theft,84
+Foster Powell,344054,2012,Offenses Against Family,
+Foster Powell,344054,2012,Prostitution,9
+Foster Powell,344054,2012,Rape,2
+Foster Powell,344054,2012,Robbery,32
+Foster Powell,344054,2012,Runaway,
+Foster Powell,344054,2012,Sex Offenses,1
+Foster Powell,344054,2012,Stolen Property,
+Foster Powell,344054,2012,Trespass,33
+Foster Powell,344054,2012,Vandalism,91
+Foster Powell,344054,2012,Weapons,6
+Foster Powell,344054,2013,Aggravated Assault,23
+Foster Powell,344054,2013,Arson,
+Foster Powell,344054,2013,"Assault, Simple",39
+Foster Powell,344054,2013,Burglary,101
+Foster Powell,344054,2013,Curfew,
+Foster Powell,344054,2013,Disorderly Conduct,41
+Foster Powell,344054,2013,Drugs,58
+Foster Powell,344054,2013,DUII,29
+Foster Powell,344054,2013,Embezzlement,4
+Foster Powell,344054,2013,Forgery,93
+Foster Powell,344054,2013,Fraud,44
+Foster Powell,344054,2013,Gambling,
+Foster Powell,344054,2013,Homicide,
+Foster Powell,344054,2013,Kidnap,
+Foster Powell,344054,2013,Larceny,848
+Foster Powell,344054,2013,Liquor Laws,12
+Foster Powell,344054,2013,Motor Vehicle Theft,85
+Foster Powell,344054,2013,Offenses Against Family,
+Foster Powell,344054,2013,Prostitution,3
+Foster Powell,344054,2013,Rape,2
+Foster Powell,344054,2013,Robbery,19
+Foster Powell,344054,2013,Runaway,
+Foster Powell,344054,2013,Sex Offenses,
+Foster Powell,344054,2013,Stolen Property,1
+Foster Powell,344054,2013,Trespass,32
+Foster Powell,344054,2013,Vandalism,101
+Foster Powell,344054,2013,Weapons,11
+Foster Powell,344054,2014,Aggravated Assault,24
+Foster Powell,344054,2014,Arson,1
+Foster Powell,344054,2014,"Assault, Simple",46
+Foster Powell,344054,2014,Burglary,93
+Foster Powell,344054,2014,Curfew,
+Foster Powell,344054,2014,Disorderly Conduct,43
+Foster Powell,344054,2014,Drugs,23
+Foster Powell,344054,2014,DUII,19
+Foster Powell,344054,2014,Embezzlement,7
+Foster Powell,344054,2014,Forgery,47
+Foster Powell,344054,2014,Fraud,42
+Foster Powell,344054,2014,Gambling,
+Foster Powell,344054,2014,Homicide,
+Foster Powell,344054,2014,Kidnap,
+Foster Powell,344054,2014,Larceny,673
+Foster Powell,344054,2014,Liquor Laws,8
+Foster Powell,344054,2014,Motor Vehicle Theft,70
+Foster Powell,344054,2014,Offenses Against Family,
+Foster Powell,344054,2014,Prostitution,2
+Foster Powell,344054,2014,Rape,1
+Foster Powell,344054,2014,Robbery,25
+Foster Powell,344054,2014,Runaway,1
+Foster Powell,344054,2014,Sex Offenses,3
+Foster Powell,344054,2014,Stolen Property,2
+Foster Powell,344054,2014,Trespass,44
+Foster Powell,344054,2014,Vandalism,66
+Foster Powell,344054,2014,Weapons,7
+Government Island,273856,2004,Aggravated Assault,
+Government Island,273856,2004,Arson,
+Government Island,273856,2004,"Assault, Simple",
+Government Island,273856,2004,Burglary,
+Government Island,273856,2004,Curfew,
+Government Island,273856,2004,Disorderly Conduct,
+Government Island,273856,2004,Drugs,
+Government Island,273856,2004,DUII,
+Government Island,273856,2004,Embezzlement,
+Government Island,273856,2004,Forgery,
+Government Island,273856,2004,Fraud,
+Government Island,273856,2004,Gambling,
+Government Island,273856,2004,Homicide,
+Government Island,273856,2004,Kidnap,
+Government Island,273856,2004,Larceny,
+Government Island,273856,2004,Liquor Laws,
+Government Island,273856,2004,Motor Vehicle Theft,
+Government Island,273856,2004,Offenses Against Family,
+Government Island,273856,2004,Prostitution,
+Government Island,273856,2004,Rape,
+Government Island,273856,2004,Robbery,
+Government Island,273856,2004,Runaway,
+Government Island,273856,2004,Sex Offenses,
+Government Island,273856,2004,Stolen Property,
+Government Island,273856,2004,Trespass,
+Government Island,273856,2004,Vandalism,
+Government Island,273856,2004,Weapons,
+Government Island,273856,2005,Aggravated Assault,
+Government Island,273856,2005,Arson,
+Government Island,273856,2005,"Assault, Simple",
+Government Island,273856,2005,Burglary,
+Government Island,273856,2005,Curfew,
+Government Island,273856,2005,Disorderly Conduct,
+Government Island,273856,2005,Drugs,
+Government Island,273856,2005,DUII,
+Government Island,273856,2005,Embezzlement,
+Government Island,273856,2005,Forgery,
+Government Island,273856,2005,Fraud,
+Government Island,273856,2005,Gambling,
+Government Island,273856,2005,Homicide,
+Government Island,273856,2005,Kidnap,
+Government Island,273856,2005,Larceny,
+Government Island,273856,2005,Liquor Laws,
+Government Island,273856,2005,Motor Vehicle Theft,
+Government Island,273856,2005,Offenses Against Family,
+Government Island,273856,2005,Prostitution,
+Government Island,273856,2005,Rape,
+Government Island,273856,2005,Robbery,
+Government Island,273856,2005,Runaway,
+Government Island,273856,2005,Sex Offenses,
+Government Island,273856,2005,Stolen Property,
+Government Island,273856,2005,Trespass,
+Government Island,273856,2005,Vandalism,
+Government Island,273856,2005,Weapons,
+Government Island,273856,2006,Aggravated Assault,
+Government Island,273856,2006,Arson,
+Government Island,273856,2006,"Assault, Simple",
+Government Island,273856,2006,Burglary,
+Government Island,273856,2006,Curfew,
+Government Island,273856,2006,Disorderly Conduct,
+Government Island,273856,2006,Drugs,
+Government Island,273856,2006,DUII,
+Government Island,273856,2006,Embezzlement,
+Government Island,273856,2006,Forgery,
+Government Island,273856,2006,Fraud,
+Government Island,273856,2006,Gambling,
+Government Island,273856,2006,Homicide,
+Government Island,273856,2006,Kidnap,
+Government Island,273856,2006,Larceny,
+Government Island,273856,2006,Liquor Laws,
+Government Island,273856,2006,Motor Vehicle Theft,
+Government Island,273856,2006,Offenses Against Family,
+Government Island,273856,2006,Prostitution,
+Government Island,273856,2006,Rape,
+Government Island,273856,2006,Robbery,
+Government Island,273856,2006,Runaway,
+Government Island,273856,2006,Sex Offenses,
+Government Island,273856,2006,Stolen Property,
+Government Island,273856,2006,Trespass,
+Government Island,273856,2006,Vandalism,
+Government Island,273856,2006,Weapons,
+Government Island,273856,2007,Aggravated Assault,
+Government Island,273856,2007,Arson,
+Government Island,273856,2007,"Assault, Simple",
+Government Island,273856,2007,Burglary,
+Government Island,273856,2007,Curfew,
+Government Island,273856,2007,Disorderly Conduct,
+Government Island,273856,2007,Drugs,
+Government Island,273856,2007,DUII,
+Government Island,273856,2007,Embezzlement,
+Government Island,273856,2007,Forgery,
+Government Island,273856,2007,Fraud,
+Government Island,273856,2007,Gambling,
+Government Island,273856,2007,Homicide,
+Government Island,273856,2007,Kidnap,
+Government Island,273856,2007,Larceny,
+Government Island,273856,2007,Liquor Laws,
+Government Island,273856,2007,Motor Vehicle Theft,
+Government Island,273856,2007,Offenses Against Family,
+Government Island,273856,2007,Prostitution,
+Government Island,273856,2007,Rape,
+Government Island,273856,2007,Robbery,
+Government Island,273856,2007,Runaway,
+Government Island,273856,2007,Sex Offenses,
+Government Island,273856,2007,Stolen Property,
+Government Island,273856,2007,Trespass,
+Government Island,273856,2007,Vandalism,
+Government Island,273856,2007,Weapons,
+Government Island,273856,2008,Aggravated Assault,
+Government Island,273856,2008,Arson,
+Government Island,273856,2008,"Assault, Simple",
+Government Island,273856,2008,Burglary,
+Government Island,273856,2008,Curfew,
+Government Island,273856,2008,Disorderly Conduct,
+Government Island,273856,2008,Drugs,
+Government Island,273856,2008,DUII,
+Government Island,273856,2008,Embezzlement,
+Government Island,273856,2008,Forgery,
+Government Island,273856,2008,Fraud,
+Government Island,273856,2008,Gambling,
+Government Island,273856,2008,Homicide,
+Government Island,273856,2008,Kidnap,
+Government Island,273856,2008,Larceny,
+Government Island,273856,2008,Liquor Laws,
+Government Island,273856,2008,Motor Vehicle Theft,
+Government Island,273856,2008,Offenses Against Family,
+Government Island,273856,2008,Prostitution,
+Government Island,273856,2008,Rape,
+Government Island,273856,2008,Robbery,
+Government Island,273856,2008,Runaway,
+Government Island,273856,2008,Sex Offenses,
+Government Island,273856,2008,Stolen Property,
+Government Island,273856,2008,Trespass,
+Government Island,273856,2008,Vandalism,
+Government Island,273856,2008,Weapons,
+Government Island,273856,2009,Aggravated Assault,
+Government Island,273856,2009,Arson,
+Government Island,273856,2009,"Assault, Simple",
+Government Island,273856,2009,Burglary,
+Government Island,273856,2009,Curfew,
+Government Island,273856,2009,Disorderly Conduct,
+Government Island,273856,2009,Drugs,
+Government Island,273856,2009,DUII,1
+Government Island,273856,2009,Embezzlement,
+Government Island,273856,2009,Forgery,
+Government Island,273856,2009,Fraud,
+Government Island,273856,2009,Gambling,
+Government Island,273856,2009,Homicide,
+Government Island,273856,2009,Kidnap,
+Government Island,273856,2009,Larceny,
+Government Island,273856,2009,Liquor Laws,
+Government Island,273856,2009,Motor Vehicle Theft,
+Government Island,273856,2009,Offenses Against Family,
+Government Island,273856,2009,Prostitution,
+Government Island,273856,2009,Rape,
+Government Island,273856,2009,Robbery,
+Government Island,273856,2009,Runaway,
+Government Island,273856,2009,Sex Offenses,
+Government Island,273856,2009,Stolen Property,
+Government Island,273856,2009,Trespass,
+Government Island,273856,2009,Vandalism,
+Government Island,273856,2009,Weapons,
+Government Island,273856,2010,Aggravated Assault,
+Government Island,273856,2010,Arson,
+Government Island,273856,2010,"Assault, Simple",
+Government Island,273856,2010,Burglary,
+Government Island,273856,2010,Curfew,
+Government Island,273856,2010,Disorderly Conduct,
+Government Island,273856,2010,Drugs,
+Government Island,273856,2010,DUII,
+Government Island,273856,2010,Embezzlement,
+Government Island,273856,2010,Forgery,
+Government Island,273856,2010,Fraud,
+Government Island,273856,2010,Gambling,
+Government Island,273856,2010,Homicide,
+Government Island,273856,2010,Kidnap,
+Government Island,273856,2010,Larceny,
+Government Island,273856,2010,Liquor Laws,
+Government Island,273856,2010,Motor Vehicle Theft,
+Government Island,273856,2010,Offenses Against Family,
+Government Island,273856,2010,Prostitution,
+Government Island,273856,2010,Rape,
+Government Island,273856,2010,Robbery,
+Government Island,273856,2010,Runaway,
+Government Island,273856,2010,Sex Offenses,
+Government Island,273856,2010,Stolen Property,
+Government Island,273856,2010,Trespass,
+Government Island,273856,2010,Vandalism,
+Government Island,273856,2010,Weapons,
+Government Island,273856,2011,Aggravated Assault,
+Government Island,273856,2011,Arson,
+Government Island,273856,2011,"Assault, Simple",
+Government Island,273856,2011,Burglary,
+Government Island,273856,2011,Curfew,
+Government Island,273856,2011,Disorderly Conduct,
+Government Island,273856,2011,Drugs,
+Government Island,273856,2011,DUII,
+Government Island,273856,2011,Embezzlement,
+Government Island,273856,2011,Forgery,
+Government Island,273856,2011,Fraud,
+Government Island,273856,2011,Gambling,
+Government Island,273856,2011,Homicide,
+Government Island,273856,2011,Kidnap,
+Government Island,273856,2011,Larceny,
+Government Island,273856,2011,Liquor Laws,
+Government Island,273856,2011,Motor Vehicle Theft,
+Government Island,273856,2011,Offenses Against Family,
+Government Island,273856,2011,Prostitution,
+Government Island,273856,2011,Rape,
+Government Island,273856,2011,Robbery,
+Government Island,273856,2011,Runaway,
+Government Island,273856,2011,Sex Offenses,
+Government Island,273856,2011,Stolen Property,
+Government Island,273856,2011,Trespass,
+Government Island,273856,2011,Vandalism,
+Government Island,273856,2011,Weapons,
+Government Island,273856,2012,Aggravated Assault,
+Government Island,273856,2012,Arson,
+Government Island,273856,2012,"Assault, Simple",
+Government Island,273856,2012,Burglary,
+Government Island,273856,2012,Curfew,
+Government Island,273856,2012,Disorderly Conduct,
+Government Island,273856,2012,Drugs,
+Government Island,273856,2012,DUII,
+Government Island,273856,2012,Embezzlement,
+Government Island,273856,2012,Forgery,
+Government Island,273856,2012,Fraud,
+Government Island,273856,2012,Gambling,
+Government Island,273856,2012,Homicide,
+Government Island,273856,2012,Kidnap,
+Government Island,273856,2012,Larceny,
+Government Island,273856,2012,Liquor Laws,
+Government Island,273856,2012,Motor Vehicle Theft,
+Government Island,273856,2012,Offenses Against Family,
+Government Island,273856,2012,Prostitution,
+Government Island,273856,2012,Rape,
+Government Island,273856,2012,Robbery,
+Government Island,273856,2012,Runaway,
+Government Island,273856,2012,Sex Offenses,
+Government Island,273856,2012,Stolen Property,
+Government Island,273856,2012,Trespass,
+Government Island,273856,2012,Vandalism,
+Government Island,273856,2012,Weapons,
+Government Island,273856,2013,Aggravated Assault,
+Government Island,273856,2013,Arson,
+Government Island,273856,2013,"Assault, Simple",
+Government Island,273856,2013,Burglary,
+Government Island,273856,2013,Curfew,
+Government Island,273856,2013,Disorderly Conduct,
+Government Island,273856,2013,Drugs,
+Government Island,273856,2013,DUII,
+Government Island,273856,2013,Embezzlement,
+Government Island,273856,2013,Forgery,
+Government Island,273856,2013,Fraud,
+Government Island,273856,2013,Gambling,
+Government Island,273856,2013,Homicide,
+Government Island,273856,2013,Kidnap,
+Government Island,273856,2013,Larceny,
+Government Island,273856,2013,Liquor Laws,
+Government Island,273856,2013,Motor Vehicle Theft,
+Government Island,273856,2013,Offenses Against Family,
+Government Island,273856,2013,Prostitution,
+Government Island,273856,2013,Rape,
+Government Island,273856,2013,Robbery,
+Government Island,273856,2013,Runaway,
+Government Island,273856,2013,Sex Offenses,
+Government Island,273856,2013,Stolen Property,
+Government Island,273856,2013,Trespass,
+Government Island,273856,2013,Vandalism,
+Government Island,273856,2013,Weapons,
+Government Island,273856,2014,Aggravated Assault,
+Government Island,273856,2014,Arson,
+Government Island,273856,2014,"Assault, Simple",
+Government Island,273856,2014,Burglary,
+Government Island,273856,2014,Curfew,
+Government Island,273856,2014,Disorderly Conduct,
+Government Island,273856,2014,Drugs,
+Government Island,273856,2014,DUII,
+Government Island,273856,2014,Embezzlement,
+Government Island,273856,2014,Forgery,
+Government Island,273856,2014,Fraud,
+Government Island,273856,2014,Gambling,
+Government Island,273856,2014,Homicide,
+Government Island,273856,2014,Kidnap,
+Government Island,273856,2014,Larceny,
+Government Island,273856,2014,Liquor Laws,
+Government Island,273856,2014,Motor Vehicle Theft,
+Government Island,273856,2014,Offenses Against Family,
+Government Island,273856,2014,Prostitution,
+Government Island,273856,2014,Rape,
+Government Island,273856,2014,Robbery,
+Government Island,273856,2014,Runaway,
+Government Island,273856,2014,Sex Offenses,
+Government Island,273856,2014,Stolen Property,
+Government Island,273856,2014,Trespass,
+Government Island,273856,2014,Vandalism,
+Government Island,273856,2014,Weapons,
+Greenway,273899,2004,Aggravated Assault,
+Greenway,273899,2004,Arson,
+Greenway,273899,2004,"Assault, Simple",
+Greenway,273899,2004,Burglary,
+Greenway,273899,2004,Curfew,
+Greenway,273899,2004,Disorderly Conduct,
+Greenway,273899,2004,Drugs,
+Greenway,273899,2004,DUII,
+Greenway,273899,2004,Embezzlement,
+Greenway,273899,2004,Forgery,
+Greenway,273899,2004,Fraud,
+Greenway,273899,2004,Gambling,
+Greenway,273899,2004,Homicide,
+Greenway,273899,2004,Kidnap,
+Greenway,273899,2004,Larceny,
+Greenway,273899,2004,Liquor Laws,
+Greenway,273899,2004,Motor Vehicle Theft,
+Greenway,273899,2004,Offenses Against Family,
+Greenway,273899,2004,Prostitution,
+Greenway,273899,2004,Rape,
+Greenway,273899,2004,Robbery,
+Greenway,273899,2004,Runaway,
+Greenway,273899,2004,Sex Offenses,
+Greenway,273899,2004,Stolen Property,
+Greenway,273899,2004,Trespass,
+Greenway,273899,2004,Vandalism,
+Greenway,273899,2004,Weapons,
+Greenway,273899,2005,Aggravated Assault,
+Greenway,273899,2005,Arson,
+Greenway,273899,2005,"Assault, Simple",
+Greenway,273899,2005,Burglary,
+Greenway,273899,2005,Curfew,
+Greenway,273899,2005,Disorderly Conduct,
+Greenway,273899,2005,Drugs,
+Greenway,273899,2005,DUII,
+Greenway,273899,2005,Embezzlement,
+Greenway,273899,2005,Forgery,
+Greenway,273899,2005,Fraud,
+Greenway,273899,2005,Gambling,
+Greenway,273899,2005,Homicide,
+Greenway,273899,2005,Kidnap,
+Greenway,273899,2005,Larceny,
+Greenway,273899,2005,Liquor Laws,
+Greenway,273899,2005,Motor Vehicle Theft,
+Greenway,273899,2005,Offenses Against Family,
+Greenway,273899,2005,Prostitution,
+Greenway,273899,2005,Rape,
+Greenway,273899,2005,Robbery,
+Greenway,273899,2005,Runaway,
+Greenway,273899,2005,Sex Offenses,
+Greenway,273899,2005,Stolen Property,
+Greenway,273899,2005,Trespass,
+Greenway,273899,2005,Vandalism,
+Greenway,273899,2005,Weapons,
+Greenway,273899,2006,Aggravated Assault,
+Greenway,273899,2006,Arson,
+Greenway,273899,2006,"Assault, Simple",
+Greenway,273899,2006,Burglary,
+Greenway,273899,2006,Curfew,
+Greenway,273899,2006,Disorderly Conduct,
+Greenway,273899,2006,Drugs,
+Greenway,273899,2006,DUII,
+Greenway,273899,2006,Embezzlement,
+Greenway,273899,2006,Forgery,
+Greenway,273899,2006,Fraud,
+Greenway,273899,2006,Gambling,
+Greenway,273899,2006,Homicide,
+Greenway,273899,2006,Kidnap,
+Greenway,273899,2006,Larceny,
+Greenway,273899,2006,Liquor Laws,
+Greenway,273899,2006,Motor Vehicle Theft,
+Greenway,273899,2006,Offenses Against Family,
+Greenway,273899,2006,Prostitution,
+Greenway,273899,2006,Rape,
+Greenway,273899,2006,Robbery,
+Greenway,273899,2006,Runaway,
+Greenway,273899,2006,Sex Offenses,
+Greenway,273899,2006,Stolen Property,
+Greenway,273899,2006,Trespass,
+Greenway,273899,2006,Vandalism,
+Greenway,273899,2006,Weapons,
+Greenway,273899,2007,Aggravated Assault,
+Greenway,273899,2007,Arson,
+Greenway,273899,2007,"Assault, Simple",
+Greenway,273899,2007,Burglary,
+Greenway,273899,2007,Curfew,
+Greenway,273899,2007,Disorderly Conduct,
+Greenway,273899,2007,Drugs,
+Greenway,273899,2007,DUII,
+Greenway,273899,2007,Embezzlement,
+Greenway,273899,2007,Forgery,
+Greenway,273899,2007,Fraud,
+Greenway,273899,2007,Gambling,
+Greenway,273899,2007,Homicide,
+Greenway,273899,2007,Kidnap,
+Greenway,273899,2007,Larceny,
+Greenway,273899,2007,Liquor Laws,
+Greenway,273899,2007,Motor Vehicle Theft,
+Greenway,273899,2007,Offenses Against Family,
+Greenway,273899,2007,Prostitution,
+Greenway,273899,2007,Rape,
+Greenway,273899,2007,Robbery,
+Greenway,273899,2007,Runaway,
+Greenway,273899,2007,Sex Offenses,
+Greenway,273899,2007,Stolen Property,
+Greenway,273899,2007,Trespass,
+Greenway,273899,2007,Vandalism,
+Greenway,273899,2007,Weapons,
+Greenway,273899,2008,Aggravated Assault,
+Greenway,273899,2008,Arson,
+Greenway,273899,2008,"Assault, Simple",
+Greenway,273899,2008,Burglary,
+Greenway,273899,2008,Curfew,
+Greenway,273899,2008,Disorderly Conduct,
+Greenway,273899,2008,Drugs,
+Greenway,273899,2008,DUII,
+Greenway,273899,2008,Embezzlement,
+Greenway,273899,2008,Forgery,
+Greenway,273899,2008,Fraud,
+Greenway,273899,2008,Gambling,
+Greenway,273899,2008,Homicide,
+Greenway,273899,2008,Kidnap,
+Greenway,273899,2008,Larceny,
+Greenway,273899,2008,Liquor Laws,
+Greenway,273899,2008,Motor Vehicle Theft,
+Greenway,273899,2008,Offenses Against Family,
+Greenway,273899,2008,Prostitution,
+Greenway,273899,2008,Rape,
+Greenway,273899,2008,Robbery,
+Greenway,273899,2008,Runaway,
+Greenway,273899,2008,Sex Offenses,
+Greenway,273899,2008,Stolen Property,
+Greenway,273899,2008,Trespass,
+Greenway,273899,2008,Vandalism,
+Greenway,273899,2008,Weapons,
+Greenway,273899,2009,Aggravated Assault,
+Greenway,273899,2009,Arson,
+Greenway,273899,2009,"Assault, Simple",
+Greenway,273899,2009,Burglary,
+Greenway,273899,2009,Curfew,
+Greenway,273899,2009,Disorderly Conduct,
+Greenway,273899,2009,Drugs,
+Greenway,273899,2009,DUII,
+Greenway,273899,2009,Embezzlement,
+Greenway,273899,2009,Forgery,
+Greenway,273899,2009,Fraud,
+Greenway,273899,2009,Gambling,
+Greenway,273899,2009,Homicide,
+Greenway,273899,2009,Kidnap,
+Greenway,273899,2009,Larceny,
+Greenway,273899,2009,Liquor Laws,
+Greenway,273899,2009,Motor Vehicle Theft,
+Greenway,273899,2009,Offenses Against Family,
+Greenway,273899,2009,Prostitution,
+Greenway,273899,2009,Rape,
+Greenway,273899,2009,Robbery,
+Greenway,273899,2009,Runaway,
+Greenway,273899,2009,Sex Offenses,
+Greenway,273899,2009,Stolen Property,
+Greenway,273899,2009,Trespass,
+Greenway,273899,2009,Vandalism,
+Greenway,273899,2009,Weapons,
+Greenway,273899,2010,Aggravated Assault,
+Greenway,273899,2010,Arson,
+Greenway,273899,2010,"Assault, Simple",
+Greenway,273899,2010,Burglary,
+Greenway,273899,2010,Curfew,
+Greenway,273899,2010,Disorderly Conduct,
+Greenway,273899,2010,Drugs,
+Greenway,273899,2010,DUII,
+Greenway,273899,2010,Embezzlement,
+Greenway,273899,2010,Forgery,
+Greenway,273899,2010,Fraud,
+Greenway,273899,2010,Gambling,
+Greenway,273899,2010,Homicide,
+Greenway,273899,2010,Kidnap,
+Greenway,273899,2010,Larceny,
+Greenway,273899,2010,Liquor Laws,
+Greenway,273899,2010,Motor Vehicle Theft,
+Greenway,273899,2010,Offenses Against Family,
+Greenway,273899,2010,Prostitution,
+Greenway,273899,2010,Rape,
+Greenway,273899,2010,Robbery,
+Greenway,273899,2010,Runaway,
+Greenway,273899,2010,Sex Offenses,
+Greenway,273899,2010,Stolen Property,
+Greenway,273899,2010,Trespass,
+Greenway,273899,2010,Vandalism,
+Greenway,273899,2010,Weapons,
+Greenway,273899,2011,Aggravated Assault,
+Greenway,273899,2011,Arson,
+Greenway,273899,2011,"Assault, Simple",
+Greenway,273899,2011,Burglary,
+Greenway,273899,2011,Curfew,
+Greenway,273899,2011,Disorderly Conduct,
+Greenway,273899,2011,Drugs,
+Greenway,273899,2011,DUII,
+Greenway,273899,2011,Embezzlement,
+Greenway,273899,2011,Forgery,
+Greenway,273899,2011,Fraud,
+Greenway,273899,2011,Gambling,
+Greenway,273899,2011,Homicide,
+Greenway,273899,2011,Kidnap,
+Greenway,273899,2011,Larceny,
+Greenway,273899,2011,Liquor Laws,
+Greenway,273899,2011,Motor Vehicle Theft,
+Greenway,273899,2011,Offenses Against Family,
+Greenway,273899,2011,Prostitution,
+Greenway,273899,2011,Rape,
+Greenway,273899,2011,Robbery,
+Greenway,273899,2011,Runaway,
+Greenway,273899,2011,Sex Offenses,
+Greenway,273899,2011,Stolen Property,
+Greenway,273899,2011,Trespass,
+Greenway,273899,2011,Vandalism,
+Greenway,273899,2011,Weapons,
+Greenway,273899,2012,Aggravated Assault,
+Greenway,273899,2012,Arson,
+Greenway,273899,2012,"Assault, Simple",
+Greenway,273899,2012,Burglary,
+Greenway,273899,2012,Curfew,
+Greenway,273899,2012,Disorderly Conduct,
+Greenway,273899,2012,Drugs,
+Greenway,273899,2012,DUII,
+Greenway,273899,2012,Embezzlement,
+Greenway,273899,2012,Forgery,
+Greenway,273899,2012,Fraud,
+Greenway,273899,2012,Gambling,
+Greenway,273899,2012,Homicide,
+Greenway,273899,2012,Kidnap,
+Greenway,273899,2012,Larceny,
+Greenway,273899,2012,Liquor Laws,
+Greenway,273899,2012,Motor Vehicle Theft,
+Greenway,273899,2012,Offenses Against Family,
+Greenway,273899,2012,Prostitution,
+Greenway,273899,2012,Rape,
+Greenway,273899,2012,Robbery,
+Greenway,273899,2012,Runaway,
+Greenway,273899,2012,Sex Offenses,
+Greenway,273899,2012,Stolen Property,
+Greenway,273899,2012,Trespass,
+Greenway,273899,2012,Vandalism,
+Greenway,273899,2012,Weapons,
+Greenway,273899,2013,Aggravated Assault,
+Greenway,273899,2013,Arson,
+Greenway,273899,2013,"Assault, Simple",
+Greenway,273899,2013,Burglary,
+Greenway,273899,2013,Curfew,
+Greenway,273899,2013,Disorderly Conduct,
+Greenway,273899,2013,Drugs,
+Greenway,273899,2013,DUII,
+Greenway,273899,2013,Embezzlement,
+Greenway,273899,2013,Forgery,
+Greenway,273899,2013,Fraud,
+Greenway,273899,2013,Gambling,
+Greenway,273899,2013,Homicide,
+Greenway,273899,2013,Kidnap,
+Greenway,273899,2013,Larceny,1
+Greenway,273899,2013,Liquor Laws,
+Greenway,273899,2013,Motor Vehicle Theft,
+Greenway,273899,2013,Offenses Against Family,
+Greenway,273899,2013,Prostitution,
+Greenway,273899,2013,Rape,
+Greenway,273899,2013,Robbery,
+Greenway,273899,2013,Runaway,
+Greenway,273899,2013,Sex Offenses,
+Greenway,273899,2013,Stolen Property,
+Greenway,273899,2013,Trespass,
+Greenway,273899,2013,Vandalism,
+Greenway,273899,2013,Weapons,
+Greenway,273899,2014,Aggravated Assault,
+Greenway,273899,2014,Arson,
+Greenway,273899,2014,"Assault, Simple",
+Greenway,273899,2014,Burglary,
+Greenway,273899,2014,Curfew,
+Greenway,273899,2014,Disorderly Conduct,
+Greenway,273899,2014,Drugs,
+Greenway,273899,2014,DUII,
+Greenway,273899,2014,Embezzlement,
+Greenway,273899,2014,Forgery,
+Greenway,273899,2014,Fraud,
+Greenway,273899,2014,Gambling,
+Greenway,273899,2014,Homicide,
+Greenway,273899,2014,Kidnap,
+Greenway,273899,2014,Larceny,
+Greenway,273899,2014,Liquor Laws,
+Greenway,273899,2014,Motor Vehicle Theft,
+Greenway,273899,2014,Offenses Against Family,
+Greenway,273899,2014,Prostitution,
+Greenway,273899,2014,Rape,
+Greenway,273899,2014,Robbery,
+Greenway,273899,2014,Runaway,
+Greenway,273899,2014,Sex Offenses,
+Greenway,273899,2014,Stolen Property,
+Greenway,273899,2014,Trespass,
+Greenway,273899,2014,Vandalism,
+Greenway,273899,2014,Weapons,
+Haden Island,273912,2004,Aggravated Assault,
+Haden Island,273912,2004,Arson,
+Haden Island,273912,2004,"Assault, Simple",
+Haden Island,273912,2004,Burglary,
+Haden Island,273912,2004,Curfew,
+Haden Island,273912,2004,Disorderly Conduct,
+Haden Island,273912,2004,Drugs,1
+Haden Island,273912,2004,DUII,
+Haden Island,273912,2004,Embezzlement,
+Haden Island,273912,2004,Forgery,
+Haden Island,273912,2004,Fraud,
+Haden Island,273912,2004,Gambling,
+Haden Island,273912,2004,Homicide,
+Haden Island,273912,2004,Kidnap,
+Haden Island,273912,2004,Larceny,1
+Haden Island,273912,2004,Liquor Laws,
+Haden Island,273912,2004,Motor Vehicle Theft,
+Haden Island,273912,2004,Offenses Against Family,
+Haden Island,273912,2004,Prostitution,
+Haden Island,273912,2004,Rape,
+Haden Island,273912,2004,Robbery,
+Haden Island,273912,2004,Runaway,
+Haden Island,273912,2004,Sex Offenses,
+Haden Island,273912,2004,Stolen Property,
+Haden Island,273912,2004,Trespass,1
+Haden Island,273912,2004,Vandalism,
+Haden Island,273912,2004,Weapons,
+Haden Island,273912,2005,Aggravated Assault,6
+Haden Island,273912,2005,Arson,
+Haden Island,273912,2005,"Assault, Simple",9
+Haden Island,273912,2005,Burglary,34
+Haden Island,273912,2005,Curfew,
+Haden Island,273912,2005,Disorderly Conduct,12
+Haden Island,273912,2005,Drugs,18
+Haden Island,273912,2005,DUII,6
+Haden Island,273912,2005,Embezzlement,14
+Haden Island,273912,2005,Forgery,31
+Haden Island,273912,2005,Fraud,42
+Haden Island,273912,2005,Gambling,
+Haden Island,273912,2005,Homicide,
+Haden Island,273912,2005,Kidnap,
+Haden Island,273912,2005,Larceny,324
+Haden Island,273912,2005,Liquor Laws,1
+Haden Island,273912,2005,Motor Vehicle Theft,53
+Haden Island,273912,2005,Offenses Against Family,
+Haden Island,273912,2005,Prostitution,
+Haden Island,273912,2005,Rape,
+Haden Island,273912,2005,Robbery,21
+Haden Island,273912,2005,Runaway,
+Haden Island,273912,2005,Sex Offenses,
+Haden Island,273912,2005,Stolen Property,
+Haden Island,273912,2005,Trespass,17
+Haden Island,273912,2005,Vandalism,9
+Haden Island,273912,2005,Weapons,3
+Haden Island,273912,2006,Aggravated Assault,9
+Haden Island,273912,2006,Arson,
+Haden Island,273912,2006,"Assault, Simple",13
+Haden Island,273912,2006,Burglary,38
+Haden Island,273912,2006,Curfew,
+Haden Island,273912,2006,Disorderly Conduct,17
+Haden Island,273912,2006,Drugs,8
+Haden Island,273912,2006,DUII,3
+Haden Island,273912,2006,Embezzlement,16
+Haden Island,273912,2006,Forgery,18
+Haden Island,273912,2006,Fraud,28
+Haden Island,273912,2006,Gambling,
+Haden Island,273912,2006,Homicide,
+Haden Island,273912,2006,Kidnap,
+Haden Island,273912,2006,Larceny,295
+Haden Island,273912,2006,Liquor Laws,2
+Haden Island,273912,2006,Motor Vehicle Theft,27
+Haden Island,273912,2006,Offenses Against Family,
+Haden Island,273912,2006,Prostitution,
+Haden Island,273912,2006,Rape,
+Haden Island,273912,2006,Robbery,12
+Haden Island,273912,2006,Runaway,
+Haden Island,273912,2006,Sex Offenses,
+Haden Island,273912,2006,Stolen Property,
+Haden Island,273912,2006,Trespass,16
+Haden Island,273912,2006,Vandalism,11
+Haden Island,273912,2006,Weapons,2
+Haden Island,273912,2007,Aggravated Assault,5
+Haden Island,273912,2007,Arson,
+Haden Island,273912,2007,"Assault, Simple",8
+Haden Island,273912,2007,Burglary,13
+Haden Island,273912,2007,Curfew,
+Haden Island,273912,2007,Disorderly Conduct,7
+Haden Island,273912,2007,Drugs,12
+Haden Island,273912,2007,DUII,14
+Haden Island,273912,2007,Embezzlement,11
+Haden Island,273912,2007,Forgery,17
+Haden Island,273912,2007,Fraud,27
+Haden Island,273912,2007,Gambling,
+Haden Island,273912,2007,Homicide,
+Haden Island,273912,2007,Kidnap,
+Haden Island,273912,2007,Larceny,234
+Haden Island,273912,2007,Liquor Laws,
+Haden Island,273912,2007,Motor Vehicle Theft,45
+Haden Island,273912,2007,Offenses Against Family,
+Haden Island,273912,2007,Prostitution,
+Haden Island,273912,2007,Rape,
+Haden Island,273912,2007,Robbery,12
+Haden Island,273912,2007,Runaway,
+Haden Island,273912,2007,Sex Offenses,
+Haden Island,273912,2007,Stolen Property,
+Haden Island,273912,2007,Trespass,12
+Haden Island,273912,2007,Vandalism,27
+Haden Island,273912,2007,Weapons,2
+Haden Island,273912,2008,Aggravated Assault,3
+Haden Island,273912,2008,Arson,
+Haden Island,273912,2008,"Assault, Simple",8
+Haden Island,273912,2008,Burglary,24
+Haden Island,273912,2008,Curfew,
+Haden Island,273912,2008,Disorderly Conduct,6
+Haden Island,273912,2008,Drugs,7
+Haden Island,273912,2008,DUII,4
+Haden Island,273912,2008,Embezzlement,9
+Haden Island,273912,2008,Forgery,9
+Haden Island,273912,2008,Fraud,16
+Haden Island,273912,2008,Gambling,
+Haden Island,273912,2008,Homicide,
+Haden Island,273912,2008,Kidnap,
+Haden Island,273912,2008,Larceny,234
+Haden Island,273912,2008,Liquor Laws,2
+Haden Island,273912,2008,Motor Vehicle Theft,42
+Haden Island,273912,2008,Offenses Against Family,
+Haden Island,273912,2008,Prostitution,
+Haden Island,273912,2008,Rape,
+Haden Island,273912,2008,Robbery,11
+Haden Island,273912,2008,Runaway,
+Haden Island,273912,2008,Sex Offenses,
+Haden Island,273912,2008,Stolen Property,
+Haden Island,273912,2008,Trespass,4
+Haden Island,273912,2008,Vandalism,13
+Haden Island,273912,2008,Weapons,
+Haden Island,273912,2009,Aggravated Assault,4
+Haden Island,273912,2009,Arson,
+Haden Island,273912,2009,"Assault, Simple",6
+Haden Island,273912,2009,Burglary,14
+Haden Island,273912,2009,Curfew,1
+Haden Island,273912,2009,Disorderly Conduct,8
+Haden Island,273912,2009,Drugs,10
+Haden Island,273912,2009,DUII,8
+Haden Island,273912,2009,Embezzlement,2
+Haden Island,273912,2009,Forgery,27
+Haden Island,273912,2009,Fraud,22
+Haden Island,273912,2009,Gambling,
+Haden Island,273912,2009,Homicide,
+Haden Island,273912,2009,Kidnap,
+Haden Island,273912,2009,Larceny,244
+Haden Island,273912,2009,Liquor Laws,6
+Haden Island,273912,2009,Motor Vehicle Theft,35
+Haden Island,273912,2009,Offenses Against Family,
+Haden Island,273912,2009,Prostitution,
+Haden Island,273912,2009,Rape,
+Haden Island,273912,2009,Robbery,12
+Haden Island,273912,2009,Runaway,
+Haden Island,273912,2009,Sex Offenses,
+Haden Island,273912,2009,Stolen Property,2
+Haden Island,273912,2009,Trespass,6
+Haden Island,273912,2009,Vandalism,14
+Haden Island,273912,2009,Weapons,1
+Haden Island,273912,2010,Aggravated Assault,4
+Haden Island,273912,2010,Arson,
+Haden Island,273912,2010,"Assault, Simple",12
+Haden Island,273912,2010,Burglary,14
+Haden Island,273912,2010,Curfew,
+Haden Island,273912,2010,Disorderly Conduct,13
+Haden Island,273912,2010,Drugs,18
+Haden Island,273912,2010,DUII,11
+Haden Island,273912,2010,Embezzlement,6
+Haden Island,273912,2010,Forgery,11
+Haden Island,273912,2010,Fraud,16
+Haden Island,273912,2010,Gambling,
+Haden Island,273912,2010,Homicide,
+Haden Island,273912,2010,Kidnap,
+Haden Island,273912,2010,Larceny,209
+Haden Island,273912,2010,Liquor Laws,3
+Haden Island,273912,2010,Motor Vehicle Theft,19
+Haden Island,273912,2010,Offenses Against Family,
+Haden Island,273912,2010,Prostitution,
+Haden Island,273912,2010,Rape,
+Haden Island,273912,2010,Robbery,6
+Haden Island,273912,2010,Runaway,
+Haden Island,273912,2010,Sex Offenses,
+Haden Island,273912,2010,Stolen Property,1
+Haden Island,273912,2010,Trespass,9
+Haden Island,273912,2010,Vandalism,17
+Haden Island,273912,2010,Weapons,
+Haden Island,273912,2011,Aggravated Assault,5
+Haden Island,273912,2011,Arson,
+Haden Island,273912,2011,"Assault, Simple",13
+Haden Island,273912,2011,Burglary,14
+Haden Island,273912,2011,Curfew,
+Haden Island,273912,2011,Disorderly Conduct,10
+Haden Island,273912,2011,Drugs,15
+Haden Island,273912,2011,DUII,15
+Haden Island,273912,2011,Embezzlement,4
+Haden Island,273912,2011,Forgery,16
+Haden Island,273912,2011,Fraud,13
+Haden Island,273912,2011,Gambling,
+Haden Island,273912,2011,Homicide,
+Haden Island,273912,2011,Kidnap,
+Haden Island,273912,2011,Larceny,220
+Haden Island,273912,2011,Liquor Laws,4
+Haden Island,273912,2011,Motor Vehicle Theft,12
+Haden Island,273912,2011,Offenses Against Family,
+Haden Island,273912,2011,Prostitution,
+Haden Island,273912,2011,Rape,
+Haden Island,273912,2011,Robbery,3
+Haden Island,273912,2011,Runaway,
+Haden Island,273912,2011,Sex Offenses,
+Haden Island,273912,2011,Stolen Property,
+Haden Island,273912,2011,Trespass,8
+Haden Island,273912,2011,Vandalism,16
+Haden Island,273912,2011,Weapons,2
+Haden Island,273912,2012,Aggravated Assault,7
+Haden Island,273912,2012,Arson,
+Haden Island,273912,2012,"Assault, Simple",11
+Haden Island,273912,2012,Burglary,13
+Haden Island,273912,2012,Curfew,
+Haden Island,273912,2012,Disorderly Conduct,8
+Haden Island,273912,2012,Drugs,16
+Haden Island,273912,2012,DUII,10
+Haden Island,273912,2012,Embezzlement,4
+Haden Island,273912,2012,Forgery,7
+Haden Island,273912,2012,Fraud,10
+Haden Island,273912,2012,Gambling,
+Haden Island,273912,2012,Homicide,
+Haden Island,273912,2012,Kidnap,
+Haden Island,273912,2012,Larceny,194
+Haden Island,273912,2012,Liquor Laws,5
+Haden Island,273912,2012,Motor Vehicle Theft,43
+Haden Island,273912,2012,Offenses Against Family,
+Haden Island,273912,2012,Prostitution,
+Haden Island,273912,2012,Rape,
+Haden Island,273912,2012,Robbery,4
+Haden Island,273912,2012,Runaway,
+Haden Island,273912,2012,Sex Offenses,
+Haden Island,273912,2012,Stolen Property,1
+Haden Island,273912,2012,Trespass,11
+Haden Island,273912,2012,Vandalism,19
+Haden Island,273912,2012,Weapons,1
+Haden Island,273912,2013,Aggravated Assault,13
+Haden Island,273912,2013,Arson,
+Haden Island,273912,2013,"Assault, Simple",10
+Haden Island,273912,2013,Burglary,9
+Haden Island,273912,2013,Curfew,
+Haden Island,273912,2013,Disorderly Conduct,12
+Haden Island,273912,2013,Drugs,21
+Haden Island,273912,2013,DUII,10
+Haden Island,273912,2013,Embezzlement,1
+Haden Island,273912,2013,Forgery,12
+Haden Island,273912,2013,Fraud,20
+Haden Island,273912,2013,Gambling,
+Haden Island,273912,2013,Homicide,
+Haden Island,273912,2013,Kidnap,1
+Haden Island,273912,2013,Larceny,249
+Haden Island,273912,2013,Liquor Laws,10
+Haden Island,273912,2013,Motor Vehicle Theft,18
+Haden Island,273912,2013,Offenses Against Family,
+Haden Island,273912,2013,Prostitution,
+Haden Island,273912,2013,Rape,
+Haden Island,273912,2013,Robbery,8
+Haden Island,273912,2013,Runaway,
+Haden Island,273912,2013,Sex Offenses,
+Haden Island,273912,2013,Stolen Property,
+Haden Island,273912,2013,Trespass,16
+Haden Island,273912,2013,Vandalism,11
+Haden Island,273912,2013,Weapons,
+Haden Island,273912,2014,Aggravated Assault,5
+Haden Island,273912,2014,Arson,1
+Haden Island,273912,2014,"Assault, Simple",8
+Haden Island,273912,2014,Burglary,8
+Haden Island,273912,2014,Curfew,
+Haden Island,273912,2014,Disorderly Conduct,17
+Haden Island,273912,2014,Drugs,9
+Haden Island,273912,2014,DUII,11
+Haden Island,273912,2014,Embezzlement,3
+Haden Island,273912,2014,Forgery,1
+Haden Island,273912,2014,Fraud,27
+Haden Island,273912,2014,Gambling,
+Haden Island,273912,2014,Homicide,
+Haden Island,273912,2014,Kidnap,
+Haden Island,273912,2014,Larceny,265
+Haden Island,273912,2014,Liquor Laws,4
+Haden Island,273912,2014,Motor Vehicle Theft,31
+Haden Island,273912,2014,Offenses Against Family,
+Haden Island,273912,2014,Prostitution,
+Haden Island,273912,2014,Rape,
+Haden Island,273912,2014,Robbery,7
+Haden Island,273912,2014,Runaway,
+Haden Island,273912,2014,Sex Offenses,
+Haden Island,273912,2014,Stolen Property,1
+Haden Island,273912,2014,Trespass,15
+Haden Island,273912,2014,Vandalism,10
+Haden Island,273912,2014,Weapons,1
+Hayhurst,271098,2004,Aggravated Assault,
+Hayhurst,271098,2004,Arson,
+Hayhurst,271098,2004,"Assault, Simple",1
+Hayhurst,271098,2004,Burglary,1
+Hayhurst,271098,2004,Curfew,
+Hayhurst,271098,2004,Disorderly Conduct,2
+Hayhurst,271098,2004,Drugs,
+Hayhurst,271098,2004,DUII,2
+Hayhurst,271098,2004,Embezzlement,
+Hayhurst,271098,2004,Forgery,
+Hayhurst,271098,2004,Fraud,4
+Hayhurst,271098,2004,Gambling,
+Hayhurst,271098,2004,Homicide,
+Hayhurst,271098,2004,Kidnap,
+Hayhurst,271098,2004,Larceny,8
+Hayhurst,271098,2004,Liquor Laws,
+Hayhurst,271098,2004,Motor Vehicle Theft,
+Hayhurst,271098,2004,Offenses Against Family,
+Hayhurst,271098,2004,Prostitution,
+Hayhurst,271098,2004,Rape,
+Hayhurst,271098,2004,Robbery,
+Hayhurst,271098,2004,Runaway,
+Hayhurst,271098,2004,Sex Offenses,
+Hayhurst,271098,2004,Stolen Property,
+Hayhurst,271098,2004,Trespass,
+Hayhurst,271098,2004,Vandalism,2
+Hayhurst,271098,2004,Weapons,
+Hayhurst,271098,2005,Aggravated Assault,5
+Hayhurst,271098,2005,Arson,
+Hayhurst,271098,2005,"Assault, Simple",2
+Hayhurst,271098,2005,Burglary,19
+Hayhurst,271098,2005,Curfew,
+Hayhurst,271098,2005,Disorderly Conduct,2
+Hayhurst,271098,2005,Drugs,3
+Hayhurst,271098,2005,DUII,6
+Hayhurst,271098,2005,Embezzlement,
+Hayhurst,271098,2005,Forgery,1
+Hayhurst,271098,2005,Fraud,8
+Hayhurst,271098,2005,Gambling,
+Hayhurst,271098,2005,Homicide,
+Hayhurst,271098,2005,Kidnap,
+Hayhurst,271098,2005,Larceny,65
+Hayhurst,271098,2005,Liquor Laws,
+Hayhurst,271098,2005,Motor Vehicle Theft,5
+Hayhurst,271098,2005,Offenses Against Family,
+Hayhurst,271098,2005,Prostitution,
+Hayhurst,271098,2005,Rape,
+Hayhurst,271098,2005,Robbery,
+Hayhurst,271098,2005,Runaway,
+Hayhurst,271098,2005,Sex Offenses,
+Hayhurst,271098,2005,Stolen Property,
+Hayhurst,271098,2005,Trespass,3
+Hayhurst,271098,2005,Vandalism,15
+Hayhurst,271098,2005,Weapons,
+Hayhurst,271098,2006,Aggravated Assault,1
+Hayhurst,271098,2006,Arson,
+Hayhurst,271098,2006,"Assault, Simple",4
+Hayhurst,271098,2006,Burglary,18
+Hayhurst,271098,2006,Curfew,1
+Hayhurst,271098,2006,Disorderly Conduct,4
+Hayhurst,271098,2006,Drugs,2
+Hayhurst,271098,2006,DUII,2
+Hayhurst,271098,2006,Embezzlement,1
+Hayhurst,271098,2006,Forgery,2
+Hayhurst,271098,2006,Fraud,9
+Hayhurst,271098,2006,Gambling,
+Hayhurst,271098,2006,Homicide,
+Hayhurst,271098,2006,Kidnap,
+Hayhurst,271098,2006,Larceny,38
+Hayhurst,271098,2006,Liquor Laws,3
+Hayhurst,271098,2006,Motor Vehicle Theft,7
+Hayhurst,271098,2006,Offenses Against Family,
+Hayhurst,271098,2006,Prostitution,
+Hayhurst,271098,2006,Rape,
+Hayhurst,271098,2006,Robbery,1
+Hayhurst,271098,2006,Runaway,
+Hayhurst,271098,2006,Sex Offenses,
+Hayhurst,271098,2006,Stolen Property,
+Hayhurst,271098,2006,Trespass,
+Hayhurst,271098,2006,Vandalism,14
+Hayhurst,271098,2006,Weapons,
+Hayhurst,271098,2007,Aggravated Assault,1
+Hayhurst,271098,2007,Arson,
+Hayhurst,271098,2007,"Assault, Simple",2
+Hayhurst,271098,2007,Burglary,11
+Hayhurst,271098,2007,Curfew,
+Hayhurst,271098,2007,Disorderly Conduct,4
+Hayhurst,271098,2007,Drugs,3
+Hayhurst,271098,2007,DUII,6
+Hayhurst,271098,2007,Embezzlement,1
+Hayhurst,271098,2007,Forgery,1
+Hayhurst,271098,2007,Fraud,6
+Hayhurst,271098,2007,Gambling,
+Hayhurst,271098,2007,Homicide,
+Hayhurst,271098,2007,Kidnap,
+Hayhurst,271098,2007,Larceny,33
+Hayhurst,271098,2007,Liquor Laws,
+Hayhurst,271098,2007,Motor Vehicle Theft,5
+Hayhurst,271098,2007,Offenses Against Family,
+Hayhurst,271098,2007,Prostitution,
+Hayhurst,271098,2007,Rape,
+Hayhurst,271098,2007,Robbery,1
+Hayhurst,271098,2007,Runaway,
+Hayhurst,271098,2007,Sex Offenses,
+Hayhurst,271098,2007,Stolen Property,
+Hayhurst,271098,2007,Trespass,3
+Hayhurst,271098,2007,Vandalism,15
+Hayhurst,271098,2007,Weapons,
+Hayhurst,271098,2008,Aggravated Assault,
+Hayhurst,271098,2008,Arson,
+Hayhurst,271098,2008,"Assault, Simple",1
+Hayhurst,271098,2008,Burglary,12
+Hayhurst,271098,2008,Curfew,
+Hayhurst,271098,2008,Disorderly Conduct,6
+Hayhurst,271098,2008,Drugs,2
+Hayhurst,271098,2008,DUII,2
+Hayhurst,271098,2008,Embezzlement,
+Hayhurst,271098,2008,Forgery,
+Hayhurst,271098,2008,Fraud,5
+Hayhurst,271098,2008,Gambling,
+Hayhurst,271098,2008,Homicide,
+Hayhurst,271098,2008,Kidnap,
+Hayhurst,271098,2008,Larceny,33
+Hayhurst,271098,2008,Liquor Laws,2
+Hayhurst,271098,2008,Motor Vehicle Theft,6
+Hayhurst,271098,2008,Offenses Against Family,
+Hayhurst,271098,2008,Prostitution,
+Hayhurst,271098,2008,Rape,
+Hayhurst,271098,2008,Robbery,
+Hayhurst,271098,2008,Runaway,
+Hayhurst,271098,2008,Sex Offenses,
+Hayhurst,271098,2008,Stolen Property,
+Hayhurst,271098,2008,Trespass,1
+Hayhurst,271098,2008,Vandalism,14
+Hayhurst,271098,2008,Weapons,
+Hayhurst,271098,2009,Aggravated Assault,3
+Hayhurst,271098,2009,Arson,
+Hayhurst,271098,2009,"Assault, Simple",
+Hayhurst,271098,2009,Burglary,10
+Hayhurst,271098,2009,Curfew,
+Hayhurst,271098,2009,Disorderly Conduct,3
+Hayhurst,271098,2009,Drugs,2
+Hayhurst,271098,2009,DUII,2
+Hayhurst,271098,2009,Embezzlement,1
+Hayhurst,271098,2009,Forgery,2
+Hayhurst,271098,2009,Fraud,4
+Hayhurst,271098,2009,Gambling,
+Hayhurst,271098,2009,Homicide,
+Hayhurst,271098,2009,Kidnap,
+Hayhurst,271098,2009,Larceny,54
+Hayhurst,271098,2009,Liquor Laws,1
+Hayhurst,271098,2009,Motor Vehicle Theft,5
+Hayhurst,271098,2009,Offenses Against Family,
+Hayhurst,271098,2009,Prostitution,
+Hayhurst,271098,2009,Rape,
+Hayhurst,271098,2009,Robbery,1
+Hayhurst,271098,2009,Runaway,
+Hayhurst,271098,2009,Sex Offenses,
+Hayhurst,271098,2009,Stolen Property,
+Hayhurst,271098,2009,Trespass,4
+Hayhurst,271098,2009,Vandalism,13
+Hayhurst,271098,2009,Weapons,
+Hayhurst,271098,2010,Aggravated Assault,2
+Hayhurst,271098,2010,Arson,
+Hayhurst,271098,2010,"Assault, Simple",2
+Hayhurst,271098,2010,Burglary,6
+Hayhurst,271098,2010,Curfew,
+Hayhurst,271098,2010,Disorderly Conduct,2
+Hayhurst,271098,2010,Drugs,1
+Hayhurst,271098,2010,DUII,1
+Hayhurst,271098,2010,Embezzlement,
+Hayhurst,271098,2010,Forgery,2
+Hayhurst,271098,2010,Fraud,5
+Hayhurst,271098,2010,Gambling,
+Hayhurst,271098,2010,Homicide,
+Hayhurst,271098,2010,Kidnap,
+Hayhurst,271098,2010,Larceny,40
+Hayhurst,271098,2010,Liquor Laws,1
+Hayhurst,271098,2010,Motor Vehicle Theft,2
+Hayhurst,271098,2010,Offenses Against Family,
+Hayhurst,271098,2010,Prostitution,
+Hayhurst,271098,2010,Rape,
+Hayhurst,271098,2010,Robbery,
+Hayhurst,271098,2010,Runaway,
+Hayhurst,271098,2010,Sex Offenses,
+Hayhurst,271098,2010,Stolen Property,
+Hayhurst,271098,2010,Trespass,3
+Hayhurst,271098,2010,Vandalism,9
+Hayhurst,271098,2010,Weapons,
+Hayhurst,271098,2011,Aggravated Assault,1
+Hayhurst,271098,2011,Arson,
+Hayhurst,271098,2011,"Assault, Simple",1
+Hayhurst,271098,2011,Burglary,18
+Hayhurst,271098,2011,Curfew,
+Hayhurst,271098,2011,Disorderly Conduct,4
+Hayhurst,271098,2011,Drugs,1
+Hayhurst,271098,2011,DUII,4
+Hayhurst,271098,2011,Embezzlement,
+Hayhurst,271098,2011,Forgery,
+Hayhurst,271098,2011,Fraud,7
+Hayhurst,271098,2011,Gambling,
+Hayhurst,271098,2011,Homicide,
+Hayhurst,271098,2011,Kidnap,
+Hayhurst,271098,2011,Larceny,43
+Hayhurst,271098,2011,Liquor Laws,
+Hayhurst,271098,2011,Motor Vehicle Theft,5
+Hayhurst,271098,2011,Offenses Against Family,
+Hayhurst,271098,2011,Prostitution,
+Hayhurst,271098,2011,Rape,
+Hayhurst,271098,2011,Robbery,3
+Hayhurst,271098,2011,Runaway,
+Hayhurst,271098,2011,Sex Offenses,
+Hayhurst,271098,2011,Stolen Property,
+Hayhurst,271098,2011,Trespass,2
+Hayhurst,271098,2011,Vandalism,11
+Hayhurst,271098,2011,Weapons,
+Hayhurst,271098,2012,Aggravated Assault,
+Hayhurst,271098,2012,Arson,
+Hayhurst,271098,2012,"Assault, Simple",4
+Hayhurst,271098,2012,Burglary,15
+Hayhurst,271098,2012,Curfew,
+Hayhurst,271098,2012,Disorderly Conduct,2
+Hayhurst,271098,2012,Drugs,1
+Hayhurst,271098,2012,DUII,1
+Hayhurst,271098,2012,Embezzlement,
+Hayhurst,271098,2012,Forgery,
+Hayhurst,271098,2012,Fraud,9
+Hayhurst,271098,2012,Gambling,
+Hayhurst,271098,2012,Homicide,1
+Hayhurst,271098,2012,Kidnap,
+Hayhurst,271098,2012,Larceny,74
+Hayhurst,271098,2012,Liquor Laws,1
+Hayhurst,271098,2012,Motor Vehicle Theft,11
+Hayhurst,271098,2012,Offenses Against Family,
+Hayhurst,271098,2012,Prostitution,
+Hayhurst,271098,2012,Rape,
+Hayhurst,271098,2012,Robbery,2
+Hayhurst,271098,2012,Runaway,
+Hayhurst,271098,2012,Sex Offenses,
+Hayhurst,271098,2012,Stolen Property,
+Hayhurst,271098,2012,Trespass,3
+Hayhurst,271098,2012,Vandalism,27
+Hayhurst,271098,2012,Weapons,
+Hayhurst,271098,2013,Aggravated Assault,2
+Hayhurst,271098,2013,Arson,
+Hayhurst,271098,2013,"Assault, Simple",3
+Hayhurst,271098,2013,Burglary,5
+Hayhurst,271098,2013,Curfew,
+Hayhurst,271098,2013,Disorderly Conduct,4
+Hayhurst,271098,2013,Drugs,2
+Hayhurst,271098,2013,DUII,
+Hayhurst,271098,2013,Embezzlement,
+Hayhurst,271098,2013,Forgery,2
+Hayhurst,271098,2013,Fraud,3
+Hayhurst,271098,2013,Gambling,
+Hayhurst,271098,2013,Homicide,
+Hayhurst,271098,2013,Kidnap,
+Hayhurst,271098,2013,Larceny,45
+Hayhurst,271098,2013,Liquor Laws,
+Hayhurst,271098,2013,Motor Vehicle Theft,3
+Hayhurst,271098,2013,Offenses Against Family,
+Hayhurst,271098,2013,Prostitution,
+Hayhurst,271098,2013,Rape,
+Hayhurst,271098,2013,Robbery,1
+Hayhurst,271098,2013,Runaway,
+Hayhurst,271098,2013,Sex Offenses,
+Hayhurst,271098,2013,Stolen Property,1
+Hayhurst,271098,2013,Trespass,3
+Hayhurst,271098,2013,Vandalism,7
+Hayhurst,271098,2013,Weapons,1
+Hayhurst,271098,2014,Aggravated Assault,
+Hayhurst,271098,2014,Arson,
+Hayhurst,271098,2014,"Assault, Simple",4
+Hayhurst,271098,2014,Burglary,8
+Hayhurst,271098,2014,Curfew,
+Hayhurst,271098,2014,Disorderly Conduct,3
+Hayhurst,271098,2014,Drugs,
+Hayhurst,271098,2014,DUII,2
+Hayhurst,271098,2014,Embezzlement,
+Hayhurst,271098,2014,Forgery,1
+Hayhurst,271098,2014,Fraud,6
+Hayhurst,271098,2014,Gambling,
+Hayhurst,271098,2014,Homicide,
+Hayhurst,271098,2014,Kidnap,
+Hayhurst,271098,2014,Larceny,56
+Hayhurst,271098,2014,Liquor Laws,
+Hayhurst,271098,2014,Motor Vehicle Theft,5
+Hayhurst,271098,2014,Offenses Against Family,
+Hayhurst,271098,2014,Prostitution,
+Hayhurst,271098,2014,Rape,
+Hayhurst,271098,2014,Robbery,1
+Hayhurst,271098,2014,Runaway,
+Hayhurst,271098,2014,Sex Offenses,
+Hayhurst,271098,2014,Stolen Property,
+Hayhurst,271098,2014,Trespass,
+Hayhurst,271098,2014,Vandalism,9
+Hayhurst,271098,2014,Weapons,
+Hazelwood,206971,2004,Aggravated Assault,11
+Hazelwood,206971,2004,Arson,
+Hazelwood,206971,2004,"Assault, Simple",25
+Hazelwood,206971,2004,Burglary,62
+Hazelwood,206971,2004,Curfew,4
+Hazelwood,206971,2004,Disorderly Conduct,14
+Hazelwood,206971,2004,Drugs,12
+Hazelwood,206971,2004,DUII,34
+Hazelwood,206971,2004,Embezzlement,4
+Hazelwood,206971,2004,Forgery,36
+Hazelwood,206971,2004,Fraud,35
+Hazelwood,206971,2004,Gambling,
+Hazelwood,206971,2004,Homicide,
+Hazelwood,206971,2004,Kidnap,
+Hazelwood,206971,2004,Larceny,305
+Hazelwood,206971,2004,Liquor Laws,13
+Hazelwood,206971,2004,Motor Vehicle Theft,76
+Hazelwood,206971,2004,Offenses Against Family,
+Hazelwood,206971,2004,Prostitution,
+Hazelwood,206971,2004,Rape,
+Hazelwood,206971,2004,Robbery,24
+Hazelwood,206971,2004,Runaway,
+Hazelwood,206971,2004,Sex Offenses,1
+Hazelwood,206971,2004,Stolen Property,
+Hazelwood,206971,2004,Trespass,19
+Hazelwood,206971,2004,Vandalism,38
+Hazelwood,206971,2004,Weapons,3
+Hazelwood,206971,2005,Aggravated Assault,79
+Hazelwood,206971,2005,Arson,2
+Hazelwood,206971,2005,"Assault, Simple",107
+Hazelwood,206971,2005,Burglary,226
+Hazelwood,206971,2005,Curfew,12
+Hazelwood,206971,2005,Disorderly Conduct,108
+Hazelwood,206971,2005,Drugs,109
+Hazelwood,206971,2005,DUII,91
+Hazelwood,206971,2005,Embezzlement,21
+Hazelwood,206971,2005,Forgery,167
+Hazelwood,206971,2005,Fraud,206
+Hazelwood,206971,2005,Gambling,
+Hazelwood,206971,2005,Homicide,3
+Hazelwood,206971,2005,Kidnap,
+Hazelwood,206971,2005,Larceny,1865
+Hazelwood,206971,2005,Liquor Laws,40
+Hazelwood,206971,2005,Motor Vehicle Theft,431
+Hazelwood,206971,2005,Offenses Against Family,
+Hazelwood,206971,2005,Prostitution,3
+Hazelwood,206971,2005,Rape,3
+Hazelwood,206971,2005,Robbery,71
+Hazelwood,206971,2005,Runaway,2
+Hazelwood,206971,2005,Sex Offenses,2
+Hazelwood,206971,2005,Stolen Property,3
+Hazelwood,206971,2005,Trespass,96
+Hazelwood,206971,2005,Vandalism,298
+Hazelwood,206971,2005,Weapons,12
+Hazelwood,206971,2006,Aggravated Assault,76
+Hazelwood,206971,2006,Arson,3
+Hazelwood,206971,2006,"Assault, Simple",129
+Hazelwood,206971,2006,Burglary,174
+Hazelwood,206971,2006,Curfew,10
+Hazelwood,206971,2006,Disorderly Conduct,160
+Hazelwood,206971,2006,Drugs,134
+Hazelwood,206971,2006,DUII,142
+Hazelwood,206971,2006,Embezzlement,27
+Hazelwood,206971,2006,Forgery,155
+Hazelwood,206971,2006,Fraud,198
+Hazelwood,206971,2006,Gambling,1
+Hazelwood,206971,2006,Homicide,2
+Hazelwood,206971,2006,Kidnap,2
+Hazelwood,206971,2006,Larceny,1614
+Hazelwood,206971,2006,Liquor Laws,52
+Hazelwood,206971,2006,Motor Vehicle Theft,322
+Hazelwood,206971,2006,Offenses Against Family,
+Hazelwood,206971,2006,Prostitution,2
+Hazelwood,206971,2006,Rape,2
+Hazelwood,206971,2006,Robbery,91
+Hazelwood,206971,2006,Runaway,2
+Hazelwood,206971,2006,Sex Offenses,2
+Hazelwood,206971,2006,Stolen Property,4
+Hazelwood,206971,2006,Trespass,127
+Hazelwood,206971,2006,Vandalism,280
+Hazelwood,206971,2006,Weapons,20
+Hazelwood,206971,2007,Aggravated Assault,88
+Hazelwood,206971,2007,Arson,2
+Hazelwood,206971,2007,"Assault, Simple",154
+Hazelwood,206971,2007,Burglary,223
+Hazelwood,206971,2007,Curfew,10
+Hazelwood,206971,2007,Disorderly Conduct,153
+Hazelwood,206971,2007,Drugs,110
+Hazelwood,206971,2007,DUII,139
+Hazelwood,206971,2007,Embezzlement,15
+Hazelwood,206971,2007,Forgery,141
+Hazelwood,206971,2007,Fraud,168
+Hazelwood,206971,2007,Gambling,
+Hazelwood,206971,2007,Homicide,3
+Hazelwood,206971,2007,Kidnap,
+Hazelwood,206971,2007,Larceny,1605
+Hazelwood,206971,2007,Liquor Laws,46
+Hazelwood,206971,2007,Motor Vehicle Theft,360
+Hazelwood,206971,2007,Offenses Against Family,1
+Hazelwood,206971,2007,Prostitution,4
+Hazelwood,206971,2007,Rape,
+Hazelwood,206971,2007,Robbery,91
+Hazelwood,206971,2007,Runaway,
+Hazelwood,206971,2007,Sex Offenses,6
+Hazelwood,206971,2007,Stolen Property,2
+Hazelwood,206971,2007,Trespass,110
+Hazelwood,206971,2007,Vandalism,350
+Hazelwood,206971,2007,Weapons,21
+Hazelwood,206971,2008,Aggravated Assault,55
+Hazelwood,206971,2008,Arson,
+Hazelwood,206971,2008,"Assault, Simple",129
+Hazelwood,206971,2008,Burglary,210
+Hazelwood,206971,2008,Curfew,15
+Hazelwood,206971,2008,Disorderly Conduct,204
+Hazelwood,206971,2008,Drugs,98
+Hazelwood,206971,2008,DUII,112
+Hazelwood,206971,2008,Embezzlement,25
+Hazelwood,206971,2008,Forgery,112
+Hazelwood,206971,2008,Fraud,152
+Hazelwood,206971,2008,Gambling,
+Hazelwood,206971,2008,Homicide,2
+Hazelwood,206971,2008,Kidnap,1
+Hazelwood,206971,2008,Larceny,1499
+Hazelwood,206971,2008,Liquor Laws,66
+Hazelwood,206971,2008,Motor Vehicle Theft,232
+Hazelwood,206971,2008,Offenses Against Family,4
+Hazelwood,206971,2008,Prostitution,4
+Hazelwood,206971,2008,Rape,1
+Hazelwood,206971,2008,Robbery,85
+Hazelwood,206971,2008,Runaway,
+Hazelwood,206971,2008,Sex Offenses,3
+Hazelwood,206971,2008,Stolen Property,6
+Hazelwood,206971,2008,Trespass,121
+Hazelwood,206971,2008,Vandalism,289
+Hazelwood,206971,2008,Weapons,19
+Hazelwood,206971,2009,Aggravated Assault,61
+Hazelwood,206971,2009,Arson,3
+Hazelwood,206971,2009,"Assault, Simple",105
+Hazelwood,206971,2009,Burglary,164
+Hazelwood,206971,2009,Curfew,16
+Hazelwood,206971,2009,Disorderly Conduct,230
+Hazelwood,206971,2009,Drugs,117
+Hazelwood,206971,2009,DUII,105
+Hazelwood,206971,2009,Embezzlement,8
+Hazelwood,206971,2009,Forgery,116
+Hazelwood,206971,2009,Fraud,141
+Hazelwood,206971,2009,Gambling,
+Hazelwood,206971,2009,Homicide,1
+Hazelwood,206971,2009,Kidnap,1
+Hazelwood,206971,2009,Larceny,1407
+Hazelwood,206971,2009,Liquor Laws,31
+Hazelwood,206971,2009,Motor Vehicle Theft,178
+Hazelwood,206971,2009,Offenses Against Family,
+Hazelwood,206971,2009,Prostitution,8
+Hazelwood,206971,2009,Rape,1
+Hazelwood,206971,2009,Robbery,66
+Hazelwood,206971,2009,Runaway,1
+Hazelwood,206971,2009,Sex Offenses,1
+Hazelwood,206971,2009,Stolen Property,9
+Hazelwood,206971,2009,Trespass,77
+Hazelwood,206971,2009,Vandalism,227
+Hazelwood,206971,2009,Weapons,16
+Hazelwood,206971,2010,Aggravated Assault,82
+Hazelwood,206971,2010,Arson,
+Hazelwood,206971,2010,"Assault, Simple",144
+Hazelwood,206971,2010,Burglary,209
+Hazelwood,206971,2010,Curfew,3
+Hazelwood,206971,2010,Disorderly Conduct,252
+Hazelwood,206971,2010,Drugs,88
+Hazelwood,206971,2010,DUII,92
+Hazelwood,206971,2010,Embezzlement,9
+Hazelwood,206971,2010,Forgery,76
+Hazelwood,206971,2010,Fraud,160
+Hazelwood,206971,2010,Gambling,
+Hazelwood,206971,2010,Homicide,3
+Hazelwood,206971,2010,Kidnap,2
+Hazelwood,206971,2010,Larceny,1586
+Hazelwood,206971,2010,Liquor Laws,32
+Hazelwood,206971,2010,Motor Vehicle Theft,215
+Hazelwood,206971,2010,Offenses Against Family,3
+Hazelwood,206971,2010,Prostitution,3
+Hazelwood,206971,2010,Rape,2
+Hazelwood,206971,2010,Robbery,76
+Hazelwood,206971,2010,Runaway,1
+Hazelwood,206971,2010,Sex Offenses,4
+Hazelwood,206971,2010,Stolen Property,4
+Hazelwood,206971,2010,Trespass,95
+Hazelwood,206971,2010,Vandalism,243
+Hazelwood,206971,2010,Weapons,14
+Hazelwood,206971,2011,Aggravated Assault,57
+Hazelwood,206971,2011,Arson,2
+Hazelwood,206971,2011,"Assault, Simple",114
+Hazelwood,206971,2011,Burglary,235
+Hazelwood,206971,2011,Curfew,4
+Hazelwood,206971,2011,Disorderly Conduct,232
+Hazelwood,206971,2011,Drugs,120
+Hazelwood,206971,2011,DUII,67
+Hazelwood,206971,2011,Embezzlement,11
+Hazelwood,206971,2011,Forgery,137
+Hazelwood,206971,2011,Fraud,170
+Hazelwood,206971,2011,Gambling,
+Hazelwood,206971,2011,Homicide,2
+Hazelwood,206971,2011,Kidnap,
+Hazelwood,206971,2011,Larceny,1550
+Hazelwood,206971,2011,Liquor Laws,33
+Hazelwood,206971,2011,Motor Vehicle Theft,229
+Hazelwood,206971,2011,Offenses Against Family,1
+Hazelwood,206971,2011,Prostitution,
+Hazelwood,206971,2011,Rape,
+Hazelwood,206971,2011,Robbery,69
+Hazelwood,206971,2011,Runaway,1
+Hazelwood,206971,2011,Sex Offenses,3
+Hazelwood,206971,2011,Stolen Property,6
+Hazelwood,206971,2011,Trespass,151
+Hazelwood,206971,2011,Vandalism,212
+Hazelwood,206971,2011,Weapons,15
+Hazelwood,206971,2012,Aggravated Assault,60
+Hazelwood,206971,2012,Arson,
+Hazelwood,206971,2012,"Assault, Simple",157
+Hazelwood,206971,2012,Burglary,195
+Hazelwood,206971,2012,Curfew,1
+Hazelwood,206971,2012,Disorderly Conduct,212
+Hazelwood,206971,2012,Drugs,138
+Hazelwood,206971,2012,DUII,103
+Hazelwood,206971,2012,Embezzlement,8
+Hazelwood,206971,2012,Forgery,101
+Hazelwood,206971,2012,Fraud,161
+Hazelwood,206971,2012,Gambling,
+Hazelwood,206971,2012,Homicide,1
+Hazelwood,206971,2012,Kidnap,2
+Hazelwood,206971,2012,Larceny,1449
+Hazelwood,206971,2012,Liquor Laws,31
+Hazelwood,206971,2012,Motor Vehicle Theft,269
+Hazelwood,206971,2012,Offenses Against Family,
+Hazelwood,206971,2012,Prostitution,8
+Hazelwood,206971,2012,Rape,1
+Hazelwood,206971,2012,Robbery,78
+Hazelwood,206971,2012,Runaway,1
+Hazelwood,206971,2012,Sex Offenses,2
+Hazelwood,206971,2012,Stolen Property,7
+Hazelwood,206971,2012,Trespass,146
+Hazelwood,206971,2012,Vandalism,200
+Hazelwood,206971,2012,Weapons,17
+Hazelwood,206971,2013,Aggravated Assault,66
+Hazelwood,206971,2013,Arson,2
+Hazelwood,206971,2013,"Assault, Simple",137
+Hazelwood,206971,2013,Burglary,173
+Hazelwood,206971,2013,Curfew,2
+Hazelwood,206971,2013,Disorderly Conduct,185
+Hazelwood,206971,2013,Drugs,122
+Hazelwood,206971,2013,DUII,100
+Hazelwood,206971,2013,Embezzlement,6
+Hazelwood,206971,2013,Forgery,67
+Hazelwood,206971,2013,Fraud,146
+Hazelwood,206971,2013,Gambling,
+Hazelwood,206971,2013,Homicide,1
+Hazelwood,206971,2013,Kidnap,1
+Hazelwood,206971,2013,Larceny,1276
+Hazelwood,206971,2013,Liquor Laws,28
+Hazelwood,206971,2013,Motor Vehicle Theft,247
+Hazelwood,206971,2013,Offenses Against Family,1
+Hazelwood,206971,2013,Prostitution,23
+Hazelwood,206971,2013,Rape,3
+Hazelwood,206971,2013,Robbery,73
+Hazelwood,206971,2013,Runaway,1
+Hazelwood,206971,2013,Sex Offenses,7
+Hazelwood,206971,2013,Stolen Property,4
+Hazelwood,206971,2013,Trespass,147
+Hazelwood,206971,2013,Vandalism,179
+Hazelwood,206971,2013,Weapons,29
+Hazelwood,206971,2014,Aggravated Assault,71
+Hazelwood,206971,2014,Arson,
+Hazelwood,206971,2014,"Assault, Simple",108
+Hazelwood,206971,2014,Burglary,240
+Hazelwood,206971,2014,Curfew,1
+Hazelwood,206971,2014,Disorderly Conduct,155
+Hazelwood,206971,2014,Drugs,114
+Hazelwood,206971,2014,DUII,91
+Hazelwood,206971,2014,Embezzlement,13
+Hazelwood,206971,2014,Forgery,45
+Hazelwood,206971,2014,Fraud,151
+Hazelwood,206971,2014,Gambling,
+Hazelwood,206971,2014,Homicide,3
+Hazelwood,206971,2014,Kidnap,1
+Hazelwood,206971,2014,Larceny,1331
+Hazelwood,206971,2014,Liquor Laws,23
+Hazelwood,206971,2014,Motor Vehicle Theft,256
+Hazelwood,206971,2014,Offenses Against Family,
+Hazelwood,206971,2014,Prostitution,53
+Hazelwood,206971,2014,Rape,3
+Hazelwood,206971,2014,Robbery,54
+Hazelwood,206971,2014,Runaway,3
+Hazelwood,206971,2014,Sex Offenses,3
+Hazelwood,206971,2014,Stolen Property,5
+Hazelwood,206971,2014,Trespass,142
+Hazelwood,206971,2014,Vandalism,187
+Hazelwood,206971,2014,Weapons,23
+Hector Campbell,273955,2004,Aggravated Assault,
+Hector Campbell,273955,2004,Arson,
+Hector Campbell,273955,2004,"Assault, Simple",
+Hector Campbell,273955,2004,Burglary,
+Hector Campbell,273955,2004,Curfew,
+Hector Campbell,273955,2004,Disorderly Conduct,
+Hector Campbell,273955,2004,Drugs,
+Hector Campbell,273955,2004,DUII,
+Hector Campbell,273955,2004,Embezzlement,
+Hector Campbell,273955,2004,Forgery,
+Hector Campbell,273955,2004,Fraud,
+Hector Campbell,273955,2004,Gambling,
+Hector Campbell,273955,2004,Homicide,
+Hector Campbell,273955,2004,Kidnap,
+Hector Campbell,273955,2004,Larceny,
+Hector Campbell,273955,2004,Liquor Laws,
+Hector Campbell,273955,2004,Motor Vehicle Theft,
+Hector Campbell,273955,2004,Offenses Against Family,
+Hector Campbell,273955,2004,Prostitution,
+Hector Campbell,273955,2004,Rape,
+Hector Campbell,273955,2004,Robbery,
+Hector Campbell,273955,2004,Runaway,
+Hector Campbell,273955,2004,Sex Offenses,
+Hector Campbell,273955,2004,Stolen Property,
+Hector Campbell,273955,2004,Trespass,
+Hector Campbell,273955,2004,Vandalism,
+Hector Campbell,273955,2004,Weapons,
+Hector Campbell,273955,2005,Aggravated Assault,
+Hector Campbell,273955,2005,Arson,
+Hector Campbell,273955,2005,"Assault, Simple",
+Hector Campbell,273955,2005,Burglary,
+Hector Campbell,273955,2005,Curfew,
+Hector Campbell,273955,2005,Disorderly Conduct,
+Hector Campbell,273955,2005,Drugs,
+Hector Campbell,273955,2005,DUII,
+Hector Campbell,273955,2005,Embezzlement,
+Hector Campbell,273955,2005,Forgery,
+Hector Campbell,273955,2005,Fraud,
+Hector Campbell,273955,2005,Gambling,
+Hector Campbell,273955,2005,Homicide,
+Hector Campbell,273955,2005,Kidnap,
+Hector Campbell,273955,2005,Larceny,
+Hector Campbell,273955,2005,Liquor Laws,
+Hector Campbell,273955,2005,Motor Vehicle Theft,
+Hector Campbell,273955,2005,Offenses Against Family,
+Hector Campbell,273955,2005,Prostitution,
+Hector Campbell,273955,2005,Rape,
+Hector Campbell,273955,2005,Robbery,
+Hector Campbell,273955,2005,Runaway,
+Hector Campbell,273955,2005,Sex Offenses,
+Hector Campbell,273955,2005,Stolen Property,
+Hector Campbell,273955,2005,Trespass,
+Hector Campbell,273955,2005,Vandalism,
+Hector Campbell,273955,2005,Weapons,
+Hector Campbell,273955,2006,Aggravated Assault,
+Hector Campbell,273955,2006,Arson,
+Hector Campbell,273955,2006,"Assault, Simple",
+Hector Campbell,273955,2006,Burglary,
+Hector Campbell,273955,2006,Curfew,
+Hector Campbell,273955,2006,Disorderly Conduct,
+Hector Campbell,273955,2006,Drugs,
+Hector Campbell,273955,2006,DUII,
+Hector Campbell,273955,2006,Embezzlement,
+Hector Campbell,273955,2006,Forgery,
+Hector Campbell,273955,2006,Fraud,
+Hector Campbell,273955,2006,Gambling,
+Hector Campbell,273955,2006,Homicide,
+Hector Campbell,273955,2006,Kidnap,
+Hector Campbell,273955,2006,Larceny,
+Hector Campbell,273955,2006,Liquor Laws,
+Hector Campbell,273955,2006,Motor Vehicle Theft,
+Hector Campbell,273955,2006,Offenses Against Family,
+Hector Campbell,273955,2006,Prostitution,
+Hector Campbell,273955,2006,Rape,
+Hector Campbell,273955,2006,Robbery,
+Hector Campbell,273955,2006,Runaway,
+Hector Campbell,273955,2006,Sex Offenses,
+Hector Campbell,273955,2006,Stolen Property,
+Hector Campbell,273955,2006,Trespass,
+Hector Campbell,273955,2006,Vandalism,
+Hector Campbell,273955,2006,Weapons,
+Hector Campbell,273955,2007,Aggravated Assault,
+Hector Campbell,273955,2007,Arson,
+Hector Campbell,273955,2007,"Assault, Simple",
+Hector Campbell,273955,2007,Burglary,
+Hector Campbell,273955,2007,Curfew,
+Hector Campbell,273955,2007,Disorderly Conduct,
+Hector Campbell,273955,2007,Drugs,
+Hector Campbell,273955,2007,DUII,
+Hector Campbell,273955,2007,Embezzlement,
+Hector Campbell,273955,2007,Forgery,
+Hector Campbell,273955,2007,Fraud,
+Hector Campbell,273955,2007,Gambling,
+Hector Campbell,273955,2007,Homicide,
+Hector Campbell,273955,2007,Kidnap,
+Hector Campbell,273955,2007,Larceny,
+Hector Campbell,273955,2007,Liquor Laws,
+Hector Campbell,273955,2007,Motor Vehicle Theft,
+Hector Campbell,273955,2007,Offenses Against Family,
+Hector Campbell,273955,2007,Prostitution,
+Hector Campbell,273955,2007,Rape,
+Hector Campbell,273955,2007,Robbery,
+Hector Campbell,273955,2007,Runaway,
+Hector Campbell,273955,2007,Sex Offenses,
+Hector Campbell,273955,2007,Stolen Property,
+Hector Campbell,273955,2007,Trespass,
+Hector Campbell,273955,2007,Vandalism,
+Hector Campbell,273955,2007,Weapons,
+Hector Campbell,273955,2008,Aggravated Assault,
+Hector Campbell,273955,2008,Arson,
+Hector Campbell,273955,2008,"Assault, Simple",
+Hector Campbell,273955,2008,Burglary,
+Hector Campbell,273955,2008,Curfew,
+Hector Campbell,273955,2008,Disorderly Conduct,
+Hector Campbell,273955,2008,Drugs,
+Hector Campbell,273955,2008,DUII,
+Hector Campbell,273955,2008,Embezzlement,
+Hector Campbell,273955,2008,Forgery,
+Hector Campbell,273955,2008,Fraud,
+Hector Campbell,273955,2008,Gambling,
+Hector Campbell,273955,2008,Homicide,
+Hector Campbell,273955,2008,Kidnap,
+Hector Campbell,273955,2008,Larceny,
+Hector Campbell,273955,2008,Liquor Laws,
+Hector Campbell,273955,2008,Motor Vehicle Theft,
+Hector Campbell,273955,2008,Offenses Against Family,
+Hector Campbell,273955,2008,Prostitution,
+Hector Campbell,273955,2008,Rape,
+Hector Campbell,273955,2008,Robbery,
+Hector Campbell,273955,2008,Runaway,
+Hector Campbell,273955,2008,Sex Offenses,
+Hector Campbell,273955,2008,Stolen Property,
+Hector Campbell,273955,2008,Trespass,
+Hector Campbell,273955,2008,Vandalism,
+Hector Campbell,273955,2008,Weapons,
+Hector Campbell,273955,2009,Aggravated Assault,
+Hector Campbell,273955,2009,Arson,
+Hector Campbell,273955,2009,"Assault, Simple",
+Hector Campbell,273955,2009,Burglary,
+Hector Campbell,273955,2009,Curfew,
+Hector Campbell,273955,2009,Disorderly Conduct,
+Hector Campbell,273955,2009,Drugs,
+Hector Campbell,273955,2009,DUII,
+Hector Campbell,273955,2009,Embezzlement,
+Hector Campbell,273955,2009,Forgery,
+Hector Campbell,273955,2009,Fraud,
+Hector Campbell,273955,2009,Gambling,
+Hector Campbell,273955,2009,Homicide,
+Hector Campbell,273955,2009,Kidnap,
+Hector Campbell,273955,2009,Larceny,
+Hector Campbell,273955,2009,Liquor Laws,
+Hector Campbell,273955,2009,Motor Vehicle Theft,
+Hector Campbell,273955,2009,Offenses Against Family,
+Hector Campbell,273955,2009,Prostitution,
+Hector Campbell,273955,2009,Rape,
+Hector Campbell,273955,2009,Robbery,
+Hector Campbell,273955,2009,Runaway,
+Hector Campbell,273955,2009,Sex Offenses,
+Hector Campbell,273955,2009,Stolen Property,
+Hector Campbell,273955,2009,Trespass,
+Hector Campbell,273955,2009,Vandalism,
+Hector Campbell,273955,2009,Weapons,
+Hector Campbell,273955,2010,Aggravated Assault,
+Hector Campbell,273955,2010,Arson,
+Hector Campbell,273955,2010,"Assault, Simple",
+Hector Campbell,273955,2010,Burglary,
+Hector Campbell,273955,2010,Curfew,
+Hector Campbell,273955,2010,Disorderly Conduct,
+Hector Campbell,273955,2010,Drugs,
+Hector Campbell,273955,2010,DUII,
+Hector Campbell,273955,2010,Embezzlement,
+Hector Campbell,273955,2010,Forgery,
+Hector Campbell,273955,2010,Fraud,
+Hector Campbell,273955,2010,Gambling,
+Hector Campbell,273955,2010,Homicide,
+Hector Campbell,273955,2010,Kidnap,
+Hector Campbell,273955,2010,Larceny,
+Hector Campbell,273955,2010,Liquor Laws,
+Hector Campbell,273955,2010,Motor Vehicle Theft,
+Hector Campbell,273955,2010,Offenses Against Family,
+Hector Campbell,273955,2010,Prostitution,
+Hector Campbell,273955,2010,Rape,
+Hector Campbell,273955,2010,Robbery,
+Hector Campbell,273955,2010,Runaway,
+Hector Campbell,273955,2010,Sex Offenses,
+Hector Campbell,273955,2010,Stolen Property,
+Hector Campbell,273955,2010,Trespass,
+Hector Campbell,273955,2010,Vandalism,
+Hector Campbell,273955,2010,Weapons,
+Hector Campbell,273955,2011,Aggravated Assault,
+Hector Campbell,273955,2011,Arson,
+Hector Campbell,273955,2011,"Assault, Simple",
+Hector Campbell,273955,2011,Burglary,
+Hector Campbell,273955,2011,Curfew,
+Hector Campbell,273955,2011,Disorderly Conduct,
+Hector Campbell,273955,2011,Drugs,
+Hector Campbell,273955,2011,DUII,
+Hector Campbell,273955,2011,Embezzlement,
+Hector Campbell,273955,2011,Forgery,
+Hector Campbell,273955,2011,Fraud,
+Hector Campbell,273955,2011,Gambling,
+Hector Campbell,273955,2011,Homicide,
+Hector Campbell,273955,2011,Kidnap,
+Hector Campbell,273955,2011,Larceny,
+Hector Campbell,273955,2011,Liquor Laws,
+Hector Campbell,273955,2011,Motor Vehicle Theft,
+Hector Campbell,273955,2011,Offenses Against Family,
+Hector Campbell,273955,2011,Prostitution,
+Hector Campbell,273955,2011,Rape,
+Hector Campbell,273955,2011,Robbery,
+Hector Campbell,273955,2011,Runaway,
+Hector Campbell,273955,2011,Sex Offenses,
+Hector Campbell,273955,2011,Stolen Property,
+Hector Campbell,273955,2011,Trespass,
+Hector Campbell,273955,2011,Vandalism,
+Hector Campbell,273955,2011,Weapons,
+Hector Campbell,273955,2012,Aggravated Assault,
+Hector Campbell,273955,2012,Arson,
+Hector Campbell,273955,2012,"Assault, Simple",
+Hector Campbell,273955,2012,Burglary,
+Hector Campbell,273955,2012,Curfew,
+Hector Campbell,273955,2012,Disorderly Conduct,
+Hector Campbell,273955,2012,Drugs,
+Hector Campbell,273955,2012,DUII,
+Hector Campbell,273955,2012,Embezzlement,
+Hector Campbell,273955,2012,Forgery,
+Hector Campbell,273955,2012,Fraud,
+Hector Campbell,273955,2012,Gambling,
+Hector Campbell,273955,2012,Homicide,
+Hector Campbell,273955,2012,Kidnap,
+Hector Campbell,273955,2012,Larceny,
+Hector Campbell,273955,2012,Liquor Laws,
+Hector Campbell,273955,2012,Motor Vehicle Theft,
+Hector Campbell,273955,2012,Offenses Against Family,
+Hector Campbell,273955,2012,Prostitution,
+Hector Campbell,273955,2012,Rape,
+Hector Campbell,273955,2012,Robbery,
+Hector Campbell,273955,2012,Runaway,
+Hector Campbell,273955,2012,Sex Offenses,
+Hector Campbell,273955,2012,Stolen Property,
+Hector Campbell,273955,2012,Trespass,
+Hector Campbell,273955,2012,Vandalism,
+Hector Campbell,273955,2012,Weapons,
+Hector Campbell,273955,2013,Aggravated Assault,
+Hector Campbell,273955,2013,Arson,
+Hector Campbell,273955,2013,"Assault, Simple",
+Hector Campbell,273955,2013,Burglary,
+Hector Campbell,273955,2013,Curfew,
+Hector Campbell,273955,2013,Disorderly Conduct,
+Hector Campbell,273955,2013,Drugs,
+Hector Campbell,273955,2013,DUII,
+Hector Campbell,273955,2013,Embezzlement,
+Hector Campbell,273955,2013,Forgery,
+Hector Campbell,273955,2013,Fraud,
+Hector Campbell,273955,2013,Gambling,
+Hector Campbell,273955,2013,Homicide,
+Hector Campbell,273955,2013,Kidnap,
+Hector Campbell,273955,2013,Larceny,
+Hector Campbell,273955,2013,Liquor Laws,
+Hector Campbell,273955,2013,Motor Vehicle Theft,
+Hector Campbell,273955,2013,Offenses Against Family,
+Hector Campbell,273955,2013,Prostitution,
+Hector Campbell,273955,2013,Rape,
+Hector Campbell,273955,2013,Robbery,
+Hector Campbell,273955,2013,Runaway,
+Hector Campbell,273955,2013,Sex Offenses,
+Hector Campbell,273955,2013,Stolen Property,
+Hector Campbell,273955,2013,Trespass,
+Hector Campbell,273955,2013,Vandalism,
+Hector Campbell,273955,2013,Weapons,
+Hector Campbell,273955,2014,Aggravated Assault,
+Hector Campbell,273955,2014,Arson,
+Hector Campbell,273955,2014,"Assault, Simple",
+Hector Campbell,273955,2014,Burglary,
+Hector Campbell,273955,2014,Curfew,
+Hector Campbell,273955,2014,Disorderly Conduct,
+Hector Campbell,273955,2014,Drugs,
+Hector Campbell,273955,2014,DUII,
+Hector Campbell,273955,2014,Embezzlement,
+Hector Campbell,273955,2014,Forgery,
+Hector Campbell,273955,2014,Fraud,
+Hector Campbell,273955,2014,Gambling,
+Hector Campbell,273955,2014,Homicide,
+Hector Campbell,273955,2014,Kidnap,
+Hector Campbell,273955,2014,Larceny,
+Hector Campbell,273955,2014,Liquor Laws,
+Hector Campbell,273955,2014,Motor Vehicle Theft,
+Hector Campbell,273955,2014,Offenses Against Family,
+Hector Campbell,273955,2014,Prostitution,
+Hector Campbell,273955,2014,Rape,
+Hector Campbell,273955,2014,Robbery,
+Hector Campbell,273955,2014,Runaway,
+Hector Campbell,273955,2014,Sex Offenses,
+Hector Campbell,273955,2014,Stolen Property,
+Hector Campbell,273955,2014,Trespass,
+Hector Campbell,273955,2014,Vandalism,
+Hector Campbell,273955,2014,Weapons,
+Highlands,274008,2004,Aggravated Assault,
+Highlands,274008,2004,Arson,
+Highlands,274008,2004,"Assault, Simple",
+Highlands,274008,2004,Burglary,
+Highlands,274008,2004,Curfew,
+Highlands,274008,2004,Disorderly Conduct,
+Highlands,274008,2004,Drugs,
+Highlands,274008,2004,DUII,
+Highlands,274008,2004,Embezzlement,
+Highlands,274008,2004,Forgery,
+Highlands,274008,2004,Fraud,
+Highlands,274008,2004,Gambling,
+Highlands,274008,2004,Homicide,
+Highlands,274008,2004,Kidnap,
+Highlands,274008,2004,Larceny,
+Highlands,274008,2004,Liquor Laws,
+Highlands,274008,2004,Motor Vehicle Theft,
+Highlands,274008,2004,Offenses Against Family,
+Highlands,274008,2004,Prostitution,
+Highlands,274008,2004,Rape,
+Highlands,274008,2004,Robbery,
+Highlands,274008,2004,Runaway,
+Highlands,274008,2004,Sex Offenses,
+Highlands,274008,2004,Stolen Property,
+Highlands,274008,2004,Trespass,
+Highlands,274008,2004,Vandalism,
+Highlands,274008,2004,Weapons,
+Highlands,274008,2005,Aggravated Assault,
+Highlands,274008,2005,Arson,
+Highlands,274008,2005,"Assault, Simple",
+Highlands,274008,2005,Burglary,
+Highlands,274008,2005,Curfew,
+Highlands,274008,2005,Disorderly Conduct,
+Highlands,274008,2005,Drugs,
+Highlands,274008,2005,DUII,
+Highlands,274008,2005,Embezzlement,
+Highlands,274008,2005,Forgery,
+Highlands,274008,2005,Fraud,
+Highlands,274008,2005,Gambling,
+Highlands,274008,2005,Homicide,
+Highlands,274008,2005,Kidnap,
+Highlands,274008,2005,Larceny,
+Highlands,274008,2005,Liquor Laws,
+Highlands,274008,2005,Motor Vehicle Theft,
+Highlands,274008,2005,Offenses Against Family,
+Highlands,274008,2005,Prostitution,
+Highlands,274008,2005,Rape,
+Highlands,274008,2005,Robbery,
+Highlands,274008,2005,Runaway,
+Highlands,274008,2005,Sex Offenses,
+Highlands,274008,2005,Stolen Property,
+Highlands,274008,2005,Trespass,
+Highlands,274008,2005,Vandalism,
+Highlands,274008,2005,Weapons,
+Highlands,274008,2006,Aggravated Assault,
+Highlands,274008,2006,Arson,
+Highlands,274008,2006,"Assault, Simple",
+Highlands,274008,2006,Burglary,
+Highlands,274008,2006,Curfew,
+Highlands,274008,2006,Disorderly Conduct,
+Highlands,274008,2006,Drugs,
+Highlands,274008,2006,DUII,
+Highlands,274008,2006,Embezzlement,
+Highlands,274008,2006,Forgery,
+Highlands,274008,2006,Fraud,
+Highlands,274008,2006,Gambling,
+Highlands,274008,2006,Homicide,
+Highlands,274008,2006,Kidnap,
+Highlands,274008,2006,Larceny,
+Highlands,274008,2006,Liquor Laws,
+Highlands,274008,2006,Motor Vehicle Theft,
+Highlands,274008,2006,Offenses Against Family,
+Highlands,274008,2006,Prostitution,
+Highlands,274008,2006,Rape,
+Highlands,274008,2006,Robbery,
+Highlands,274008,2006,Runaway,
+Highlands,274008,2006,Sex Offenses,
+Highlands,274008,2006,Stolen Property,
+Highlands,274008,2006,Trespass,
+Highlands,274008,2006,Vandalism,
+Highlands,274008,2006,Weapons,
+Highlands,274008,2007,Aggravated Assault,
+Highlands,274008,2007,Arson,
+Highlands,274008,2007,"Assault, Simple",
+Highlands,274008,2007,Burglary,
+Highlands,274008,2007,Curfew,
+Highlands,274008,2007,Disorderly Conduct,
+Highlands,274008,2007,Drugs,
+Highlands,274008,2007,DUII,
+Highlands,274008,2007,Embezzlement,
+Highlands,274008,2007,Forgery,
+Highlands,274008,2007,Fraud,
+Highlands,274008,2007,Gambling,
+Highlands,274008,2007,Homicide,
+Highlands,274008,2007,Kidnap,
+Highlands,274008,2007,Larceny,
+Highlands,274008,2007,Liquor Laws,
+Highlands,274008,2007,Motor Vehicle Theft,
+Highlands,274008,2007,Offenses Against Family,
+Highlands,274008,2007,Prostitution,
+Highlands,274008,2007,Rape,
+Highlands,274008,2007,Robbery,
+Highlands,274008,2007,Runaway,
+Highlands,274008,2007,Sex Offenses,
+Highlands,274008,2007,Stolen Property,
+Highlands,274008,2007,Trespass,
+Highlands,274008,2007,Vandalism,
+Highlands,274008,2007,Weapons,
+Highlands,274008,2008,Aggravated Assault,
+Highlands,274008,2008,Arson,
+Highlands,274008,2008,"Assault, Simple",
+Highlands,274008,2008,Burglary,
+Highlands,274008,2008,Curfew,
+Highlands,274008,2008,Disorderly Conduct,
+Highlands,274008,2008,Drugs,
+Highlands,274008,2008,DUII,
+Highlands,274008,2008,Embezzlement,
+Highlands,274008,2008,Forgery,
+Highlands,274008,2008,Fraud,
+Highlands,274008,2008,Gambling,
+Highlands,274008,2008,Homicide,
+Highlands,274008,2008,Kidnap,
+Highlands,274008,2008,Larceny,
+Highlands,274008,2008,Liquor Laws,
+Highlands,274008,2008,Motor Vehicle Theft,
+Highlands,274008,2008,Offenses Against Family,
+Highlands,274008,2008,Prostitution,
+Highlands,274008,2008,Rape,
+Highlands,274008,2008,Robbery,
+Highlands,274008,2008,Runaway,
+Highlands,274008,2008,Sex Offenses,
+Highlands,274008,2008,Stolen Property,
+Highlands,274008,2008,Trespass,
+Highlands,274008,2008,Vandalism,
+Highlands,274008,2008,Weapons,
+Highlands,274008,2009,Aggravated Assault,
+Highlands,274008,2009,Arson,
+Highlands,274008,2009,"Assault, Simple",
+Highlands,274008,2009,Burglary,
+Highlands,274008,2009,Curfew,
+Highlands,274008,2009,Disorderly Conduct,
+Highlands,274008,2009,Drugs,
+Highlands,274008,2009,DUII,
+Highlands,274008,2009,Embezzlement,
+Highlands,274008,2009,Forgery,
+Highlands,274008,2009,Fraud,
+Highlands,274008,2009,Gambling,
+Highlands,274008,2009,Homicide,
+Highlands,274008,2009,Kidnap,
+Highlands,274008,2009,Larceny,
+Highlands,274008,2009,Liquor Laws,
+Highlands,274008,2009,Motor Vehicle Theft,
+Highlands,274008,2009,Offenses Against Family,
+Highlands,274008,2009,Prostitution,
+Highlands,274008,2009,Rape,
+Highlands,274008,2009,Robbery,
+Highlands,274008,2009,Runaway,
+Highlands,274008,2009,Sex Offenses,
+Highlands,274008,2009,Stolen Property,
+Highlands,274008,2009,Trespass,
+Highlands,274008,2009,Vandalism,
+Highlands,274008,2009,Weapons,
+Highlands,274008,2010,Aggravated Assault,
+Highlands,274008,2010,Arson,
+Highlands,274008,2010,"Assault, Simple",
+Highlands,274008,2010,Burglary,
+Highlands,274008,2010,Curfew,
+Highlands,274008,2010,Disorderly Conduct,
+Highlands,274008,2010,Drugs,
+Highlands,274008,2010,DUII,
+Highlands,274008,2010,Embezzlement,
+Highlands,274008,2010,Forgery,
+Highlands,274008,2010,Fraud,
+Highlands,274008,2010,Gambling,
+Highlands,274008,2010,Homicide,
+Highlands,274008,2010,Kidnap,
+Highlands,274008,2010,Larceny,
+Highlands,274008,2010,Liquor Laws,
+Highlands,274008,2010,Motor Vehicle Theft,
+Highlands,274008,2010,Offenses Against Family,
+Highlands,274008,2010,Prostitution,
+Highlands,274008,2010,Rape,
+Highlands,274008,2010,Robbery,
+Highlands,274008,2010,Runaway,
+Highlands,274008,2010,Sex Offenses,
+Highlands,274008,2010,Stolen Property,
+Highlands,274008,2010,Trespass,
+Highlands,274008,2010,Vandalism,
+Highlands,274008,2010,Weapons,
+Highlands,274008,2011,Aggravated Assault,
+Highlands,274008,2011,Arson,
+Highlands,274008,2011,"Assault, Simple",
+Highlands,274008,2011,Burglary,
+Highlands,274008,2011,Curfew,
+Highlands,274008,2011,Disorderly Conduct,
+Highlands,274008,2011,Drugs,
+Highlands,274008,2011,DUII,
+Highlands,274008,2011,Embezzlement,
+Highlands,274008,2011,Forgery,
+Highlands,274008,2011,Fraud,
+Highlands,274008,2011,Gambling,
+Highlands,274008,2011,Homicide,
+Highlands,274008,2011,Kidnap,
+Highlands,274008,2011,Larceny,
+Highlands,274008,2011,Liquor Laws,
+Highlands,274008,2011,Motor Vehicle Theft,
+Highlands,274008,2011,Offenses Against Family,
+Highlands,274008,2011,Prostitution,
+Highlands,274008,2011,Rape,
+Highlands,274008,2011,Robbery,
+Highlands,274008,2011,Runaway,
+Highlands,274008,2011,Sex Offenses,
+Highlands,274008,2011,Stolen Property,
+Highlands,274008,2011,Trespass,
+Highlands,274008,2011,Vandalism,
+Highlands,274008,2011,Weapons,
+Highlands,274008,2012,Aggravated Assault,
+Highlands,274008,2012,Arson,
+Highlands,274008,2012,"Assault, Simple",
+Highlands,274008,2012,Burglary,
+Highlands,274008,2012,Curfew,
+Highlands,274008,2012,Disorderly Conduct,
+Highlands,274008,2012,Drugs,
+Highlands,274008,2012,DUII,
+Highlands,274008,2012,Embezzlement,
+Highlands,274008,2012,Forgery,
+Highlands,274008,2012,Fraud,
+Highlands,274008,2012,Gambling,
+Highlands,274008,2012,Homicide,
+Highlands,274008,2012,Kidnap,
+Highlands,274008,2012,Larceny,
+Highlands,274008,2012,Liquor Laws,
+Highlands,274008,2012,Motor Vehicle Theft,
+Highlands,274008,2012,Offenses Against Family,
+Highlands,274008,2012,Prostitution,
+Highlands,274008,2012,Rape,
+Highlands,274008,2012,Robbery,
+Highlands,274008,2012,Runaway,
+Highlands,274008,2012,Sex Offenses,
+Highlands,274008,2012,Stolen Property,
+Highlands,274008,2012,Trespass,
+Highlands,274008,2012,Vandalism,
+Highlands,274008,2012,Weapons,
+Highlands,274008,2013,Aggravated Assault,
+Highlands,274008,2013,Arson,
+Highlands,274008,2013,"Assault, Simple",
+Highlands,274008,2013,Burglary,
+Highlands,274008,2013,Curfew,
+Highlands,274008,2013,Disorderly Conduct,
+Highlands,274008,2013,Drugs,
+Highlands,274008,2013,DUII,
+Highlands,274008,2013,Embezzlement,
+Highlands,274008,2013,Forgery,
+Highlands,274008,2013,Fraud,
+Highlands,274008,2013,Gambling,
+Highlands,274008,2013,Homicide,
+Highlands,274008,2013,Kidnap,
+Highlands,274008,2013,Larceny,
+Highlands,274008,2013,Liquor Laws,
+Highlands,274008,2013,Motor Vehicle Theft,
+Highlands,274008,2013,Offenses Against Family,
+Highlands,274008,2013,Prostitution,
+Highlands,274008,2013,Rape,
+Highlands,274008,2013,Robbery,
+Highlands,274008,2013,Runaway,
+Highlands,274008,2013,Sex Offenses,
+Highlands,274008,2013,Stolen Property,
+Highlands,274008,2013,Trespass,
+Highlands,274008,2013,Vandalism,
+Highlands,274008,2013,Weapons,
+Highlands,274008,2014,Aggravated Assault,
+Highlands,274008,2014,Arson,
+Highlands,274008,2014,"Assault, Simple",
+Highlands,274008,2014,Burglary,
+Highlands,274008,2014,Curfew,
+Highlands,274008,2014,Disorderly Conduct,
+Highlands,274008,2014,Drugs,
+Highlands,274008,2014,DUII,
+Highlands,274008,2014,Embezzlement,
+Highlands,274008,2014,Forgery,
+Highlands,274008,2014,Fraud,
+Highlands,274008,2014,Gambling,
+Highlands,274008,2014,Homicide,
+Highlands,274008,2014,Kidnap,
+Highlands,274008,2014,Larceny,
+Highlands,274008,2014,Liquor Laws,
+Highlands,274008,2014,Motor Vehicle Theft,
+Highlands,274008,2014,Offenses Against Family,
+Highlands,274008,2014,Prostitution,
+Highlands,274008,2014,Rape,
+Highlands,274008,2014,Robbery,
+Highlands,274008,2014,Runaway,
+Highlands,274008,2014,Sex Offenses,
+Highlands,274008,2014,Stolen Property,
+Highlands,274008,2014,Trespass,
+Highlands,274008,2014,Vandalism,
+Highlands,274008,2014,Weapons,
+Hillsdale,206987,2004,Aggravated Assault,2
+Hillsdale,206987,2004,Arson,
+Hillsdale,206987,2004,"Assault, Simple",2
+Hillsdale,206987,2004,Burglary,10
+Hillsdale,206987,2004,Curfew,
+Hillsdale,206987,2004,Disorderly Conduct,2
+Hillsdale,206987,2004,Drugs,
+Hillsdale,206987,2004,DUII,4
+Hillsdale,206987,2004,Embezzlement,
+Hillsdale,206987,2004,Forgery,2
+Hillsdale,206987,2004,Fraud,3
+Hillsdale,206987,2004,Gambling,
+Hillsdale,206987,2004,Homicide,
+Hillsdale,206987,2004,Kidnap,
+Hillsdale,206987,2004,Larceny,20
+Hillsdale,206987,2004,Liquor Laws,
+Hillsdale,206987,2004,Motor Vehicle Theft,1
+Hillsdale,206987,2004,Offenses Against Family,
+Hillsdale,206987,2004,Prostitution,
+Hillsdale,206987,2004,Rape,
+Hillsdale,206987,2004,Robbery,1
+Hillsdale,206987,2004,Runaway,
+Hillsdale,206987,2004,Sex Offenses,
+Hillsdale,206987,2004,Stolen Property,
+Hillsdale,206987,2004,Trespass,2
+Hillsdale,206987,2004,Vandalism,9
+Hillsdale,206987,2004,Weapons,
+Hillsdale,206987,2005,Aggravated Assault,4
+Hillsdale,206987,2005,Arson,
+Hillsdale,206987,2005,"Assault, Simple",14
+Hillsdale,206987,2005,Burglary,29
+Hillsdale,206987,2005,Curfew,
+Hillsdale,206987,2005,Disorderly Conduct,8
+Hillsdale,206987,2005,Drugs,10
+Hillsdale,206987,2005,DUII,24
+Hillsdale,206987,2005,Embezzlement,3
+Hillsdale,206987,2005,Forgery,13
+Hillsdale,206987,2005,Fraud,17
+Hillsdale,206987,2005,Gambling,
+Hillsdale,206987,2005,Homicide,
+Hillsdale,206987,2005,Kidnap,
+Hillsdale,206987,2005,Larceny,144
+Hillsdale,206987,2005,Liquor Laws,4
+Hillsdale,206987,2005,Motor Vehicle Theft,21
+Hillsdale,206987,2005,Offenses Against Family,
+Hillsdale,206987,2005,Prostitution,
+Hillsdale,206987,2005,Rape,
+Hillsdale,206987,2005,Robbery,9
+Hillsdale,206987,2005,Runaway,
+Hillsdale,206987,2005,Sex Offenses,3
+Hillsdale,206987,2005,Stolen Property,
+Hillsdale,206987,2005,Trespass,13
+Hillsdale,206987,2005,Vandalism,58
+Hillsdale,206987,2005,Weapons,
+Hillsdale,206987,2006,Aggravated Assault,3
+Hillsdale,206987,2006,Arson,
+Hillsdale,206987,2006,"Assault, Simple",7
+Hillsdale,206987,2006,Burglary,41
+Hillsdale,206987,2006,Curfew,
+Hillsdale,206987,2006,Disorderly Conduct,8
+Hillsdale,206987,2006,Drugs,15
+Hillsdale,206987,2006,DUII,37
+Hillsdale,206987,2006,Embezzlement,
+Hillsdale,206987,2006,Forgery,19
+Hillsdale,206987,2006,Fraud,14
+Hillsdale,206987,2006,Gambling,
+Hillsdale,206987,2006,Homicide,
+Hillsdale,206987,2006,Kidnap,1
+Hillsdale,206987,2006,Larceny,104
+Hillsdale,206987,2006,Liquor Laws,6
+Hillsdale,206987,2006,Motor Vehicle Theft,23
+Hillsdale,206987,2006,Offenses Against Family,
+Hillsdale,206987,2006,Prostitution,
+Hillsdale,206987,2006,Rape,
+Hillsdale,206987,2006,Robbery,8
+Hillsdale,206987,2006,Runaway,
+Hillsdale,206987,2006,Sex Offenses,
+Hillsdale,206987,2006,Stolen Property,
+Hillsdale,206987,2006,Trespass,13
+Hillsdale,206987,2006,Vandalism,50
+Hillsdale,206987,2006,Weapons,1
+Hillsdale,206987,2007,Aggravated Assault,7
+Hillsdale,206987,2007,Arson,
+Hillsdale,206987,2007,"Assault, Simple",11
+Hillsdale,206987,2007,Burglary,28
+Hillsdale,206987,2007,Curfew,
+Hillsdale,206987,2007,Disorderly Conduct,10
+Hillsdale,206987,2007,Drugs,12
+Hillsdale,206987,2007,DUII,33
+Hillsdale,206987,2007,Embezzlement,3
+Hillsdale,206987,2007,Forgery,9
+Hillsdale,206987,2007,Fraud,10
+Hillsdale,206987,2007,Gambling,
+Hillsdale,206987,2007,Homicide,1
+Hillsdale,206987,2007,Kidnap,
+Hillsdale,206987,2007,Larceny,156
+Hillsdale,206987,2007,Liquor Laws,2
+Hillsdale,206987,2007,Motor Vehicle Theft,22
+Hillsdale,206987,2007,Offenses Against Family,
+Hillsdale,206987,2007,Prostitution,
+Hillsdale,206987,2007,Rape,
+Hillsdale,206987,2007,Robbery,7
+Hillsdale,206987,2007,Runaway,
+Hillsdale,206987,2007,Sex Offenses,
+Hillsdale,206987,2007,Stolen Property,
+Hillsdale,206987,2007,Trespass,10
+Hillsdale,206987,2007,Vandalism,31
+Hillsdale,206987,2007,Weapons,
+Hillsdale,206987,2008,Aggravated Assault,6
+Hillsdale,206987,2008,Arson,
+Hillsdale,206987,2008,"Assault, Simple",8
+Hillsdale,206987,2008,Burglary,31
+Hillsdale,206987,2008,Curfew,
+Hillsdale,206987,2008,Disorderly Conduct,11
+Hillsdale,206987,2008,Drugs,12
+Hillsdale,206987,2008,DUII,22
+Hillsdale,206987,2008,Embezzlement,4
+Hillsdale,206987,2008,Forgery,7
+Hillsdale,206987,2008,Fraud,22
+Hillsdale,206987,2008,Gambling,
+Hillsdale,206987,2008,Homicide,1
+Hillsdale,206987,2008,Kidnap,
+Hillsdale,206987,2008,Larceny,105
+Hillsdale,206987,2008,Liquor Laws,7
+Hillsdale,206987,2008,Motor Vehicle Theft,10
+Hillsdale,206987,2008,Offenses Against Family,
+Hillsdale,206987,2008,Prostitution,
+Hillsdale,206987,2008,Rape,
+Hillsdale,206987,2008,Robbery,1
+Hillsdale,206987,2008,Runaway,
+Hillsdale,206987,2008,Sex Offenses,
+Hillsdale,206987,2008,Stolen Property,
+Hillsdale,206987,2008,Trespass,6
+Hillsdale,206987,2008,Vandalism,42
+Hillsdale,206987,2008,Weapons,
+Hillsdale,206987,2009,Aggravated Assault,7
+Hillsdale,206987,2009,Arson,1
+Hillsdale,206987,2009,"Assault, Simple",7
+Hillsdale,206987,2009,Burglary,43
+Hillsdale,206987,2009,Curfew,
+Hillsdale,206987,2009,Disorderly Conduct,9
+Hillsdale,206987,2009,Drugs,16
+Hillsdale,206987,2009,DUII,22
+Hillsdale,206987,2009,Embezzlement,3
+Hillsdale,206987,2009,Forgery,4
+Hillsdale,206987,2009,Fraud,17
+Hillsdale,206987,2009,Gambling,
+Hillsdale,206987,2009,Homicide,
+Hillsdale,206987,2009,Kidnap,
+Hillsdale,206987,2009,Larceny,157
+Hillsdale,206987,2009,Liquor Laws,8
+Hillsdale,206987,2009,Motor Vehicle Theft,27
+Hillsdale,206987,2009,Offenses Against Family,
+Hillsdale,206987,2009,Prostitution,
+Hillsdale,206987,2009,Rape,1
+Hillsdale,206987,2009,Robbery,5
+Hillsdale,206987,2009,Runaway,
+Hillsdale,206987,2009,Sex Offenses,
+Hillsdale,206987,2009,Stolen Property,1
+Hillsdale,206987,2009,Trespass,13
+Hillsdale,206987,2009,Vandalism,49
+Hillsdale,206987,2009,Weapons,1
+Hillsdale,206987,2010,Aggravated Assault,4
+Hillsdale,206987,2010,Arson,
+Hillsdale,206987,2010,"Assault, Simple",10
+Hillsdale,206987,2010,Burglary,39
+Hillsdale,206987,2010,Curfew,
+Hillsdale,206987,2010,Disorderly Conduct,13
+Hillsdale,206987,2010,Drugs,10
+Hillsdale,206987,2010,DUII,26
+Hillsdale,206987,2010,Embezzlement,1
+Hillsdale,206987,2010,Forgery,4
+Hillsdale,206987,2010,Fraud,8
+Hillsdale,206987,2010,Gambling,
+Hillsdale,206987,2010,Homicide,
+Hillsdale,206987,2010,Kidnap,
+Hillsdale,206987,2010,Larceny,125
+Hillsdale,206987,2010,Liquor Laws,4
+Hillsdale,206987,2010,Motor Vehicle Theft,23
+Hillsdale,206987,2010,Offenses Against Family,
+Hillsdale,206987,2010,Prostitution,
+Hillsdale,206987,2010,Rape,
+Hillsdale,206987,2010,Robbery,8
+Hillsdale,206987,2010,Runaway,
+Hillsdale,206987,2010,Sex Offenses,2
+Hillsdale,206987,2010,Stolen Property,
+Hillsdale,206987,2010,Trespass,5
+Hillsdale,206987,2010,Vandalism,34
+Hillsdale,206987,2010,Weapons,
+Hillsdale,206987,2011,Aggravated Assault,6
+Hillsdale,206987,2011,Arson,
+Hillsdale,206987,2011,"Assault, Simple",20
+Hillsdale,206987,2011,Burglary,29
+Hillsdale,206987,2011,Curfew,
+Hillsdale,206987,2011,Disorderly Conduct,13
+Hillsdale,206987,2011,Drugs,13
+Hillsdale,206987,2011,DUII,32
+Hillsdale,206987,2011,Embezzlement,1
+Hillsdale,206987,2011,Forgery,2
+Hillsdale,206987,2011,Fraud,7
+Hillsdale,206987,2011,Gambling,
+Hillsdale,206987,2011,Homicide,
+Hillsdale,206987,2011,Kidnap,
+Hillsdale,206987,2011,Larceny,99
+Hillsdale,206987,2011,Liquor Laws,1
+Hillsdale,206987,2011,Motor Vehicle Theft,14
+Hillsdale,206987,2011,Offenses Against Family,
+Hillsdale,206987,2011,Prostitution,
+Hillsdale,206987,2011,Rape,
+Hillsdale,206987,2011,Robbery,11
+Hillsdale,206987,2011,Runaway,
+Hillsdale,206987,2011,Sex Offenses,
+Hillsdale,206987,2011,Stolen Property,
+Hillsdale,206987,2011,Trespass,4
+Hillsdale,206987,2011,Vandalism,32
+Hillsdale,206987,2011,Weapons,1
+Hillsdale,206987,2012,Aggravated Assault,3
+Hillsdale,206987,2012,Arson,
+Hillsdale,206987,2012,"Assault, Simple",6
+Hillsdale,206987,2012,Burglary,38
+Hillsdale,206987,2012,Curfew,
+Hillsdale,206987,2012,Disorderly Conduct,7
+Hillsdale,206987,2012,Drugs,7
+Hillsdale,206987,2012,DUII,25
+Hillsdale,206987,2012,Embezzlement,4
+Hillsdale,206987,2012,Forgery,8
+Hillsdale,206987,2012,Fraud,15
+Hillsdale,206987,2012,Gambling,
+Hillsdale,206987,2012,Homicide,
+Hillsdale,206987,2012,Kidnap,
+Hillsdale,206987,2012,Larceny,102
+Hillsdale,206987,2012,Liquor Laws,3
+Hillsdale,206987,2012,Motor Vehicle Theft,8
+Hillsdale,206987,2012,Offenses Against Family,
+Hillsdale,206987,2012,Prostitution,
+Hillsdale,206987,2012,Rape,
+Hillsdale,206987,2012,Robbery,11
+Hillsdale,206987,2012,Runaway,
+Hillsdale,206987,2012,Sex Offenses,1
+Hillsdale,206987,2012,Stolen Property,
+Hillsdale,206987,2012,Trespass,7
+Hillsdale,206987,2012,Vandalism,31
+Hillsdale,206987,2012,Weapons,
+Hillsdale,206987,2013,Aggravated Assault,4
+Hillsdale,206987,2013,Arson,
+Hillsdale,206987,2013,"Assault, Simple",9
+Hillsdale,206987,2013,Burglary,39
+Hillsdale,206987,2013,Curfew,
+Hillsdale,206987,2013,Disorderly Conduct,9
+Hillsdale,206987,2013,Drugs,5
+Hillsdale,206987,2013,DUII,27
+Hillsdale,206987,2013,Embezzlement,
+Hillsdale,206987,2013,Forgery,18
+Hillsdale,206987,2013,Fraud,17
+Hillsdale,206987,2013,Gambling,
+Hillsdale,206987,2013,Homicide,
+Hillsdale,206987,2013,Kidnap,
+Hillsdale,206987,2013,Larceny,118
+Hillsdale,206987,2013,Liquor Laws,2
+Hillsdale,206987,2013,Motor Vehicle Theft,8
+Hillsdale,206987,2013,Offenses Against Family,
+Hillsdale,206987,2013,Prostitution,
+Hillsdale,206987,2013,Rape,
+Hillsdale,206987,2013,Robbery,
+Hillsdale,206987,2013,Runaway,
+Hillsdale,206987,2013,Sex Offenses,1
+Hillsdale,206987,2013,Stolen Property,
+Hillsdale,206987,2013,Trespass,4
+Hillsdale,206987,2013,Vandalism,19
+Hillsdale,206987,2013,Weapons,
+Hillsdale,206987,2014,Aggravated Assault,1
+Hillsdale,206987,2014,Arson,
+Hillsdale,206987,2014,"Assault, Simple",9
+Hillsdale,206987,2014,Burglary,11
+Hillsdale,206987,2014,Curfew,
+Hillsdale,206987,2014,Disorderly Conduct,8
+Hillsdale,206987,2014,Drugs,
+Hillsdale,206987,2014,DUII,20
+Hillsdale,206987,2014,Embezzlement,
+Hillsdale,206987,2014,Forgery,1
+Hillsdale,206987,2014,Fraud,21
+Hillsdale,206987,2014,Gambling,
+Hillsdale,206987,2014,Homicide,1
+Hillsdale,206987,2014,Kidnap,
+Hillsdale,206987,2014,Larceny,90
+Hillsdale,206987,2014,Liquor Laws,
+Hillsdale,206987,2014,Motor Vehicle Theft,9
+Hillsdale,206987,2014,Offenses Against Family,
+Hillsdale,206987,2014,Prostitution,
+Hillsdale,206987,2014,Rape,
+Hillsdale,206987,2014,Robbery,
+Hillsdale,206987,2014,Runaway,
+Hillsdale,206987,2014,Sex Offenses,
+Hillsdale,206987,2014,Stolen Property,1
+Hillsdale,206987,2014,Trespass,4
+Hillsdale,206987,2014,Vandalism,29
+Hillsdale,206987,2014,Weapons,
+Historic Milwaukie,274035,2004,Aggravated Assault,
+Historic Milwaukie,274035,2004,Arson,
+Historic Milwaukie,274035,2004,"Assault, Simple",
+Historic Milwaukie,274035,2004,Burglary,
+Historic Milwaukie,274035,2004,Curfew,
+Historic Milwaukie,274035,2004,Disorderly Conduct,
+Historic Milwaukie,274035,2004,Drugs,
+Historic Milwaukie,274035,2004,DUII,
+Historic Milwaukie,274035,2004,Embezzlement,
+Historic Milwaukie,274035,2004,Forgery,
+Historic Milwaukie,274035,2004,Fraud,
+Historic Milwaukie,274035,2004,Gambling,
+Historic Milwaukie,274035,2004,Homicide,
+Historic Milwaukie,274035,2004,Kidnap,
+Historic Milwaukie,274035,2004,Larceny,
+Historic Milwaukie,274035,2004,Liquor Laws,
+Historic Milwaukie,274035,2004,Motor Vehicle Theft,
+Historic Milwaukie,274035,2004,Offenses Against Family,
+Historic Milwaukie,274035,2004,Prostitution,
+Historic Milwaukie,274035,2004,Rape,
+Historic Milwaukie,274035,2004,Robbery,
+Historic Milwaukie,274035,2004,Runaway,
+Historic Milwaukie,274035,2004,Sex Offenses,
+Historic Milwaukie,274035,2004,Stolen Property,
+Historic Milwaukie,274035,2004,Trespass,
+Historic Milwaukie,274035,2004,Vandalism,
+Historic Milwaukie,274035,2004,Weapons,
+Historic Milwaukie,274035,2005,Aggravated Assault,
+Historic Milwaukie,274035,2005,Arson,
+Historic Milwaukie,274035,2005,"Assault, Simple",
+Historic Milwaukie,274035,2005,Burglary,
+Historic Milwaukie,274035,2005,Curfew,
+Historic Milwaukie,274035,2005,Disorderly Conduct,
+Historic Milwaukie,274035,2005,Drugs,
+Historic Milwaukie,274035,2005,DUII,
+Historic Milwaukie,274035,2005,Embezzlement,
+Historic Milwaukie,274035,2005,Forgery,
+Historic Milwaukie,274035,2005,Fraud,
+Historic Milwaukie,274035,2005,Gambling,
+Historic Milwaukie,274035,2005,Homicide,
+Historic Milwaukie,274035,2005,Kidnap,
+Historic Milwaukie,274035,2005,Larceny,
+Historic Milwaukie,274035,2005,Liquor Laws,
+Historic Milwaukie,274035,2005,Motor Vehicle Theft,
+Historic Milwaukie,274035,2005,Offenses Against Family,
+Historic Milwaukie,274035,2005,Prostitution,
+Historic Milwaukie,274035,2005,Rape,
+Historic Milwaukie,274035,2005,Robbery,
+Historic Milwaukie,274035,2005,Runaway,
+Historic Milwaukie,274035,2005,Sex Offenses,
+Historic Milwaukie,274035,2005,Stolen Property,
+Historic Milwaukie,274035,2005,Trespass,
+Historic Milwaukie,274035,2005,Vandalism,
+Historic Milwaukie,274035,2005,Weapons,
+Historic Milwaukie,274035,2006,Aggravated Assault,
+Historic Milwaukie,274035,2006,Arson,
+Historic Milwaukie,274035,2006,"Assault, Simple",
+Historic Milwaukie,274035,2006,Burglary,
+Historic Milwaukie,274035,2006,Curfew,
+Historic Milwaukie,274035,2006,Disorderly Conduct,
+Historic Milwaukie,274035,2006,Drugs,
+Historic Milwaukie,274035,2006,DUII,
+Historic Milwaukie,274035,2006,Embezzlement,
+Historic Milwaukie,274035,2006,Forgery,
+Historic Milwaukie,274035,2006,Fraud,
+Historic Milwaukie,274035,2006,Gambling,
+Historic Milwaukie,274035,2006,Homicide,
+Historic Milwaukie,274035,2006,Kidnap,
+Historic Milwaukie,274035,2006,Larceny,
+Historic Milwaukie,274035,2006,Liquor Laws,
+Historic Milwaukie,274035,2006,Motor Vehicle Theft,
+Historic Milwaukie,274035,2006,Offenses Against Family,
+Historic Milwaukie,274035,2006,Prostitution,
+Historic Milwaukie,274035,2006,Rape,
+Historic Milwaukie,274035,2006,Robbery,
+Historic Milwaukie,274035,2006,Runaway,
+Historic Milwaukie,274035,2006,Sex Offenses,
+Historic Milwaukie,274035,2006,Stolen Property,
+Historic Milwaukie,274035,2006,Trespass,
+Historic Milwaukie,274035,2006,Vandalism,
+Historic Milwaukie,274035,2006,Weapons,
+Historic Milwaukie,274035,2007,Aggravated Assault,
+Historic Milwaukie,274035,2007,Arson,
+Historic Milwaukie,274035,2007,"Assault, Simple",
+Historic Milwaukie,274035,2007,Burglary,
+Historic Milwaukie,274035,2007,Curfew,
+Historic Milwaukie,274035,2007,Disorderly Conduct,
+Historic Milwaukie,274035,2007,Drugs,
+Historic Milwaukie,274035,2007,DUII,
+Historic Milwaukie,274035,2007,Embezzlement,
+Historic Milwaukie,274035,2007,Forgery,
+Historic Milwaukie,274035,2007,Fraud,
+Historic Milwaukie,274035,2007,Gambling,
+Historic Milwaukie,274035,2007,Homicide,
+Historic Milwaukie,274035,2007,Kidnap,
+Historic Milwaukie,274035,2007,Larceny,
+Historic Milwaukie,274035,2007,Liquor Laws,
+Historic Milwaukie,274035,2007,Motor Vehicle Theft,
+Historic Milwaukie,274035,2007,Offenses Against Family,
+Historic Milwaukie,274035,2007,Prostitution,
+Historic Milwaukie,274035,2007,Rape,
+Historic Milwaukie,274035,2007,Robbery,
+Historic Milwaukie,274035,2007,Runaway,
+Historic Milwaukie,274035,2007,Sex Offenses,
+Historic Milwaukie,274035,2007,Stolen Property,
+Historic Milwaukie,274035,2007,Trespass,
+Historic Milwaukie,274035,2007,Vandalism,
+Historic Milwaukie,274035,2007,Weapons,
+Historic Milwaukie,274035,2008,Aggravated Assault,
+Historic Milwaukie,274035,2008,Arson,
+Historic Milwaukie,274035,2008,"Assault, Simple",
+Historic Milwaukie,274035,2008,Burglary,
+Historic Milwaukie,274035,2008,Curfew,
+Historic Milwaukie,274035,2008,Disorderly Conduct,
+Historic Milwaukie,274035,2008,Drugs,
+Historic Milwaukie,274035,2008,DUII,
+Historic Milwaukie,274035,2008,Embezzlement,
+Historic Milwaukie,274035,2008,Forgery,
+Historic Milwaukie,274035,2008,Fraud,
+Historic Milwaukie,274035,2008,Gambling,
+Historic Milwaukie,274035,2008,Homicide,
+Historic Milwaukie,274035,2008,Kidnap,
+Historic Milwaukie,274035,2008,Larceny,
+Historic Milwaukie,274035,2008,Liquor Laws,
+Historic Milwaukie,274035,2008,Motor Vehicle Theft,
+Historic Milwaukie,274035,2008,Offenses Against Family,
+Historic Milwaukie,274035,2008,Prostitution,
+Historic Milwaukie,274035,2008,Rape,
+Historic Milwaukie,274035,2008,Robbery,
+Historic Milwaukie,274035,2008,Runaway,
+Historic Milwaukie,274035,2008,Sex Offenses,
+Historic Milwaukie,274035,2008,Stolen Property,
+Historic Milwaukie,274035,2008,Trespass,
+Historic Milwaukie,274035,2008,Vandalism,
+Historic Milwaukie,274035,2008,Weapons,
+Historic Milwaukie,274035,2009,Aggravated Assault,
+Historic Milwaukie,274035,2009,Arson,
+Historic Milwaukie,274035,2009,"Assault, Simple",
+Historic Milwaukie,274035,2009,Burglary,
+Historic Milwaukie,274035,2009,Curfew,
+Historic Milwaukie,274035,2009,Disorderly Conduct,
+Historic Milwaukie,274035,2009,Drugs,
+Historic Milwaukie,274035,2009,DUII,
+Historic Milwaukie,274035,2009,Embezzlement,
+Historic Milwaukie,274035,2009,Forgery,
+Historic Milwaukie,274035,2009,Fraud,
+Historic Milwaukie,274035,2009,Gambling,
+Historic Milwaukie,274035,2009,Homicide,
+Historic Milwaukie,274035,2009,Kidnap,
+Historic Milwaukie,274035,2009,Larceny,
+Historic Milwaukie,274035,2009,Liquor Laws,
+Historic Milwaukie,274035,2009,Motor Vehicle Theft,
+Historic Milwaukie,274035,2009,Offenses Against Family,
+Historic Milwaukie,274035,2009,Prostitution,
+Historic Milwaukie,274035,2009,Rape,
+Historic Milwaukie,274035,2009,Robbery,
+Historic Milwaukie,274035,2009,Runaway,
+Historic Milwaukie,274035,2009,Sex Offenses,
+Historic Milwaukie,274035,2009,Stolen Property,
+Historic Milwaukie,274035,2009,Trespass,
+Historic Milwaukie,274035,2009,Vandalism,
+Historic Milwaukie,274035,2009,Weapons,
+Historic Milwaukie,274035,2010,Aggravated Assault,
+Historic Milwaukie,274035,2010,Arson,
+Historic Milwaukie,274035,2010,"Assault, Simple",
+Historic Milwaukie,274035,2010,Burglary,
+Historic Milwaukie,274035,2010,Curfew,
+Historic Milwaukie,274035,2010,Disorderly Conduct,
+Historic Milwaukie,274035,2010,Drugs,
+Historic Milwaukie,274035,2010,DUII,
+Historic Milwaukie,274035,2010,Embezzlement,
+Historic Milwaukie,274035,2010,Forgery,
+Historic Milwaukie,274035,2010,Fraud,
+Historic Milwaukie,274035,2010,Gambling,
+Historic Milwaukie,274035,2010,Homicide,
+Historic Milwaukie,274035,2010,Kidnap,
+Historic Milwaukie,274035,2010,Larceny,
+Historic Milwaukie,274035,2010,Liquor Laws,
+Historic Milwaukie,274035,2010,Motor Vehicle Theft,
+Historic Milwaukie,274035,2010,Offenses Against Family,
+Historic Milwaukie,274035,2010,Prostitution,
+Historic Milwaukie,274035,2010,Rape,
+Historic Milwaukie,274035,2010,Robbery,
+Historic Milwaukie,274035,2010,Runaway,
+Historic Milwaukie,274035,2010,Sex Offenses,
+Historic Milwaukie,274035,2010,Stolen Property,
+Historic Milwaukie,274035,2010,Trespass,
+Historic Milwaukie,274035,2010,Vandalism,
+Historic Milwaukie,274035,2010,Weapons,
+Historic Milwaukie,274035,2011,Aggravated Assault,
+Historic Milwaukie,274035,2011,Arson,
+Historic Milwaukie,274035,2011,"Assault, Simple",
+Historic Milwaukie,274035,2011,Burglary,
+Historic Milwaukie,274035,2011,Curfew,
+Historic Milwaukie,274035,2011,Disorderly Conduct,
+Historic Milwaukie,274035,2011,Drugs,
+Historic Milwaukie,274035,2011,DUII,
+Historic Milwaukie,274035,2011,Embezzlement,
+Historic Milwaukie,274035,2011,Forgery,
+Historic Milwaukie,274035,2011,Fraud,
+Historic Milwaukie,274035,2011,Gambling,
+Historic Milwaukie,274035,2011,Homicide,
+Historic Milwaukie,274035,2011,Kidnap,
+Historic Milwaukie,274035,2011,Larceny,1
+Historic Milwaukie,274035,2011,Liquor Laws,
+Historic Milwaukie,274035,2011,Motor Vehicle Theft,
+Historic Milwaukie,274035,2011,Offenses Against Family,
+Historic Milwaukie,274035,2011,Prostitution,
+Historic Milwaukie,274035,2011,Rape,
+Historic Milwaukie,274035,2011,Robbery,
+Historic Milwaukie,274035,2011,Runaway,
+Historic Milwaukie,274035,2011,Sex Offenses,
+Historic Milwaukie,274035,2011,Stolen Property,
+Historic Milwaukie,274035,2011,Trespass,
+Historic Milwaukie,274035,2011,Vandalism,
+Historic Milwaukie,274035,2011,Weapons,
+Historic Milwaukie,274035,2012,Aggravated Assault,
+Historic Milwaukie,274035,2012,Arson,
+Historic Milwaukie,274035,2012,"Assault, Simple",
+Historic Milwaukie,274035,2012,Burglary,
+Historic Milwaukie,274035,2012,Curfew,
+Historic Milwaukie,274035,2012,Disorderly Conduct,
+Historic Milwaukie,274035,2012,Drugs,
+Historic Milwaukie,274035,2012,DUII,
+Historic Milwaukie,274035,2012,Embezzlement,
+Historic Milwaukie,274035,2012,Forgery,2
+Historic Milwaukie,274035,2012,Fraud,
+Historic Milwaukie,274035,2012,Gambling,
+Historic Milwaukie,274035,2012,Homicide,
+Historic Milwaukie,274035,2012,Kidnap,
+Historic Milwaukie,274035,2012,Larceny,
+Historic Milwaukie,274035,2012,Liquor Laws,
+Historic Milwaukie,274035,2012,Motor Vehicle Theft,
+Historic Milwaukie,274035,2012,Offenses Against Family,
+Historic Milwaukie,274035,2012,Prostitution,
+Historic Milwaukie,274035,2012,Rape,
+Historic Milwaukie,274035,2012,Robbery,
+Historic Milwaukie,274035,2012,Runaway,
+Historic Milwaukie,274035,2012,Sex Offenses,
+Historic Milwaukie,274035,2012,Stolen Property,
+Historic Milwaukie,274035,2012,Trespass,
+Historic Milwaukie,274035,2012,Vandalism,
+Historic Milwaukie,274035,2012,Weapons,
+Historic Milwaukie,274035,2013,Aggravated Assault,
+Historic Milwaukie,274035,2013,Arson,
+Historic Milwaukie,274035,2013,"Assault, Simple",
+Historic Milwaukie,274035,2013,Burglary,
+Historic Milwaukie,274035,2013,Curfew,
+Historic Milwaukie,274035,2013,Disorderly Conduct,
+Historic Milwaukie,274035,2013,Drugs,
+Historic Milwaukie,274035,2013,DUII,
+Historic Milwaukie,274035,2013,Embezzlement,
+Historic Milwaukie,274035,2013,Forgery,
+Historic Milwaukie,274035,2013,Fraud,1
+Historic Milwaukie,274035,2013,Gambling,
+Historic Milwaukie,274035,2013,Homicide,
+Historic Milwaukie,274035,2013,Kidnap,
+Historic Milwaukie,274035,2013,Larceny,
+Historic Milwaukie,274035,2013,Liquor Laws,
+Historic Milwaukie,274035,2013,Motor Vehicle Theft,
+Historic Milwaukie,274035,2013,Offenses Against Family,
+Historic Milwaukie,274035,2013,Prostitution,
+Historic Milwaukie,274035,2013,Rape,
+Historic Milwaukie,274035,2013,Robbery,
+Historic Milwaukie,274035,2013,Runaway,
+Historic Milwaukie,274035,2013,Sex Offenses,
+Historic Milwaukie,274035,2013,Stolen Property,
+Historic Milwaukie,274035,2013,Trespass,
+Historic Milwaukie,274035,2013,Vandalism,
+Historic Milwaukie,274035,2013,Weapons,
+Historic Milwaukie,274035,2014,Aggravated Assault,
+Historic Milwaukie,274035,2014,Arson,
+Historic Milwaukie,274035,2014,"Assault, Simple",
+Historic Milwaukie,274035,2014,Burglary,
+Historic Milwaukie,274035,2014,Curfew,
+Historic Milwaukie,274035,2014,Disorderly Conduct,
+Historic Milwaukie,274035,2014,Drugs,
+Historic Milwaukie,274035,2014,DUII,
+Historic Milwaukie,274035,2014,Embezzlement,
+Historic Milwaukie,274035,2014,Forgery,
+Historic Milwaukie,274035,2014,Fraud,
+Historic Milwaukie,274035,2014,Gambling,
+Historic Milwaukie,274035,2014,Homicide,
+Historic Milwaukie,274035,2014,Kidnap,
+Historic Milwaukie,274035,2014,Larceny,
+Historic Milwaukie,274035,2014,Liquor Laws,
+Historic Milwaukie,274035,2014,Motor Vehicle Theft,
+Historic Milwaukie,274035,2014,Offenses Against Family,
+Historic Milwaukie,274035,2014,Prostitution,
+Historic Milwaukie,274035,2014,Rape,
+Historic Milwaukie,274035,2014,Robbery,
+Historic Milwaukie,274035,2014,Runaway,
+Historic Milwaukie,274035,2014,Sex Offenses,
+Historic Milwaukie,274035,2014,Stolen Property,
+Historic Milwaukie,274035,2014,Trespass,1
+Historic Milwaukie,274035,2014,Vandalism,
+Historic Milwaukie,274035,2014,Weapons,
+Homestead,274053,2004,Aggravated Assault,
+Homestead,274053,2004,Arson,
+Homestead,274053,2004,"Assault, Simple",1
+Homestead,274053,2004,Burglary,9
+Homestead,274053,2004,Curfew,
+Homestead,274053,2004,Disorderly Conduct,4
+Homestead,274053,2004,Drugs,3
+Homestead,274053,2004,DUII,
+Homestead,274053,2004,Embezzlement,
+Homestead,274053,2004,Forgery,
+Homestead,274053,2004,Fraud,1
+Homestead,274053,2004,Gambling,
+Homestead,274053,2004,Homicide,
+Homestead,274053,2004,Kidnap,
+Homestead,274053,2004,Larceny,72
+Homestead,274053,2004,Liquor Laws,6
+Homestead,274053,2004,Motor Vehicle Theft,4
+Homestead,274053,2004,Offenses Against Family,
+Homestead,274053,2004,Prostitution,
+Homestead,274053,2004,Rape,
+Homestead,274053,2004,Robbery,
+Homestead,274053,2004,Runaway,
+Homestead,274053,2004,Sex Offenses,1
+Homestead,274053,2004,Stolen Property,
+Homestead,274053,2004,Trespass,1
+Homestead,274053,2004,Vandalism,4
+Homestead,274053,2004,Weapons,
+Homestead,274053,2005,Aggravated Assault,3
+Homestead,274053,2005,Arson,
+Homestead,274053,2005,"Assault, Simple",9
+Homestead,274053,2005,Burglary,27
+Homestead,274053,2005,Curfew,
+Homestead,274053,2005,Disorderly Conduct,14
+Homestead,274053,2005,Drugs,5
+Homestead,274053,2005,DUII,7
+Homestead,274053,2005,Embezzlement,1
+Homestead,274053,2005,Forgery,9
+Homestead,274053,2005,Fraud,8
+Homestead,274053,2005,Gambling,
+Homestead,274053,2005,Homicide,
+Homestead,274053,2005,Kidnap,
+Homestead,274053,2005,Larceny,204
+Homestead,274053,2005,Liquor Laws,6
+Homestead,274053,2005,Motor Vehicle Theft,18
+Homestead,274053,2005,Offenses Against Family,
+Homestead,274053,2005,Prostitution,
+Homestead,274053,2005,Rape,
+Homestead,274053,2005,Robbery,4
+Homestead,274053,2005,Runaway,
+Homestead,274053,2005,Sex Offenses,
+Homestead,274053,2005,Stolen Property,
+Homestead,274053,2005,Trespass,16
+Homestead,274053,2005,Vandalism,28
+Homestead,274053,2005,Weapons,2
+Homestead,274053,2006,Aggravated Assault,7
+Homestead,274053,2006,Arson,
+Homestead,274053,2006,"Assault, Simple",4
+Homestead,274053,2006,Burglary,17
+Homestead,274053,2006,Curfew,
+Homestead,274053,2006,Disorderly Conduct,13
+Homestead,274053,2006,Drugs,3
+Homestead,274053,2006,DUII,8
+Homestead,274053,2006,Embezzlement,2
+Homestead,274053,2006,Forgery,1
+Homestead,274053,2006,Fraud,5
+Homestead,274053,2006,Gambling,
+Homestead,274053,2006,Homicide,
+Homestead,274053,2006,Kidnap,
+Homestead,274053,2006,Larceny,191
+Homestead,274053,2006,Liquor Laws,2
+Homestead,274053,2006,Motor Vehicle Theft,18
+Homestead,274053,2006,Offenses Against Family,
+Homestead,274053,2006,Prostitution,
+Homestead,274053,2006,Rape,
+Homestead,274053,2006,Robbery,2
+Homestead,274053,2006,Runaway,
+Homestead,274053,2006,Sex Offenses,
+Homestead,274053,2006,Stolen Property,1
+Homestead,274053,2006,Trespass,9
+Homestead,274053,2006,Vandalism,22
+Homestead,274053,2006,Weapons,1
+Homestead,274053,2007,Aggravated Assault,2
+Homestead,274053,2007,Arson,1
+Homestead,274053,2007,"Assault, Simple",3
+Homestead,274053,2007,Burglary,10
+Homestead,274053,2007,Curfew,
+Homestead,274053,2007,Disorderly Conduct,17
+Homestead,274053,2007,Drugs,9
+Homestead,274053,2007,DUII,15
+Homestead,274053,2007,Embezzlement,2
+Homestead,274053,2007,Forgery,1
+Homestead,274053,2007,Fraud,12
+Homestead,274053,2007,Gambling,
+Homestead,274053,2007,Homicide,
+Homestead,274053,2007,Kidnap,
+Homestead,274053,2007,Larceny,139
+Homestead,274053,2007,Liquor Laws,2
+Homestead,274053,2007,Motor Vehicle Theft,25
+Homestead,274053,2007,Offenses Against Family,
+Homestead,274053,2007,Prostitution,
+Homestead,274053,2007,Rape,
+Homestead,274053,2007,Robbery,
+Homestead,274053,2007,Runaway,
+Homestead,274053,2007,Sex Offenses,
+Homestead,274053,2007,Stolen Property,
+Homestead,274053,2007,Trespass,10
+Homestead,274053,2007,Vandalism,16
+Homestead,274053,2007,Weapons,
+Homestead,274053,2008,Aggravated Assault,
+Homestead,274053,2008,Arson,
+Homestead,274053,2008,"Assault, Simple",7
+Homestead,274053,2008,Burglary,14
+Homestead,274053,2008,Curfew,
+Homestead,274053,2008,Disorderly Conduct,19
+Homestead,274053,2008,Drugs,4
+Homestead,274053,2008,DUII,11
+Homestead,274053,2008,Embezzlement,1
+Homestead,274053,2008,Forgery,1
+Homestead,274053,2008,Fraud,7
+Homestead,274053,2008,Gambling,
+Homestead,274053,2008,Homicide,
+Homestead,274053,2008,Kidnap,
+Homestead,274053,2008,Larceny,111
+Homestead,274053,2008,Liquor Laws,5
+Homestead,274053,2008,Motor Vehicle Theft,12
+Homestead,274053,2008,Offenses Against Family,
+Homestead,274053,2008,Prostitution,
+Homestead,274053,2008,Rape,
+Homestead,274053,2008,Robbery,
+Homestead,274053,2008,Runaway,
+Homestead,274053,2008,Sex Offenses,
+Homestead,274053,2008,Stolen Property,
+Homestead,274053,2008,Trespass,13
+Homestead,274053,2008,Vandalism,21
+Homestead,274053,2008,Weapons,
+Homestead,274053,2009,Aggravated Assault,2
+Homestead,274053,2009,Arson,
+Homestead,274053,2009,"Assault, Simple",17
+Homestead,274053,2009,Burglary,6
+Homestead,274053,2009,Curfew,
+Homestead,274053,2009,Disorderly Conduct,12
+Homestead,274053,2009,Drugs,3
+Homestead,274053,2009,DUII,11
+Homestead,274053,2009,Embezzlement,
+Homestead,274053,2009,Forgery,
+Homestead,274053,2009,Fraud,6
+Homestead,274053,2009,Gambling,
+Homestead,274053,2009,Homicide,
+Homestead,274053,2009,Kidnap,
+Homestead,274053,2009,Larceny,103
+Homestead,274053,2009,Liquor Laws,2
+Homestead,274053,2009,Motor Vehicle Theft,11
+Homestead,274053,2009,Offenses Against Family,
+Homestead,274053,2009,Prostitution,
+Homestead,274053,2009,Rape,
+Homestead,274053,2009,Robbery,
+Homestead,274053,2009,Runaway,
+Homestead,274053,2009,Sex Offenses,
+Homestead,274053,2009,Stolen Property,
+Homestead,274053,2009,Trespass,8
+Homestead,274053,2009,Vandalism,24
+Homestead,274053,2009,Weapons,1
+Homestead,274053,2010,Aggravated Assault,2
+Homestead,274053,2010,Arson,
+Homestead,274053,2010,"Assault, Simple",1
+Homestead,274053,2010,Burglary,19
+Homestead,274053,2010,Curfew,
+Homestead,274053,2010,Disorderly Conduct,7
+Homestead,274053,2010,Drugs,2
+Homestead,274053,2010,DUII,3
+Homestead,274053,2010,Embezzlement,
+Homestead,274053,2010,Forgery,
+Homestead,274053,2010,Fraud,3
+Homestead,274053,2010,Gambling,
+Homestead,274053,2010,Homicide,1
+Homestead,274053,2010,Kidnap,
+Homestead,274053,2010,Larceny,109
+Homestead,274053,2010,Liquor Laws,7
+Homestead,274053,2010,Motor Vehicle Theft,3
+Homestead,274053,2010,Offenses Against Family,
+Homestead,274053,2010,Prostitution,
+Homestead,274053,2010,Rape,
+Homestead,274053,2010,Robbery,1
+Homestead,274053,2010,Runaway,
+Homestead,274053,2010,Sex Offenses,
+Homestead,274053,2010,Stolen Property,
+Homestead,274053,2010,Trespass,12
+Homestead,274053,2010,Vandalism,11
+Homestead,274053,2010,Weapons,
+Homestead,274053,2011,Aggravated Assault,4
+Homestead,274053,2011,Arson,
+Homestead,274053,2011,"Assault, Simple",5
+Homestead,274053,2011,Burglary,7
+Homestead,274053,2011,Curfew,
+Homestead,274053,2011,Disorderly Conduct,8
+Homestead,274053,2011,Drugs,4
+Homestead,274053,2011,DUII,12
+Homestead,274053,2011,Embezzlement,2
+Homestead,274053,2011,Forgery,4
+Homestead,274053,2011,Fraud,12
+Homestead,274053,2011,Gambling,
+Homestead,274053,2011,Homicide,
+Homestead,274053,2011,Kidnap,
+Homestead,274053,2011,Larceny,137
+Homestead,274053,2011,Liquor Laws,10
+Homestead,274053,2011,Motor Vehicle Theft,8
+Homestead,274053,2011,Offenses Against Family,
+Homestead,274053,2011,Prostitution,
+Homestead,274053,2011,Rape,
+Homestead,274053,2011,Robbery,1
+Homestead,274053,2011,Runaway,
+Homestead,274053,2011,Sex Offenses,
+Homestead,274053,2011,Stolen Property,
+Homestead,274053,2011,Trespass,7
+Homestead,274053,2011,Vandalism,45
+Homestead,274053,2011,Weapons,1
+Homestead,274053,2012,Aggravated Assault,1
+Homestead,274053,2012,Arson,
+Homestead,274053,2012,"Assault, Simple",2
+Homestead,274053,2012,Burglary,9
+Homestead,274053,2012,Curfew,
+Homestead,274053,2012,Disorderly Conduct,7
+Homestead,274053,2012,Drugs,1
+Homestead,274053,2012,DUII,6
+Homestead,274053,2012,Embezzlement,1
+Homestead,274053,2012,Forgery,1
+Homestead,274053,2012,Fraud,3
+Homestead,274053,2012,Gambling,
+Homestead,274053,2012,Homicide,
+Homestead,274053,2012,Kidnap,
+Homestead,274053,2012,Larceny,72
+Homestead,274053,2012,Liquor Laws,6
+Homestead,274053,2012,Motor Vehicle Theft,18
+Homestead,274053,2012,Offenses Against Family,
+Homestead,274053,2012,Prostitution,
+Homestead,274053,2012,Rape,
+Homestead,274053,2012,Robbery,2
+Homestead,274053,2012,Runaway,
+Homestead,274053,2012,Sex Offenses,1
+Homestead,274053,2012,Stolen Property,
+Homestead,274053,2012,Trespass,5
+Homestead,274053,2012,Vandalism,18
+Homestead,274053,2012,Weapons,1
+Homestead,274053,2013,Aggravated Assault,4
+Homestead,274053,2013,Arson,
+Homestead,274053,2013,"Assault, Simple",13
+Homestead,274053,2013,Burglary,6
+Homestead,274053,2013,Curfew,
+Homestead,274053,2013,Disorderly Conduct,11
+Homestead,274053,2013,Drugs,26
+Homestead,274053,2013,DUII,11
+Homestead,274053,2013,Embezzlement,1
+Homestead,274053,2013,Forgery,1
+Homestead,274053,2013,Fraud,3
+Homestead,274053,2013,Gambling,
+Homestead,274053,2013,Homicide,
+Homestead,274053,2013,Kidnap,
+Homestead,274053,2013,Larceny,63
+Homestead,274053,2013,Liquor Laws,4
+Homestead,274053,2013,Motor Vehicle Theft,9
+Homestead,274053,2013,Offenses Against Family,
+Homestead,274053,2013,Prostitution,
+Homestead,274053,2013,Rape,
+Homestead,274053,2013,Robbery,
+Homestead,274053,2013,Runaway,
+Homestead,274053,2013,Sex Offenses,
+Homestead,274053,2013,Stolen Property,
+Homestead,274053,2013,Trespass,24
+Homestead,274053,2013,Vandalism,14
+Homestead,274053,2013,Weapons,8
+Homestead,274053,2014,Aggravated Assault,2
+Homestead,274053,2014,Arson,
+Homestead,274053,2014,"Assault, Simple",18
+Homestead,274053,2014,Burglary,17
+Homestead,274053,2014,Curfew,
+Homestead,274053,2014,Disorderly Conduct,39
+Homestead,274053,2014,Drugs,60
+Homestead,274053,2014,DUII,8
+Homestead,274053,2014,Embezzlement,1
+Homestead,274053,2014,Forgery,7
+Homestead,274053,2014,Fraud,15
+Homestead,274053,2014,Gambling,
+Homestead,274053,2014,Homicide,
+Homestead,274053,2014,Kidnap,
+Homestead,274053,2014,Larceny,129
+Homestead,274053,2014,Liquor Laws,7
+Homestead,274053,2014,Motor Vehicle Theft,10
+Homestead,274053,2014,Offenses Against Family,
+Homestead,274053,2014,Prostitution,
+Homestead,274053,2014,Rape,1
+Homestead,274053,2014,Robbery,
+Homestead,274053,2014,Runaway,
+Homestead,274053,2014,Sex Offenses,
+Homestead,274053,2014,Stolen Property,1
+Homestead,274053,2014,Trespass,38
+Homestead,274053,2014,Vandalism,42
+Homestead,274053,2014,Weapons,11
+Hosford,274059,2004,Aggravated Assault,6
+Hosford,274059,2004,Arson,1
+Hosford,274059,2004,"Assault, Simple",4
+Hosford,274059,2004,Burglary,41
+Hosford,274059,2004,Curfew,
+Hosford,274059,2004,Disorderly Conduct,8
+Hosford,274059,2004,Drugs,9
+Hosford,274059,2004,DUII,13
+Hosford,274059,2004,Embezzlement,3
+Hosford,274059,2004,Forgery,6
+Hosford,274059,2004,Fraud,10
+Hosford,274059,2004,Gambling,
+Hosford,274059,2004,Homicide,
+Hosford,274059,2004,Kidnap,
+Hosford,274059,2004,Larceny,106
+Hosford,274059,2004,Liquor Laws,4
+Hosford,274059,2004,Motor Vehicle Theft,20
+Hosford,274059,2004,Offenses Against Family,
+Hosford,274059,2004,Prostitution,
+Hosford,274059,2004,Rape,
+Hosford,274059,2004,Robbery,8
+Hosford,274059,2004,Runaway,
+Hosford,274059,2004,Sex Offenses,1
+Hosford,274059,2004,Stolen Property,1
+Hosford,274059,2004,Trespass,6
+Hosford,274059,2004,Vandalism,44
+Hosford,274059,2004,Weapons,1
+Hosford,274059,2005,Aggravated Assault,16
+Hosford,274059,2005,Arson,1
+Hosford,274059,2005,"Assault, Simple",29
+Hosford,274059,2005,Burglary,121
+Hosford,274059,2005,Curfew,
+Hosford,274059,2005,Disorderly Conduct,25
+Hosford,274059,2005,Drugs,54
+Hosford,274059,2005,DUII,43
+Hosford,274059,2005,Embezzlement,4
+Hosford,274059,2005,Forgery,8
+Hosford,274059,2005,Fraud,28
+Hosford,274059,2005,Gambling,
+Hosford,274059,2005,Homicide,
+Hosford,274059,2005,Kidnap,
+Hosford,274059,2005,Larceny,364
+Hosford,274059,2005,Liquor Laws,8
+Hosford,274059,2005,Motor Vehicle Theft,95
+Hosford,274059,2005,Offenses Against Family,
+Hosford,274059,2005,Prostitution,1
+Hosford,274059,2005,Rape,2
+Hosford,274059,2005,Robbery,10
+Hosford,274059,2005,Runaway,
+Hosford,274059,2005,Sex Offenses,
+Hosford,274059,2005,Stolen Property,1
+Hosford,274059,2005,Trespass,36
+Hosford,274059,2005,Vandalism,142
+Hosford,274059,2005,Weapons,3
+Hosford,274059,2006,Aggravated Assault,16
+Hosford,274059,2006,Arson,
+Hosford,274059,2006,"Assault, Simple",24
+Hosford,274059,2006,Burglary,94
+Hosford,274059,2006,Curfew,
+Hosford,274059,2006,Disorderly Conduct,29
+Hosford,274059,2006,Drugs,41
+Hosford,274059,2006,DUII,44
+Hosford,274059,2006,Embezzlement,7
+Hosford,274059,2006,Forgery,9
+Hosford,274059,2006,Fraud,22
+Hosford,274059,2006,Gambling,
+Hosford,274059,2006,Homicide,
+Hosford,274059,2006,Kidnap,
+Hosford,274059,2006,Larceny,327
+Hosford,274059,2006,Liquor Laws,18
+Hosford,274059,2006,Motor Vehicle Theft,88
+Hosford,274059,2006,Offenses Against Family,
+Hosford,274059,2006,Prostitution,
+Hosford,274059,2006,Rape,
+Hosford,274059,2006,Robbery,11
+Hosford,274059,2006,Runaway,1
+Hosford,274059,2006,Sex Offenses,
+Hosford,274059,2006,Stolen Property,
+Hosford,274059,2006,Trespass,50
+Hosford,274059,2006,Vandalism,137
+Hosford,274059,2006,Weapons,8
+Hosford,274059,2007,Aggravated Assault,32
+Hosford,274059,2007,Arson,1
+Hosford,274059,2007,"Assault, Simple",26
+Hosford,274059,2007,Burglary,78
+Hosford,274059,2007,Curfew,
+Hosford,274059,2007,Disorderly Conduct,22
+Hosford,274059,2007,Drugs,34
+Hosford,274059,2007,DUII,48
+Hosford,274059,2007,Embezzlement,3
+Hosford,274059,2007,Forgery,16
+Hosford,274059,2007,Fraud,23
+Hosford,274059,2007,Gambling,
+Hosford,274059,2007,Homicide,
+Hosford,274059,2007,Kidnap,
+Hosford,274059,2007,Larceny,317
+Hosford,274059,2007,Liquor Laws,10
+Hosford,274059,2007,Motor Vehicle Theft,57
+Hosford,274059,2007,Offenses Against Family,
+Hosford,274059,2007,Prostitution,
+Hosford,274059,2007,Rape,
+Hosford,274059,2007,Robbery,9
+Hosford,274059,2007,Runaway,
+Hosford,274059,2007,Sex Offenses,1
+Hosford,274059,2007,Stolen Property,2
+Hosford,274059,2007,Trespass,27
+Hosford,274059,2007,Vandalism,141
+Hosford,274059,2007,Weapons,2
+Hosford,274059,2008,Aggravated Assault,8
+Hosford,274059,2008,Arson,2
+Hosford,274059,2008,"Assault, Simple",19
+Hosford,274059,2008,Burglary,49
+Hosford,274059,2008,Curfew,
+Hosford,274059,2008,Disorderly Conduct,28
+Hosford,274059,2008,Drugs,26
+Hosford,274059,2008,DUII,47
+Hosford,274059,2008,Embezzlement,6
+Hosford,274059,2008,Forgery,17
+Hosford,274059,2008,Fraud,25
+Hosford,274059,2008,Gambling,
+Hosford,274059,2008,Homicide,
+Hosford,274059,2008,Kidnap,
+Hosford,274059,2008,Larceny,251
+Hosford,274059,2008,Liquor Laws,12
+Hosford,274059,2008,Motor Vehicle Theft,45
+Hosford,274059,2008,Offenses Against Family,
+Hosford,274059,2008,Prostitution,
+Hosford,274059,2008,Rape,
+Hosford,274059,2008,Robbery,10
+Hosford,274059,2008,Runaway,
+Hosford,274059,2008,Sex Offenses,2
+Hosford,274059,2008,Stolen Property,2
+Hosford,274059,2008,Trespass,39
+Hosford,274059,2008,Vandalism,109
+Hosford,274059,2008,Weapons,1
+Hosford,274059,2009,Aggravated Assault,8
+Hosford,274059,2009,Arson,2
+Hosford,274059,2009,"Assault, Simple",29
+Hosford,274059,2009,Burglary,49
+Hosford,274059,2009,Curfew,
+Hosford,274059,2009,Disorderly Conduct,46
+Hosford,274059,2009,Drugs,30
+Hosford,274059,2009,DUII,54
+Hosford,274059,2009,Embezzlement,3
+Hosford,274059,2009,Forgery,7
+Hosford,274059,2009,Fraud,37
+Hosford,274059,2009,Gambling,
+Hosford,274059,2009,Homicide,
+Hosford,274059,2009,Kidnap,
+Hosford,274059,2009,Larceny,248
+Hosford,274059,2009,Liquor Laws,22
+Hosford,274059,2009,Motor Vehicle Theft,40
+Hosford,274059,2009,Offenses Against Family,
+Hosford,274059,2009,Prostitution,1
+Hosford,274059,2009,Rape,
+Hosford,274059,2009,Robbery,10
+Hosford,274059,2009,Runaway,1
+Hosford,274059,2009,Sex Offenses,1
+Hosford,274059,2009,Stolen Property,1
+Hosford,274059,2009,Trespass,36
+Hosford,274059,2009,Vandalism,88
+Hosford,274059,2009,Weapons,1
+Hosford,274059,2010,Aggravated Assault,10
+Hosford,274059,2010,Arson,1
+Hosford,274059,2010,"Assault, Simple",17
+Hosford,274059,2010,Burglary,66
+Hosford,274059,2010,Curfew,
+Hosford,274059,2010,Disorderly Conduct,39
+Hosford,274059,2010,Drugs,14
+Hosford,274059,2010,DUII,51
+Hosford,274059,2010,Embezzlement,1
+Hosford,274059,2010,Forgery,7
+Hosford,274059,2010,Fraud,35
+Hosford,274059,2010,Gambling,
+Hosford,274059,2010,Homicide,
+Hosford,274059,2010,Kidnap,
+Hosford,274059,2010,Larceny,278
+Hosford,274059,2010,Liquor Laws,33
+Hosford,274059,2010,Motor Vehicle Theft,50
+Hosford,274059,2010,Offenses Against Family,1
+Hosford,274059,2010,Prostitution,
+Hosford,274059,2010,Rape,
+Hosford,274059,2010,Robbery,4
+Hosford,274059,2010,Runaway,
+Hosford,274059,2010,Sex Offenses,1
+Hosford,274059,2010,Stolen Property,1
+Hosford,274059,2010,Trespass,33
+Hosford,274059,2010,Vandalism,97
+Hosford,274059,2010,Weapons,1
+Hosford,274059,2011,Aggravated Assault,17
+Hosford,274059,2011,Arson,
+Hosford,274059,2011,"Assault, Simple",28
+Hosford,274059,2011,Burglary,63
+Hosford,274059,2011,Curfew,
+Hosford,274059,2011,Disorderly Conduct,37
+Hosford,274059,2011,Drugs,15
+Hosford,274059,2011,DUII,38
+Hosford,274059,2011,Embezzlement,4
+Hosford,274059,2011,Forgery,5
+Hosford,274059,2011,Fraud,14
+Hosford,274059,2011,Gambling,
+Hosford,274059,2011,Homicide,
+Hosford,274059,2011,Kidnap,
+Hosford,274059,2011,Larceny,332
+Hosford,274059,2011,Liquor Laws,18
+Hosford,274059,2011,Motor Vehicle Theft,46
+Hosford,274059,2011,Offenses Against Family,
+Hosford,274059,2011,Prostitution,
+Hosford,274059,2011,Rape,1
+Hosford,274059,2011,Robbery,4
+Hosford,274059,2011,Runaway,
+Hosford,274059,2011,Sex Offenses,3
+Hosford,274059,2011,Stolen Property,
+Hosford,274059,2011,Trespass,22
+Hosford,274059,2011,Vandalism,88
+Hosford,274059,2011,Weapons,1
+Hosford,274059,2012,Aggravated Assault,12
+Hosford,274059,2012,Arson,
+Hosford,274059,2012,"Assault, Simple",20
+Hosford,274059,2012,Burglary,71
+Hosford,274059,2012,Curfew,
+Hosford,274059,2012,Disorderly Conduct,38
+Hosford,274059,2012,Drugs,17
+Hosford,274059,2012,DUII,53
+Hosford,274059,2012,Embezzlement,4
+Hosford,274059,2012,Forgery,6
+Hosford,274059,2012,Fraud,15
+Hosford,274059,2012,Gambling,
+Hosford,274059,2012,Homicide,
+Hosford,274059,2012,Kidnap,
+Hosford,274059,2012,Larceny,387
+Hosford,274059,2012,Liquor Laws,10
+Hosford,274059,2012,Motor Vehicle Theft,53
+Hosford,274059,2012,Offenses Against Family,
+Hosford,274059,2012,Prostitution,
+Hosford,274059,2012,Rape,
+Hosford,274059,2012,Robbery,8
+Hosford,274059,2012,Runaway,3
+Hosford,274059,2012,Sex Offenses,1
+Hosford,274059,2012,Stolen Property,2
+Hosford,274059,2012,Trespass,32
+Hosford,274059,2012,Vandalism,102
+Hosford,274059,2012,Weapons,1
+Hosford,274059,2013,Aggravated Assault,12
+Hosford,274059,2013,Arson,
+Hosford,274059,2013,"Assault, Simple",25
+Hosford,274059,2013,Burglary,57
+Hosford,274059,2013,Curfew,
+Hosford,274059,2013,Disorderly Conduct,19
+Hosford,274059,2013,Drugs,15
+Hosford,274059,2013,DUII,53
+Hosford,274059,2013,Embezzlement,3
+Hosford,274059,2013,Forgery,13
+Hosford,274059,2013,Fraud,15
+Hosford,274059,2013,Gambling,
+Hosford,274059,2013,Homicide,
+Hosford,274059,2013,Kidnap,
+Hosford,274059,2013,Larceny,375
+Hosford,274059,2013,Liquor Laws,6
+Hosford,274059,2013,Motor Vehicle Theft,49
+Hosford,274059,2013,Offenses Against Family,
+Hosford,274059,2013,Prostitution,
+Hosford,274059,2013,Rape,
+Hosford,274059,2013,Robbery,4
+Hosford,274059,2013,Runaway,
+Hosford,274059,2013,Sex Offenses,
+Hosford,274059,2013,Stolen Property,2
+Hosford,274059,2013,Trespass,13
+Hosford,274059,2013,Vandalism,154
+Hosford,274059,2013,Weapons,3
+Hosford,274059,2014,Aggravated Assault,4
+Hosford,274059,2014,Arson,1
+Hosford,274059,2014,"Assault, Simple",15
+Hosford,274059,2014,Burglary,56
+Hosford,274059,2014,Curfew,
+Hosford,274059,2014,Disorderly Conduct,36
+Hosford,274059,2014,Drugs,11
+Hosford,274059,2014,DUII,38
+Hosford,274059,2014,Embezzlement,2
+Hosford,274059,2014,Forgery,5
+Hosford,274059,2014,Fraud,19
+Hosford,274059,2014,Gambling,
+Hosford,274059,2014,Homicide,
+Hosford,274059,2014,Kidnap,
+Hosford,274059,2014,Larceny,468
+Hosford,274059,2014,Liquor Laws,1
+Hosford,274059,2014,Motor Vehicle Theft,49
+Hosford,274059,2014,Offenses Against Family,2
+Hosford,274059,2014,Prostitution,
+Hosford,274059,2014,Rape,
+Hosford,274059,2014,Robbery,7
+Hosford,274059,2014,Runaway,
+Hosford,274059,2014,Sex Offenses,3
+Hosford,274059,2014,Stolen Property,
+Hosford,274059,2014,Trespass,19
+Hosford,274059,2014,Vandalism,101
+Hosford,274059,2014,Weapons,2
+Irvington,207031,2004,Aggravated Assault,2
+Irvington,207031,2004,Arson,1
+Irvington,207031,2004,"Assault, Simple",9
+Irvington,207031,2004,Burglary,46
+Irvington,207031,2004,Curfew,
+Irvington,207031,2004,Disorderly Conduct,6
+Irvington,207031,2004,Drugs,3
+Irvington,207031,2004,DUII,6
+Irvington,207031,2004,Embezzlement,2
+Irvington,207031,2004,Forgery,14
+Irvington,207031,2004,Fraud,11
+Irvington,207031,2004,Gambling,
+Irvington,207031,2004,Homicide,
+Irvington,207031,2004,Kidnap,
+Irvington,207031,2004,Larceny,138
+Irvington,207031,2004,Liquor Laws,7
+Irvington,207031,2004,Motor Vehicle Theft,24
+Irvington,207031,2004,Offenses Against Family,
+Irvington,207031,2004,Prostitution,
+Irvington,207031,2004,Rape,
+Irvington,207031,2004,Robbery,4
+Irvington,207031,2004,Runaway,1
+Irvington,207031,2004,Sex Offenses,
+Irvington,207031,2004,Stolen Property,
+Irvington,207031,2004,Trespass,6
+Irvington,207031,2004,Vandalism,14
+Irvington,207031,2004,Weapons,
+Irvington,207031,2005,Aggravated Assault,4
+Irvington,207031,2005,Arson,
+Irvington,207031,2005,"Assault, Simple",21
+Irvington,207031,2005,Burglary,104
+Irvington,207031,2005,Curfew,1
+Irvington,207031,2005,Disorderly Conduct,29
+Irvington,207031,2005,Drugs,16
+Irvington,207031,2005,DUII,4
+Irvington,207031,2005,Embezzlement,4
+Irvington,207031,2005,Forgery,32
+Irvington,207031,2005,Fraud,49
+Irvington,207031,2005,Gambling,
+Irvington,207031,2005,Homicide,1
+Irvington,207031,2005,Kidnap,
+Irvington,207031,2005,Larceny,336
+Irvington,207031,2005,Liquor Laws,15
+Irvington,207031,2005,Motor Vehicle Theft,64
+Irvington,207031,2005,Offenses Against Family,
+Irvington,207031,2005,Prostitution,
+Irvington,207031,2005,Rape,
+Irvington,207031,2005,Robbery,16
+Irvington,207031,2005,Runaway,
+Irvington,207031,2005,Sex Offenses,
+Irvington,207031,2005,Stolen Property,
+Irvington,207031,2005,Trespass,35
+Irvington,207031,2005,Vandalism,66
+Irvington,207031,2005,Weapons,1
+Irvington,207031,2006,Aggravated Assault,6
+Irvington,207031,2006,Arson,
+Irvington,207031,2006,"Assault, Simple",12
+Irvington,207031,2006,Burglary,103
+Irvington,207031,2006,Curfew,1
+Irvington,207031,2006,Disorderly Conduct,22
+Irvington,207031,2006,Drugs,14
+Irvington,207031,2006,DUII,20
+Irvington,207031,2006,Embezzlement,1
+Irvington,207031,2006,Forgery,16
+Irvington,207031,2006,Fraud,31
+Irvington,207031,2006,Gambling,
+Irvington,207031,2006,Homicide,
+Irvington,207031,2006,Kidnap,1
+Irvington,207031,2006,Larceny,324
+Irvington,207031,2006,Liquor Laws,6
+Irvington,207031,2006,Motor Vehicle Theft,50
+Irvington,207031,2006,Offenses Against Family,
+Irvington,207031,2006,Prostitution,
+Irvington,207031,2006,Rape,1
+Irvington,207031,2006,Robbery,15
+Irvington,207031,2006,Runaway,
+Irvington,207031,2006,Sex Offenses,
+Irvington,207031,2006,Stolen Property,
+Irvington,207031,2006,Trespass,27
+Irvington,207031,2006,Vandalism,87
+Irvington,207031,2006,Weapons,3
+Irvington,207031,2007,Aggravated Assault,7
+Irvington,207031,2007,Arson,1
+Irvington,207031,2007,"Assault, Simple",13
+Irvington,207031,2007,Burglary,66
+Irvington,207031,2007,Curfew,
+Irvington,207031,2007,Disorderly Conduct,15
+Irvington,207031,2007,Drugs,10
+Irvington,207031,2007,DUII,21
+Irvington,207031,2007,Embezzlement,2
+Irvington,207031,2007,Forgery,10
+Irvington,207031,2007,Fraud,27
+Irvington,207031,2007,Gambling,
+Irvington,207031,2007,Homicide,
+Irvington,207031,2007,Kidnap,1
+Irvington,207031,2007,Larceny,322
+Irvington,207031,2007,Liquor Laws,11
+Irvington,207031,2007,Motor Vehicle Theft,65
+Irvington,207031,2007,Offenses Against Family,
+Irvington,207031,2007,Prostitution,
+Irvington,207031,2007,Rape,1
+Irvington,207031,2007,Robbery,16
+Irvington,207031,2007,Runaway,
+Irvington,207031,2007,Sex Offenses,
+Irvington,207031,2007,Stolen Property,
+Irvington,207031,2007,Trespass,30
+Irvington,207031,2007,Vandalism,63
+Irvington,207031,2007,Weapons,1
+Irvington,207031,2008,Aggravated Assault,8
+Irvington,207031,2008,Arson,
+Irvington,207031,2008,"Assault, Simple",24
+Irvington,207031,2008,Burglary,58
+Irvington,207031,2008,Curfew,1
+Irvington,207031,2008,Disorderly Conduct,16
+Irvington,207031,2008,Drugs,9
+Irvington,207031,2008,DUII,21
+Irvington,207031,2008,Embezzlement,7
+Irvington,207031,2008,Forgery,9
+Irvington,207031,2008,Fraud,18
+Irvington,207031,2008,Gambling,
+Irvington,207031,2008,Homicide,
+Irvington,207031,2008,Kidnap,1
+Irvington,207031,2008,Larceny,300
+Irvington,207031,2008,Liquor Laws,10
+Irvington,207031,2008,Motor Vehicle Theft,49
+Irvington,207031,2008,Offenses Against Family,
+Irvington,207031,2008,Prostitution,
+Irvington,207031,2008,Rape,
+Irvington,207031,2008,Robbery,12
+Irvington,207031,2008,Runaway,1
+Irvington,207031,2008,Sex Offenses,2
+Irvington,207031,2008,Stolen Property,
+Irvington,207031,2008,Trespass,25
+Irvington,207031,2008,Vandalism,50
+Irvington,207031,2008,Weapons,2
+Irvington,207031,2009,Aggravated Assault,6
+Irvington,207031,2009,Arson,
+Irvington,207031,2009,"Assault, Simple",15
+Irvington,207031,2009,Burglary,45
+Irvington,207031,2009,Curfew,
+Irvington,207031,2009,Disorderly Conduct,15
+Irvington,207031,2009,Drugs,10
+Irvington,207031,2009,DUII,14
+Irvington,207031,2009,Embezzlement,1
+Irvington,207031,2009,Forgery,15
+Irvington,207031,2009,Fraud,25
+Irvington,207031,2009,Gambling,
+Irvington,207031,2009,Homicide,
+Irvington,207031,2009,Kidnap,
+Irvington,207031,2009,Larceny,351
+Irvington,207031,2009,Liquor Laws,23
+Irvington,207031,2009,Motor Vehicle Theft,39
+Irvington,207031,2009,Offenses Against Family,
+Irvington,207031,2009,Prostitution,
+Irvington,207031,2009,Rape,
+Irvington,207031,2009,Robbery,11
+Irvington,207031,2009,Runaway,
+Irvington,207031,2009,Sex Offenses,1
+Irvington,207031,2009,Stolen Property,
+Irvington,207031,2009,Trespass,17
+Irvington,207031,2009,Vandalism,54
+Irvington,207031,2009,Weapons,4
+Irvington,207031,2010,Aggravated Assault,3
+Irvington,207031,2010,Arson,
+Irvington,207031,2010,"Assault, Simple",17
+Irvington,207031,2010,Burglary,49
+Irvington,207031,2010,Curfew,
+Irvington,207031,2010,Disorderly Conduct,16
+Irvington,207031,2010,Drugs,22
+Irvington,207031,2010,DUII,19
+Irvington,207031,2010,Embezzlement,2
+Irvington,207031,2010,Forgery,12
+Irvington,207031,2010,Fraud,14
+Irvington,207031,2010,Gambling,
+Irvington,207031,2010,Homicide,
+Irvington,207031,2010,Kidnap,
+Irvington,207031,2010,Larceny,346
+Irvington,207031,2010,Liquor Laws,19
+Irvington,207031,2010,Motor Vehicle Theft,38
+Irvington,207031,2010,Offenses Against Family,
+Irvington,207031,2010,Prostitution,
+Irvington,207031,2010,Rape,1
+Irvington,207031,2010,Robbery,14
+Irvington,207031,2010,Runaway,1
+Irvington,207031,2010,Sex Offenses,2
+Irvington,207031,2010,Stolen Property,1
+Irvington,207031,2010,Trespass,17
+Irvington,207031,2010,Vandalism,43
+Irvington,207031,2010,Weapons,2
+Irvington,207031,2011,Aggravated Assault,2
+Irvington,207031,2011,Arson,
+Irvington,207031,2011,"Assault, Simple",17
+Irvington,207031,2011,Burglary,50
+Irvington,207031,2011,Curfew,
+Irvington,207031,2011,Disorderly Conduct,18
+Irvington,207031,2011,Drugs,13
+Irvington,207031,2011,DUII,16
+Irvington,207031,2011,Embezzlement,1
+Irvington,207031,2011,Forgery,4
+Irvington,207031,2011,Fraud,25
+Irvington,207031,2011,Gambling,
+Irvington,207031,2011,Homicide,
+Irvington,207031,2011,Kidnap,1
+Irvington,207031,2011,Larceny,288
+Irvington,207031,2011,Liquor Laws,24
+Irvington,207031,2011,Motor Vehicle Theft,53
+Irvington,207031,2011,Offenses Against Family,
+Irvington,207031,2011,Prostitution,
+Irvington,207031,2011,Rape,
+Irvington,207031,2011,Robbery,6
+Irvington,207031,2011,Runaway,
+Irvington,207031,2011,Sex Offenses,2
+Irvington,207031,2011,Stolen Property,1
+Irvington,207031,2011,Trespass,19
+Irvington,207031,2011,Vandalism,35
+Irvington,207031,2011,Weapons,1
+Irvington,207031,2012,Aggravated Assault,15
+Irvington,207031,2012,Arson,
+Irvington,207031,2012,"Assault, Simple",13
+Irvington,207031,2012,Burglary,62
+Irvington,207031,2012,Curfew,
+Irvington,207031,2012,Disorderly Conduct,18
+Irvington,207031,2012,Drugs,22
+Irvington,207031,2012,DUII,27
+Irvington,207031,2012,Embezzlement,1
+Irvington,207031,2012,Forgery,2
+Irvington,207031,2012,Fraud,21
+Irvington,207031,2012,Gambling,
+Irvington,207031,2012,Homicide,
+Irvington,207031,2012,Kidnap,
+Irvington,207031,2012,Larceny,327
+Irvington,207031,2012,Liquor Laws,21
+Irvington,207031,2012,Motor Vehicle Theft,54
+Irvington,207031,2012,Offenses Against Family,
+Irvington,207031,2012,Prostitution,
+Irvington,207031,2012,Rape,
+Irvington,207031,2012,Robbery,19
+Irvington,207031,2012,Runaway,
+Irvington,207031,2012,Sex Offenses,1
+Irvington,207031,2012,Stolen Property,
+Irvington,207031,2012,Trespass,24
+Irvington,207031,2012,Vandalism,48
+Irvington,207031,2012,Weapons,1
+Irvington,207031,2013,Aggravated Assault,7
+Irvington,207031,2013,Arson,
+Irvington,207031,2013,"Assault, Simple",18
+Irvington,207031,2013,Burglary,75
+Irvington,207031,2013,Curfew,
+Irvington,207031,2013,Disorderly Conduct,24
+Irvington,207031,2013,Drugs,11
+Irvington,207031,2013,DUII,15
+Irvington,207031,2013,Embezzlement,3
+Irvington,207031,2013,Forgery,7
+Irvington,207031,2013,Fraud,18
+Irvington,207031,2013,Gambling,
+Irvington,207031,2013,Homicide,
+Irvington,207031,2013,Kidnap,
+Irvington,207031,2013,Larceny,347
+Irvington,207031,2013,Liquor Laws,24
+Irvington,207031,2013,Motor Vehicle Theft,51
+Irvington,207031,2013,Offenses Against Family,
+Irvington,207031,2013,Prostitution,
+Irvington,207031,2013,Rape,
+Irvington,207031,2013,Robbery,19
+Irvington,207031,2013,Runaway,1
+Irvington,207031,2013,Sex Offenses,2
+Irvington,207031,2013,Stolen Property,
+Irvington,207031,2013,Trespass,24
+Irvington,207031,2013,Vandalism,135
+Irvington,207031,2013,Weapons,2
+Irvington,207031,2014,Aggravated Assault,5
+Irvington,207031,2014,Arson,
+Irvington,207031,2014,"Assault, Simple",13
+Irvington,207031,2014,Burglary,65
+Irvington,207031,2014,Curfew,
+Irvington,207031,2014,Disorderly Conduct,27
+Irvington,207031,2014,Drugs,12
+Irvington,207031,2014,DUII,10
+Irvington,207031,2014,Embezzlement,
+Irvington,207031,2014,Forgery,7
+Irvington,207031,2014,Fraud,18
+Irvington,207031,2014,Gambling,
+Irvington,207031,2014,Homicide,
+Irvington,207031,2014,Kidnap,
+Irvington,207031,2014,Larceny,379
+Irvington,207031,2014,Liquor Laws,34
+Irvington,207031,2014,Motor Vehicle Theft,63
+Irvington,207031,2014,Offenses Against Family,
+Irvington,207031,2014,Prostitution,
+Irvington,207031,2014,Rape,
+Irvington,207031,2014,Robbery,14
+Irvington,207031,2014,Runaway,
+Irvington,207031,2014,Sex Offenses,1
+Irvington,207031,2014,Stolen Property,
+Irvington,207031,2014,Trespass,11
+Irvington,207031,2014,Vandalism,56
+Irvington,207031,2014,Weapons,1
+Island Station,274111,2004,Aggravated Assault,
+Island Station,274111,2004,Arson,
+Island Station,274111,2004,"Assault, Simple",
+Island Station,274111,2004,Burglary,
+Island Station,274111,2004,Curfew,
+Island Station,274111,2004,Disorderly Conduct,
+Island Station,274111,2004,Drugs,
+Island Station,274111,2004,DUII,
+Island Station,274111,2004,Embezzlement,
+Island Station,274111,2004,Forgery,
+Island Station,274111,2004,Fraud,
+Island Station,274111,2004,Gambling,
+Island Station,274111,2004,Homicide,
+Island Station,274111,2004,Kidnap,
+Island Station,274111,2004,Larceny,
+Island Station,274111,2004,Liquor Laws,
+Island Station,274111,2004,Motor Vehicle Theft,
+Island Station,274111,2004,Offenses Against Family,
+Island Station,274111,2004,Prostitution,
+Island Station,274111,2004,Rape,
+Island Station,274111,2004,Robbery,
+Island Station,274111,2004,Runaway,
+Island Station,274111,2004,Sex Offenses,
+Island Station,274111,2004,Stolen Property,
+Island Station,274111,2004,Trespass,
+Island Station,274111,2004,Vandalism,
+Island Station,274111,2004,Weapons,
+Island Station,274111,2005,Aggravated Assault,
+Island Station,274111,2005,Arson,
+Island Station,274111,2005,"Assault, Simple",
+Island Station,274111,2005,Burglary,
+Island Station,274111,2005,Curfew,
+Island Station,274111,2005,Disorderly Conduct,
+Island Station,274111,2005,Drugs,
+Island Station,274111,2005,DUII,
+Island Station,274111,2005,Embezzlement,
+Island Station,274111,2005,Forgery,
+Island Station,274111,2005,Fraud,
+Island Station,274111,2005,Gambling,
+Island Station,274111,2005,Homicide,
+Island Station,274111,2005,Kidnap,
+Island Station,274111,2005,Larceny,
+Island Station,274111,2005,Liquor Laws,
+Island Station,274111,2005,Motor Vehicle Theft,
+Island Station,274111,2005,Offenses Against Family,
+Island Station,274111,2005,Prostitution,
+Island Station,274111,2005,Rape,
+Island Station,274111,2005,Robbery,
+Island Station,274111,2005,Runaway,
+Island Station,274111,2005,Sex Offenses,
+Island Station,274111,2005,Stolen Property,
+Island Station,274111,2005,Trespass,
+Island Station,274111,2005,Vandalism,
+Island Station,274111,2005,Weapons,
+Island Station,274111,2006,Aggravated Assault,
+Island Station,274111,2006,Arson,
+Island Station,274111,2006,"Assault, Simple",
+Island Station,274111,2006,Burglary,
+Island Station,274111,2006,Curfew,
+Island Station,274111,2006,Disorderly Conduct,
+Island Station,274111,2006,Drugs,
+Island Station,274111,2006,DUII,
+Island Station,274111,2006,Embezzlement,
+Island Station,274111,2006,Forgery,
+Island Station,274111,2006,Fraud,
+Island Station,274111,2006,Gambling,
+Island Station,274111,2006,Homicide,
+Island Station,274111,2006,Kidnap,
+Island Station,274111,2006,Larceny,
+Island Station,274111,2006,Liquor Laws,
+Island Station,274111,2006,Motor Vehicle Theft,
+Island Station,274111,2006,Offenses Against Family,
+Island Station,274111,2006,Prostitution,
+Island Station,274111,2006,Rape,
+Island Station,274111,2006,Robbery,
+Island Station,274111,2006,Runaway,
+Island Station,274111,2006,Sex Offenses,
+Island Station,274111,2006,Stolen Property,
+Island Station,274111,2006,Trespass,
+Island Station,274111,2006,Vandalism,
+Island Station,274111,2006,Weapons,
+Island Station,274111,2007,Aggravated Assault,
+Island Station,274111,2007,Arson,
+Island Station,274111,2007,"Assault, Simple",
+Island Station,274111,2007,Burglary,
+Island Station,274111,2007,Curfew,
+Island Station,274111,2007,Disorderly Conduct,
+Island Station,274111,2007,Drugs,
+Island Station,274111,2007,DUII,
+Island Station,274111,2007,Embezzlement,
+Island Station,274111,2007,Forgery,
+Island Station,274111,2007,Fraud,
+Island Station,274111,2007,Gambling,
+Island Station,274111,2007,Homicide,
+Island Station,274111,2007,Kidnap,
+Island Station,274111,2007,Larceny,
+Island Station,274111,2007,Liquor Laws,
+Island Station,274111,2007,Motor Vehicle Theft,
+Island Station,274111,2007,Offenses Against Family,
+Island Station,274111,2007,Prostitution,
+Island Station,274111,2007,Rape,
+Island Station,274111,2007,Robbery,
+Island Station,274111,2007,Runaway,
+Island Station,274111,2007,Sex Offenses,
+Island Station,274111,2007,Stolen Property,
+Island Station,274111,2007,Trespass,
+Island Station,274111,2007,Vandalism,
+Island Station,274111,2007,Weapons,
+Island Station,274111,2008,Aggravated Assault,
+Island Station,274111,2008,Arson,
+Island Station,274111,2008,"Assault, Simple",
+Island Station,274111,2008,Burglary,
+Island Station,274111,2008,Curfew,
+Island Station,274111,2008,Disorderly Conduct,
+Island Station,274111,2008,Drugs,
+Island Station,274111,2008,DUII,
+Island Station,274111,2008,Embezzlement,
+Island Station,274111,2008,Forgery,
+Island Station,274111,2008,Fraud,
+Island Station,274111,2008,Gambling,
+Island Station,274111,2008,Homicide,
+Island Station,274111,2008,Kidnap,
+Island Station,274111,2008,Larceny,
+Island Station,274111,2008,Liquor Laws,
+Island Station,274111,2008,Motor Vehicle Theft,
+Island Station,274111,2008,Offenses Against Family,
+Island Station,274111,2008,Prostitution,
+Island Station,274111,2008,Rape,
+Island Station,274111,2008,Robbery,
+Island Station,274111,2008,Runaway,
+Island Station,274111,2008,Sex Offenses,
+Island Station,274111,2008,Stolen Property,
+Island Station,274111,2008,Trespass,
+Island Station,274111,2008,Vandalism,
+Island Station,274111,2008,Weapons,
+Island Station,274111,2009,Aggravated Assault,
+Island Station,274111,2009,Arson,
+Island Station,274111,2009,"Assault, Simple",
+Island Station,274111,2009,Burglary,
+Island Station,274111,2009,Curfew,
+Island Station,274111,2009,Disorderly Conduct,
+Island Station,274111,2009,Drugs,
+Island Station,274111,2009,DUII,
+Island Station,274111,2009,Embezzlement,
+Island Station,274111,2009,Forgery,
+Island Station,274111,2009,Fraud,
+Island Station,274111,2009,Gambling,
+Island Station,274111,2009,Homicide,
+Island Station,274111,2009,Kidnap,
+Island Station,274111,2009,Larceny,
+Island Station,274111,2009,Liquor Laws,
+Island Station,274111,2009,Motor Vehicle Theft,
+Island Station,274111,2009,Offenses Against Family,
+Island Station,274111,2009,Prostitution,
+Island Station,274111,2009,Rape,
+Island Station,274111,2009,Robbery,
+Island Station,274111,2009,Runaway,
+Island Station,274111,2009,Sex Offenses,
+Island Station,274111,2009,Stolen Property,
+Island Station,274111,2009,Trespass,
+Island Station,274111,2009,Vandalism,
+Island Station,274111,2009,Weapons,
+Island Station,274111,2010,Aggravated Assault,
+Island Station,274111,2010,Arson,
+Island Station,274111,2010,"Assault, Simple",
+Island Station,274111,2010,Burglary,
+Island Station,274111,2010,Curfew,
+Island Station,274111,2010,Disorderly Conduct,
+Island Station,274111,2010,Drugs,
+Island Station,274111,2010,DUII,
+Island Station,274111,2010,Embezzlement,
+Island Station,274111,2010,Forgery,
+Island Station,274111,2010,Fraud,
+Island Station,274111,2010,Gambling,
+Island Station,274111,2010,Homicide,
+Island Station,274111,2010,Kidnap,
+Island Station,274111,2010,Larceny,
+Island Station,274111,2010,Liquor Laws,
+Island Station,274111,2010,Motor Vehicle Theft,
+Island Station,274111,2010,Offenses Against Family,
+Island Station,274111,2010,Prostitution,
+Island Station,274111,2010,Rape,
+Island Station,274111,2010,Robbery,
+Island Station,274111,2010,Runaway,
+Island Station,274111,2010,Sex Offenses,
+Island Station,274111,2010,Stolen Property,
+Island Station,274111,2010,Trespass,
+Island Station,274111,2010,Vandalism,
+Island Station,274111,2010,Weapons,
+Island Station,274111,2011,Aggravated Assault,
+Island Station,274111,2011,Arson,
+Island Station,274111,2011,"Assault, Simple",
+Island Station,274111,2011,Burglary,
+Island Station,274111,2011,Curfew,
+Island Station,274111,2011,Disorderly Conduct,
+Island Station,274111,2011,Drugs,
+Island Station,274111,2011,DUII,
+Island Station,274111,2011,Embezzlement,
+Island Station,274111,2011,Forgery,
+Island Station,274111,2011,Fraud,
+Island Station,274111,2011,Gambling,
+Island Station,274111,2011,Homicide,
+Island Station,274111,2011,Kidnap,
+Island Station,274111,2011,Larceny,
+Island Station,274111,2011,Liquor Laws,
+Island Station,274111,2011,Motor Vehicle Theft,
+Island Station,274111,2011,Offenses Against Family,
+Island Station,274111,2011,Prostitution,
+Island Station,274111,2011,Rape,
+Island Station,274111,2011,Robbery,
+Island Station,274111,2011,Runaway,
+Island Station,274111,2011,Sex Offenses,
+Island Station,274111,2011,Stolen Property,
+Island Station,274111,2011,Trespass,
+Island Station,274111,2011,Vandalism,
+Island Station,274111,2011,Weapons,
+Island Station,274111,2012,Aggravated Assault,
+Island Station,274111,2012,Arson,
+Island Station,274111,2012,"Assault, Simple",
+Island Station,274111,2012,Burglary,
+Island Station,274111,2012,Curfew,
+Island Station,274111,2012,Disorderly Conduct,
+Island Station,274111,2012,Drugs,
+Island Station,274111,2012,DUII,
+Island Station,274111,2012,Embezzlement,
+Island Station,274111,2012,Forgery,
+Island Station,274111,2012,Fraud,
+Island Station,274111,2012,Gambling,
+Island Station,274111,2012,Homicide,
+Island Station,274111,2012,Kidnap,
+Island Station,274111,2012,Larceny,1
+Island Station,274111,2012,Liquor Laws,
+Island Station,274111,2012,Motor Vehicle Theft,
+Island Station,274111,2012,Offenses Against Family,
+Island Station,274111,2012,Prostitution,
+Island Station,274111,2012,Rape,
+Island Station,274111,2012,Robbery,
+Island Station,274111,2012,Runaway,
+Island Station,274111,2012,Sex Offenses,
+Island Station,274111,2012,Stolen Property,
+Island Station,274111,2012,Trespass,
+Island Station,274111,2012,Vandalism,
+Island Station,274111,2012,Weapons,
+Island Station,274111,2013,Aggravated Assault,
+Island Station,274111,2013,Arson,
+Island Station,274111,2013,"Assault, Simple",
+Island Station,274111,2013,Burglary,
+Island Station,274111,2013,Curfew,
+Island Station,274111,2013,Disorderly Conduct,
+Island Station,274111,2013,Drugs,
+Island Station,274111,2013,DUII,
+Island Station,274111,2013,Embezzlement,
+Island Station,274111,2013,Forgery,
+Island Station,274111,2013,Fraud,
+Island Station,274111,2013,Gambling,
+Island Station,274111,2013,Homicide,
+Island Station,274111,2013,Kidnap,
+Island Station,274111,2013,Larceny,
+Island Station,274111,2013,Liquor Laws,
+Island Station,274111,2013,Motor Vehicle Theft,
+Island Station,274111,2013,Offenses Against Family,
+Island Station,274111,2013,Prostitution,
+Island Station,274111,2013,Rape,
+Island Station,274111,2013,Robbery,
+Island Station,274111,2013,Runaway,
+Island Station,274111,2013,Sex Offenses,
+Island Station,274111,2013,Stolen Property,
+Island Station,274111,2013,Trespass,
+Island Station,274111,2013,Vandalism,
+Island Station,274111,2013,Weapons,
+Island Station,274111,2014,Aggravated Assault,
+Island Station,274111,2014,Arson,
+Island Station,274111,2014,"Assault, Simple",
+Island Station,274111,2014,Burglary,
+Island Station,274111,2014,Curfew,
+Island Station,274111,2014,Disorderly Conduct,
+Island Station,274111,2014,Drugs,
+Island Station,274111,2014,DUII,1
+Island Station,274111,2014,Embezzlement,
+Island Station,274111,2014,Forgery,
+Island Station,274111,2014,Fraud,
+Island Station,274111,2014,Gambling,
+Island Station,274111,2014,Homicide,
+Island Station,274111,2014,Kidnap,
+Island Station,274111,2014,Larceny,
+Island Station,274111,2014,Liquor Laws,
+Island Station,274111,2014,Motor Vehicle Theft,
+Island Station,274111,2014,Offenses Against Family,
+Island Station,274111,2014,Prostitution,
+Island Station,274111,2014,Rape,
+Island Station,274111,2014,Robbery,
+Island Station,274111,2014,Runaway,
+Island Station,274111,2014,Sex Offenses,
+Island Station,274111,2014,Stolen Property,
+Island Station,274111,2014,Trespass,
+Island Station,274111,2014,Vandalism,
+Island Station,274111,2014,Weapons,
+Kenton,207061,2004,Aggravated Assault,4
+Kenton,207061,2004,Arson,
+Kenton,207061,2004,"Assault, Simple",5
+Kenton,207061,2004,Burglary,26
+Kenton,207061,2004,Curfew,1
+Kenton,207061,2004,Disorderly Conduct,7
+Kenton,207061,2004,Drugs,14
+Kenton,207061,2004,DUII,13
+Kenton,207061,2004,Embezzlement,1
+Kenton,207061,2004,Forgery,5
+Kenton,207061,2004,Fraud,7
+Kenton,207061,2004,Gambling,
+Kenton,207061,2004,Homicide,
+Kenton,207061,2004,Kidnap,1
+Kenton,207061,2004,Larceny,73
+Kenton,207061,2004,Liquor Laws,1
+Kenton,207061,2004,Motor Vehicle Theft,26
+Kenton,207061,2004,Offenses Against Family,
+Kenton,207061,2004,Prostitution,
+Kenton,207061,2004,Rape,
+Kenton,207061,2004,Robbery,4
+Kenton,207061,2004,Runaway,
+Kenton,207061,2004,Sex Offenses,
+Kenton,207061,2004,Stolen Property,
+Kenton,207061,2004,Trespass,13
+Kenton,207061,2004,Vandalism,27
+Kenton,207061,2004,Weapons,2
+Kenton,207061,2005,Aggravated Assault,22
+Kenton,207061,2005,Arson,
+Kenton,207061,2005,"Assault, Simple",44
+Kenton,207061,2005,Burglary,69
+Kenton,207061,2005,Curfew,12
+Kenton,207061,2005,Disorderly Conduct,41
+Kenton,207061,2005,Drugs,32
+Kenton,207061,2005,DUII,26
+Kenton,207061,2005,Embezzlement,2
+Kenton,207061,2005,Forgery,20
+Kenton,207061,2005,Fraud,28
+Kenton,207061,2005,Gambling,
+Kenton,207061,2005,Homicide,
+Kenton,207061,2005,Kidnap,
+Kenton,207061,2005,Larceny,188
+Kenton,207061,2005,Liquor Laws,16
+Kenton,207061,2005,Motor Vehicle Theft,78
+Kenton,207061,2005,Offenses Against Family,
+Kenton,207061,2005,Prostitution,
+Kenton,207061,2005,Rape,
+Kenton,207061,2005,Robbery,10
+Kenton,207061,2005,Runaway,
+Kenton,207061,2005,Sex Offenses,
+Kenton,207061,2005,Stolen Property,1
+Kenton,207061,2005,Trespass,37
+Kenton,207061,2005,Vandalism,74
+Kenton,207061,2005,Weapons,9
+Kenton,207061,2006,Aggravated Assault,24
+Kenton,207061,2006,Arson,
+Kenton,207061,2006,"Assault, Simple",27
+Kenton,207061,2006,Burglary,74
+Kenton,207061,2006,Curfew,3
+Kenton,207061,2006,Disorderly Conduct,37
+Kenton,207061,2006,Drugs,37
+Kenton,207061,2006,DUII,20
+Kenton,207061,2006,Embezzlement,4
+Kenton,207061,2006,Forgery,9
+Kenton,207061,2006,Fraud,20
+Kenton,207061,2006,Gambling,
+Kenton,207061,2006,Homicide,1
+Kenton,207061,2006,Kidnap,2
+Kenton,207061,2006,Larceny,194
+Kenton,207061,2006,Liquor Laws,20
+Kenton,207061,2006,Motor Vehicle Theft,38
+Kenton,207061,2006,Offenses Against Family,
+Kenton,207061,2006,Prostitution,
+Kenton,207061,2006,Rape,
+Kenton,207061,2006,Robbery,14
+Kenton,207061,2006,Runaway,
+Kenton,207061,2006,Sex Offenses,1
+Kenton,207061,2006,Stolen Property,3
+Kenton,207061,2006,Trespass,36
+Kenton,207061,2006,Vandalism,113
+Kenton,207061,2006,Weapons,1
+Kenton,207061,2007,Aggravated Assault,20
+Kenton,207061,2007,Arson,
+Kenton,207061,2007,"Assault, Simple",23
+Kenton,207061,2007,Burglary,49
+Kenton,207061,2007,Curfew,3
+Kenton,207061,2007,Disorderly Conduct,31
+Kenton,207061,2007,Drugs,39
+Kenton,207061,2007,DUII,25
+Kenton,207061,2007,Embezzlement,3
+Kenton,207061,2007,Forgery,17
+Kenton,207061,2007,Fraud,16
+Kenton,207061,2007,Gambling,
+Kenton,207061,2007,Homicide,
+Kenton,207061,2007,Kidnap,
+Kenton,207061,2007,Larceny,159
+Kenton,207061,2007,Liquor Laws,10
+Kenton,207061,2007,Motor Vehicle Theft,73
+Kenton,207061,2007,Offenses Against Family,
+Kenton,207061,2007,Prostitution,
+Kenton,207061,2007,Rape,1
+Kenton,207061,2007,Robbery,12
+Kenton,207061,2007,Runaway,
+Kenton,207061,2007,Sex Offenses,
+Kenton,207061,2007,Stolen Property,2
+Kenton,207061,2007,Trespass,26
+Kenton,207061,2007,Vandalism,59
+Kenton,207061,2007,Weapons,4
+Kenton,207061,2008,Aggravated Assault,24
+Kenton,207061,2008,Arson,1
+Kenton,207061,2008,"Assault, Simple",19
+Kenton,207061,2008,Burglary,52
+Kenton,207061,2008,Curfew,1
+Kenton,207061,2008,Disorderly Conduct,20
+Kenton,207061,2008,Drugs,25
+Kenton,207061,2008,DUII,27
+Kenton,207061,2008,Embezzlement,4
+Kenton,207061,2008,Forgery,13
+Kenton,207061,2008,Fraud,20
+Kenton,207061,2008,Gambling,
+Kenton,207061,2008,Homicide,
+Kenton,207061,2008,Kidnap,
+Kenton,207061,2008,Larceny,206
+Kenton,207061,2008,Liquor Laws,11
+Kenton,207061,2008,Motor Vehicle Theft,46
+Kenton,207061,2008,Offenses Against Family,2
+Kenton,207061,2008,Prostitution,
+Kenton,207061,2008,Rape,
+Kenton,207061,2008,Robbery,13
+Kenton,207061,2008,Runaway,
+Kenton,207061,2008,Sex Offenses,1
+Kenton,207061,2008,Stolen Property,2
+Kenton,207061,2008,Trespass,32
+Kenton,207061,2008,Vandalism,45
+Kenton,207061,2008,Weapons,2
+Kenton,207061,2009,Aggravated Assault,9
+Kenton,207061,2009,Arson,
+Kenton,207061,2009,"Assault, Simple",20
+Kenton,207061,2009,Burglary,64
+Kenton,207061,2009,Curfew,
+Kenton,207061,2009,Disorderly Conduct,24
+Kenton,207061,2009,Drugs,27
+Kenton,207061,2009,DUII,21
+Kenton,207061,2009,Embezzlement,1
+Kenton,207061,2009,Forgery,5
+Kenton,207061,2009,Fraud,18
+Kenton,207061,2009,Gambling,
+Kenton,207061,2009,Homicide,1
+Kenton,207061,2009,Kidnap,
+Kenton,207061,2009,Larceny,179
+Kenton,207061,2009,Liquor Laws,8
+Kenton,207061,2009,Motor Vehicle Theft,71
+Kenton,207061,2009,Offenses Against Family,
+Kenton,207061,2009,Prostitution,
+Kenton,207061,2009,Rape,
+Kenton,207061,2009,Robbery,10
+Kenton,207061,2009,Runaway,
+Kenton,207061,2009,Sex Offenses,
+Kenton,207061,2009,Stolen Property,1
+Kenton,207061,2009,Trespass,31
+Kenton,207061,2009,Vandalism,74
+Kenton,207061,2009,Weapons,2
+Kenton,207061,2010,Aggravated Assault,11
+Kenton,207061,2010,Arson,
+Kenton,207061,2010,"Assault, Simple",21
+Kenton,207061,2010,Burglary,77
+Kenton,207061,2010,Curfew,
+Kenton,207061,2010,Disorderly Conduct,13
+Kenton,207061,2010,Drugs,13
+Kenton,207061,2010,DUII,26
+Kenton,207061,2010,Embezzlement,2
+Kenton,207061,2010,Forgery,4
+Kenton,207061,2010,Fraud,12
+Kenton,207061,2010,Gambling,
+Kenton,207061,2010,Homicide,
+Kenton,207061,2010,Kidnap,
+Kenton,207061,2010,Larceny,168
+Kenton,207061,2010,Liquor Laws,12
+Kenton,207061,2010,Motor Vehicle Theft,51
+Kenton,207061,2010,Offenses Against Family,
+Kenton,207061,2010,Prostitution,
+Kenton,207061,2010,Rape,1
+Kenton,207061,2010,Robbery,1
+Kenton,207061,2010,Runaway,
+Kenton,207061,2010,Sex Offenses,
+Kenton,207061,2010,Stolen Property,
+Kenton,207061,2010,Trespass,16
+Kenton,207061,2010,Vandalism,42
+Kenton,207061,2010,Weapons,3
+Kenton,207061,2011,Aggravated Assault,15
+Kenton,207061,2011,Arson,1
+Kenton,207061,2011,"Assault, Simple",24
+Kenton,207061,2011,Burglary,34
+Kenton,207061,2011,Curfew,
+Kenton,207061,2011,Disorderly Conduct,16
+Kenton,207061,2011,Drugs,8
+Kenton,207061,2011,DUII,19
+Kenton,207061,2011,Embezzlement,
+Kenton,207061,2011,Forgery,6
+Kenton,207061,2011,Fraud,10
+Kenton,207061,2011,Gambling,
+Kenton,207061,2011,Homicide,
+Kenton,207061,2011,Kidnap,
+Kenton,207061,2011,Larceny,200
+Kenton,207061,2011,Liquor Laws,12
+Kenton,207061,2011,Motor Vehicle Theft,51
+Kenton,207061,2011,Offenses Against Family,
+Kenton,207061,2011,Prostitution,1
+Kenton,207061,2011,Rape,1
+Kenton,207061,2011,Robbery,6
+Kenton,207061,2011,Runaway,
+Kenton,207061,2011,Sex Offenses,1
+Kenton,207061,2011,Stolen Property,1
+Kenton,207061,2011,Trespass,11
+Kenton,207061,2011,Vandalism,59
+Kenton,207061,2011,Weapons,1
+Kenton,207061,2012,Aggravated Assault,18
+Kenton,207061,2012,Arson,
+Kenton,207061,2012,"Assault, Simple",26
+Kenton,207061,2012,Burglary,50
+Kenton,207061,2012,Curfew,
+Kenton,207061,2012,Disorderly Conduct,26
+Kenton,207061,2012,Drugs,8
+Kenton,207061,2012,DUII,20
+Kenton,207061,2012,Embezzlement,1
+Kenton,207061,2012,Forgery,2
+Kenton,207061,2012,Fraud,14
+Kenton,207061,2012,Gambling,
+Kenton,207061,2012,Homicide,
+Kenton,207061,2012,Kidnap,
+Kenton,207061,2012,Larceny,181
+Kenton,207061,2012,Liquor Laws,1
+Kenton,207061,2012,Motor Vehicle Theft,57
+Kenton,207061,2012,Offenses Against Family,
+Kenton,207061,2012,Prostitution,
+Kenton,207061,2012,Rape,
+Kenton,207061,2012,Robbery,4
+Kenton,207061,2012,Runaway,
+Kenton,207061,2012,Sex Offenses,
+Kenton,207061,2012,Stolen Property,
+Kenton,207061,2012,Trespass,31
+Kenton,207061,2012,Vandalism,72
+Kenton,207061,2012,Weapons,3
+Kenton,207061,2013,Aggravated Assault,21
+Kenton,207061,2013,Arson,1
+Kenton,207061,2013,"Assault, Simple",21
+Kenton,207061,2013,Burglary,47
+Kenton,207061,2013,Curfew,
+Kenton,207061,2013,Disorderly Conduct,31
+Kenton,207061,2013,Drugs,19
+Kenton,207061,2013,DUII,34
+Kenton,207061,2013,Embezzlement,
+Kenton,207061,2013,Forgery,1
+Kenton,207061,2013,Fraud,5
+Kenton,207061,2013,Gambling,
+Kenton,207061,2013,Homicide,
+Kenton,207061,2013,Kidnap,
+Kenton,207061,2013,Larceny,160
+Kenton,207061,2013,Liquor Laws,7
+Kenton,207061,2013,Motor Vehicle Theft,31
+Kenton,207061,2013,Offenses Against Family,
+Kenton,207061,2013,Prostitution,
+Kenton,207061,2013,Rape,
+Kenton,207061,2013,Robbery,6
+Kenton,207061,2013,Runaway,
+Kenton,207061,2013,Sex Offenses,
+Kenton,207061,2013,Stolen Property,2
+Kenton,207061,2013,Trespass,23
+Kenton,207061,2013,Vandalism,45
+Kenton,207061,2013,Weapons,1
+Kenton,207061,2014,Aggravated Assault,14
+Kenton,207061,2014,Arson,
+Kenton,207061,2014,"Assault, Simple",26
+Kenton,207061,2014,Burglary,39
+Kenton,207061,2014,Curfew,
+Kenton,207061,2014,Disorderly Conduct,14
+Kenton,207061,2014,Drugs,18
+Kenton,207061,2014,DUII,19
+Kenton,207061,2014,Embezzlement,2
+Kenton,207061,2014,Forgery,6
+Kenton,207061,2014,Fraud,16
+Kenton,207061,2014,Gambling,
+Kenton,207061,2014,Homicide,
+Kenton,207061,2014,Kidnap,
+Kenton,207061,2014,Larceny,167
+Kenton,207061,2014,Liquor Laws,8
+Kenton,207061,2014,Motor Vehicle Theft,40
+Kenton,207061,2014,Offenses Against Family,1
+Kenton,207061,2014,Prostitution,
+Kenton,207061,2014,Rape,
+Kenton,207061,2014,Robbery,9
+Kenton,207061,2014,Runaway,
+Kenton,207061,2014,Sex Offenses,
+Kenton,207061,2014,Stolen Property,
+Kenton,207061,2014,Trespass,19
+Kenton,207061,2014,Vandalism,49
+Kenton,207061,2014,Weapons,4
+Kerns,271104,2004,Aggravated Assault,9
+Kerns,271104,2004,Arson,
+Kerns,271104,2004,"Assault, Simple",10
+Kerns,271104,2004,Burglary,24
+Kerns,271104,2004,Curfew,
+Kerns,271104,2004,Disorderly Conduct,10
+Kerns,271104,2004,Drugs,16
+Kerns,271104,2004,DUII,15
+Kerns,271104,2004,Embezzlement,1
+Kerns,271104,2004,Forgery,17
+Kerns,271104,2004,Fraud,13
+Kerns,271104,2004,Gambling,
+Kerns,271104,2004,Homicide,
+Kerns,271104,2004,Kidnap,1
+Kerns,271104,2004,Larceny,158
+Kerns,271104,2004,Liquor Laws,15
+Kerns,271104,2004,Motor Vehicle Theft,33
+Kerns,271104,2004,Offenses Against Family,
+Kerns,271104,2004,Prostitution,7
+Kerns,271104,2004,Rape,1
+Kerns,271104,2004,Robbery,6
+Kerns,271104,2004,Runaway,
+Kerns,271104,2004,Sex Offenses,2
+Kerns,271104,2004,Stolen Property,
+Kerns,271104,2004,Trespass,26
+Kerns,271104,2004,Vandalism,39
+Kerns,271104,2004,Weapons,1
+Kerns,271104,2005,Aggravated Assault,20
+Kerns,271104,2005,Arson,2
+Kerns,271104,2005,"Assault, Simple",29
+Kerns,271104,2005,Burglary,74
+Kerns,271104,2005,Curfew,
+Kerns,271104,2005,Disorderly Conduct,31
+Kerns,271104,2005,Drugs,94
+Kerns,271104,2005,DUII,41
+Kerns,271104,2005,Embezzlement,6
+Kerns,271104,2005,Forgery,25
+Kerns,271104,2005,Fraud,21
+Kerns,271104,2005,Gambling,
+Kerns,271104,2005,Homicide,
+Kerns,271104,2005,Kidnap,
+Kerns,271104,2005,Larceny,435
+Kerns,271104,2005,Liquor Laws,41
+Kerns,271104,2005,Motor Vehicle Theft,103
+Kerns,271104,2005,Offenses Against Family,
+Kerns,271104,2005,Prostitution,2
+Kerns,271104,2005,Rape,2
+Kerns,271104,2005,Robbery,19
+Kerns,271104,2005,Runaway,1
+Kerns,271104,2005,Sex Offenses,3
+Kerns,271104,2005,Stolen Property,2
+Kerns,271104,2005,Trespass,90
+Kerns,271104,2005,Vandalism,104
+Kerns,271104,2005,Weapons,5
+Kerns,271104,2006,Aggravated Assault,21
+Kerns,271104,2006,Arson,1
+Kerns,271104,2006,"Assault, Simple",30
+Kerns,271104,2006,Burglary,65
+Kerns,271104,2006,Curfew,
+Kerns,271104,2006,Disorderly Conduct,34
+Kerns,271104,2006,Drugs,52
+Kerns,271104,2006,DUII,55
+Kerns,271104,2006,Embezzlement,6
+Kerns,271104,2006,Forgery,11
+Kerns,271104,2006,Fraud,22
+Kerns,271104,2006,Gambling,
+Kerns,271104,2006,Homicide,
+Kerns,271104,2006,Kidnap,1
+Kerns,271104,2006,Larceny,282
+Kerns,271104,2006,Liquor Laws,53
+Kerns,271104,2006,Motor Vehicle Theft,70
+Kerns,271104,2006,Offenses Against Family,
+Kerns,271104,2006,Prostitution,22
+Kerns,271104,2006,Rape,2
+Kerns,271104,2006,Robbery,18
+Kerns,271104,2006,Runaway,
+Kerns,271104,2006,Sex Offenses,
+Kerns,271104,2006,Stolen Property,1
+Kerns,271104,2006,Trespass,51
+Kerns,271104,2006,Vandalism,166
+Kerns,271104,2006,Weapons,
+Kerns,271104,2007,Aggravated Assault,9
+Kerns,271104,2007,Arson,1
+Kerns,271104,2007,"Assault, Simple",33
+Kerns,271104,2007,Burglary,61
+Kerns,271104,2007,Curfew,
+Kerns,271104,2007,Disorderly Conduct,32
+Kerns,271104,2007,Drugs,34
+Kerns,271104,2007,DUII,48
+Kerns,271104,2007,Embezzlement,10
+Kerns,271104,2007,Forgery,7
+Kerns,271104,2007,Fraud,39
+Kerns,271104,2007,Gambling,
+Kerns,271104,2007,Homicide,1
+Kerns,271104,2007,Kidnap,
+Kerns,271104,2007,Larceny,320
+Kerns,271104,2007,Liquor Laws,49
+Kerns,271104,2007,Motor Vehicle Theft,92
+Kerns,271104,2007,Offenses Against Family,
+Kerns,271104,2007,Prostitution,1
+Kerns,271104,2007,Rape,1
+Kerns,271104,2007,Robbery,21
+Kerns,271104,2007,Runaway,1
+Kerns,271104,2007,Sex Offenses,
+Kerns,271104,2007,Stolen Property,
+Kerns,271104,2007,Trespass,44
+Kerns,271104,2007,Vandalism,137
+Kerns,271104,2007,Weapons,2
+Kerns,271104,2008,Aggravated Assault,14
+Kerns,271104,2008,Arson,
+Kerns,271104,2008,"Assault, Simple",29
+Kerns,271104,2008,Burglary,51
+Kerns,271104,2008,Curfew,
+Kerns,271104,2008,Disorderly Conduct,38
+Kerns,271104,2008,Drugs,29
+Kerns,271104,2008,DUII,40
+Kerns,271104,2008,Embezzlement,2
+Kerns,271104,2008,Forgery,17
+Kerns,271104,2008,Fraud,32
+Kerns,271104,2008,Gambling,
+Kerns,271104,2008,Homicide,1
+Kerns,271104,2008,Kidnap,
+Kerns,271104,2008,Larceny,296
+Kerns,271104,2008,Liquor Laws,38
+Kerns,271104,2008,Motor Vehicle Theft,56
+Kerns,271104,2008,Offenses Against Family,
+Kerns,271104,2008,Prostitution,1
+Kerns,271104,2008,Rape,1
+Kerns,271104,2008,Robbery,13
+Kerns,271104,2008,Runaway,
+Kerns,271104,2008,Sex Offenses,1
+Kerns,271104,2008,Stolen Property,
+Kerns,271104,2008,Trespass,46
+Kerns,271104,2008,Vandalism,115
+Kerns,271104,2008,Weapons,1
+Kerns,271104,2009,Aggravated Assault,17
+Kerns,271104,2009,Arson,3
+Kerns,271104,2009,"Assault, Simple",37
+Kerns,271104,2009,Burglary,44
+Kerns,271104,2009,Curfew,1
+Kerns,271104,2009,Disorderly Conduct,40
+Kerns,271104,2009,Drugs,39
+Kerns,271104,2009,DUII,28
+Kerns,271104,2009,Embezzlement,4
+Kerns,271104,2009,Forgery,8
+Kerns,271104,2009,Fraud,32
+Kerns,271104,2009,Gambling,
+Kerns,271104,2009,Homicide,
+Kerns,271104,2009,Kidnap,
+Kerns,271104,2009,Larceny,282
+Kerns,271104,2009,Liquor Laws,35
+Kerns,271104,2009,Motor Vehicle Theft,38
+Kerns,271104,2009,Offenses Against Family,
+Kerns,271104,2009,Prostitution,
+Kerns,271104,2009,Rape,
+Kerns,271104,2009,Robbery,8
+Kerns,271104,2009,Runaway,
+Kerns,271104,2009,Sex Offenses,3
+Kerns,271104,2009,Stolen Property,1
+Kerns,271104,2009,Trespass,49
+Kerns,271104,2009,Vandalism,113
+Kerns,271104,2009,Weapons,4
+Kerns,271104,2010,Aggravated Assault,18
+Kerns,271104,2010,Arson,
+Kerns,271104,2010,"Assault, Simple",29
+Kerns,271104,2010,Burglary,47
+Kerns,271104,2010,Curfew,
+Kerns,271104,2010,Disorderly Conduct,38
+Kerns,271104,2010,Drugs,25
+Kerns,271104,2010,DUII,41
+Kerns,271104,2010,Embezzlement,1
+Kerns,271104,2010,Forgery,9
+Kerns,271104,2010,Fraud,23
+Kerns,271104,2010,Gambling,
+Kerns,271104,2010,Homicide,
+Kerns,271104,2010,Kidnap,
+Kerns,271104,2010,Larceny,303
+Kerns,271104,2010,Liquor Laws,28
+Kerns,271104,2010,Motor Vehicle Theft,52
+Kerns,271104,2010,Offenses Against Family,
+Kerns,271104,2010,Prostitution,
+Kerns,271104,2010,Rape,
+Kerns,271104,2010,Robbery,8
+Kerns,271104,2010,Runaway,
+Kerns,271104,2010,Sex Offenses,2
+Kerns,271104,2010,Stolen Property,2
+Kerns,271104,2010,Trespass,27
+Kerns,271104,2010,Vandalism,93
+Kerns,271104,2010,Weapons,3
+Kerns,271104,2011,Aggravated Assault,14
+Kerns,271104,2011,Arson,4
+Kerns,271104,2011,"Assault, Simple",30
+Kerns,271104,2011,Burglary,46
+Kerns,271104,2011,Curfew,
+Kerns,271104,2011,Disorderly Conduct,36
+Kerns,271104,2011,Drugs,27
+Kerns,271104,2011,DUII,81
+Kerns,271104,2011,Embezzlement,5
+Kerns,271104,2011,Forgery,6
+Kerns,271104,2011,Fraud,12
+Kerns,271104,2011,Gambling,
+Kerns,271104,2011,Homicide,
+Kerns,271104,2011,Kidnap,1
+Kerns,271104,2011,Larceny,330
+Kerns,271104,2011,Liquor Laws,47
+Kerns,271104,2011,Motor Vehicle Theft,40
+Kerns,271104,2011,Offenses Against Family,
+Kerns,271104,2011,Prostitution,
+Kerns,271104,2011,Rape,2
+Kerns,271104,2011,Robbery,7
+Kerns,271104,2011,Runaway,
+Kerns,271104,2011,Sex Offenses,1
+Kerns,271104,2011,Stolen Property,1
+Kerns,271104,2011,Trespass,26
+Kerns,271104,2011,Vandalism,76
+Kerns,271104,2011,Weapons,1
+Kerns,271104,2012,Aggravated Assault,14
+Kerns,271104,2012,Arson,
+Kerns,271104,2012,"Assault, Simple",29
+Kerns,271104,2012,Burglary,52
+Kerns,271104,2012,Curfew,
+Kerns,271104,2012,Disorderly Conduct,27
+Kerns,271104,2012,Drugs,19
+Kerns,271104,2012,DUII,95
+Kerns,271104,2012,Embezzlement,4
+Kerns,271104,2012,Forgery,18
+Kerns,271104,2012,Fraud,13
+Kerns,271104,2012,Gambling,
+Kerns,271104,2012,Homicide,
+Kerns,271104,2012,Kidnap,
+Kerns,271104,2012,Larceny,379
+Kerns,271104,2012,Liquor Laws,34
+Kerns,271104,2012,Motor Vehicle Theft,49
+Kerns,271104,2012,Offenses Against Family,
+Kerns,271104,2012,Prostitution,
+Kerns,271104,2012,Rape,
+Kerns,271104,2012,Robbery,4
+Kerns,271104,2012,Runaway,1
+Kerns,271104,2012,Sex Offenses,
+Kerns,271104,2012,Stolen Property,
+Kerns,271104,2012,Trespass,34
+Kerns,271104,2012,Vandalism,83
+Kerns,271104,2012,Weapons,6
+Kerns,271104,2013,Aggravated Assault,15
+Kerns,271104,2013,Arson,1
+Kerns,271104,2013,"Assault, Simple",23
+Kerns,271104,2013,Burglary,52
+Kerns,271104,2013,Curfew,
+Kerns,271104,2013,Disorderly Conduct,33
+Kerns,271104,2013,Drugs,24
+Kerns,271104,2013,DUII,55
+Kerns,271104,2013,Embezzlement,3
+Kerns,271104,2013,Forgery,24
+Kerns,271104,2013,Fraud,19
+Kerns,271104,2013,Gambling,
+Kerns,271104,2013,Homicide,
+Kerns,271104,2013,Kidnap,
+Kerns,271104,2013,Larceny,408
+Kerns,271104,2013,Liquor Laws,22
+Kerns,271104,2013,Motor Vehicle Theft,58
+Kerns,271104,2013,Offenses Against Family,
+Kerns,271104,2013,Prostitution,
+Kerns,271104,2013,Rape,
+Kerns,271104,2013,Robbery,1
+Kerns,271104,2013,Runaway,1
+Kerns,271104,2013,Sex Offenses,
+Kerns,271104,2013,Stolen Property,
+Kerns,271104,2013,Trespass,24
+Kerns,271104,2013,Vandalism,106
+Kerns,271104,2013,Weapons,1
+Kerns,271104,2014,Aggravated Assault,14
+Kerns,271104,2014,Arson,1
+Kerns,271104,2014,"Assault, Simple",28
+Kerns,271104,2014,Burglary,56
+Kerns,271104,2014,Curfew,
+Kerns,271104,2014,Disorderly Conduct,35
+Kerns,271104,2014,Drugs,16
+Kerns,271104,2014,DUII,53
+Kerns,271104,2014,Embezzlement,1
+Kerns,271104,2014,Forgery,4
+Kerns,271104,2014,Fraud,26
+Kerns,271104,2014,Gambling,
+Kerns,271104,2014,Homicide,
+Kerns,271104,2014,Kidnap,1
+Kerns,271104,2014,Larceny,431
+Kerns,271104,2014,Liquor Laws,34
+Kerns,271104,2014,Motor Vehicle Theft,54
+Kerns,271104,2014,Offenses Against Family,
+Kerns,271104,2014,Prostitution,
+Kerns,271104,2014,Rape,
+Kerns,271104,2014,Robbery,9
+Kerns,271104,2014,Runaway,
+Kerns,271104,2014,Sex Offenses,1
+Kerns,271104,2014,Stolen Property,1
+Kerns,271104,2014,Trespass,30
+Kerns,271104,2014,Vandalism,85
+Kerns,271104,2014,Weapons,2
+King,271105,2004,Aggravated Assault,23
+King,271105,2004,Arson,
+King,271105,2004,"Assault, Simple",20
+King,271105,2004,Burglary,75
+King,271105,2004,Curfew,15
+King,271105,2004,Disorderly Conduct,24
+King,271105,2004,Drugs,61
+King,271105,2004,DUII,11
+King,271105,2004,Embezzlement,2
+King,271105,2004,Forgery,31
+King,271105,2004,Fraud,15
+King,271105,2004,Gambling,
+King,271105,2004,Homicide,
+King,271105,2004,Kidnap,1
+King,271105,2004,Larceny,211
+King,271105,2004,Liquor Laws,6
+King,271105,2004,Motor Vehicle Theft,43
+King,271105,2004,Offenses Against Family,
+King,271105,2004,Prostitution,2
+King,271105,2004,Rape,
+King,271105,2004,Robbery,15
+King,271105,2004,Runaway,
+King,271105,2004,Sex Offenses,
+King,271105,2004,Stolen Property,
+King,271105,2004,Trespass,43
+King,271105,2004,Vandalism,59
+King,271105,2004,Weapons,10
+King,271105,2005,Aggravated Assault,70
+King,271105,2005,Arson,2
+King,271105,2005,"Assault, Simple",68
+King,271105,2005,Burglary,189
+King,271105,2005,Curfew,38
+King,271105,2005,Disorderly Conduct,75
+King,271105,2005,Drugs,248
+King,271105,2005,DUII,38
+King,271105,2005,Embezzlement,5
+King,271105,2005,Forgery,45
+King,271105,2005,Fraud,67
+King,271105,2005,Gambling,3
+King,271105,2005,Homicide,1
+King,271105,2005,Kidnap,1
+King,271105,2005,Larceny,529
+King,271105,2005,Liquor Laws,11
+King,271105,2005,Motor Vehicle Theft,65
+King,271105,2005,Offenses Against Family,
+King,271105,2005,Prostitution,8
+King,271105,2005,Rape,3
+King,271105,2005,Robbery,39
+King,271105,2005,Runaway,2
+King,271105,2005,Sex Offenses,1
+King,271105,2005,Stolen Property,3
+King,271105,2005,Trespass,118
+King,271105,2005,Vandalism,172
+King,271105,2005,Weapons,18
+King,271105,2006,Aggravated Assault,49
+King,271105,2006,Arson,1
+King,271105,2006,"Assault, Simple",87
+King,271105,2006,Burglary,171
+King,271105,2006,Curfew,26
+King,271105,2006,Disorderly Conduct,80
+King,271105,2006,Drugs,248
+King,271105,2006,DUII,49
+King,271105,2006,Embezzlement,4
+King,271105,2006,Forgery,49
+King,271105,2006,Fraud,64
+King,271105,2006,Gambling,
+King,271105,2006,Homicide,1
+King,271105,2006,Kidnap,1
+King,271105,2006,Larceny,384
+King,271105,2006,Liquor Laws,17
+King,271105,2006,Motor Vehicle Theft,62
+King,271105,2006,Offenses Against Family,1
+King,271105,2006,Prostitution,6
+King,271105,2006,Rape,6
+King,271105,2006,Robbery,48
+King,271105,2006,Runaway,4
+King,271105,2006,Sex Offenses,
+King,271105,2006,Stolen Property,
+King,271105,2006,Trespass,106
+King,271105,2006,Vandalism,187
+King,271105,2006,Weapons,10
+King,271105,2007,Aggravated Assault,46
+King,271105,2007,Arson,2
+King,271105,2007,"Assault, Simple",74
+King,271105,2007,Burglary,175
+King,271105,2007,Curfew,5
+King,271105,2007,Disorderly Conduct,62
+King,271105,2007,Drugs,174
+King,271105,2007,DUII,41
+King,271105,2007,Embezzlement,3
+King,271105,2007,Forgery,35
+King,271105,2007,Fraud,69
+King,271105,2007,Gambling,
+King,271105,2007,Homicide,
+King,271105,2007,Kidnap,1
+King,271105,2007,Larceny,359
+King,271105,2007,Liquor Laws,22
+King,271105,2007,Motor Vehicle Theft,70
+King,271105,2007,Offenses Against Family,
+King,271105,2007,Prostitution,4
+King,271105,2007,Rape,3
+King,271105,2007,Robbery,30
+King,271105,2007,Runaway,1
+King,271105,2007,Sex Offenses,1
+King,271105,2007,Stolen Property,3
+King,271105,2007,Trespass,76
+King,271105,2007,Vandalism,186
+King,271105,2007,Weapons,21
+King,271105,2008,Aggravated Assault,45
+King,271105,2008,Arson,
+King,271105,2008,"Assault, Simple",65
+King,271105,2008,Burglary,198
+King,271105,2008,Curfew,3
+King,271105,2008,Disorderly Conduct,55
+King,271105,2008,Drugs,90
+King,271105,2008,DUII,31
+King,271105,2008,Embezzlement,2
+King,271105,2008,Forgery,18
+King,271105,2008,Fraud,52
+King,271105,2008,Gambling,
+King,271105,2008,Homicide,
+King,271105,2008,Kidnap,
+King,271105,2008,Larceny,481
+King,271105,2008,Liquor Laws,24
+King,271105,2008,Motor Vehicle Theft,49
+King,271105,2008,Offenses Against Family,
+King,271105,2008,Prostitution,1
+King,271105,2008,Rape,1
+King,271105,2008,Robbery,32
+King,271105,2008,Runaway,1
+King,271105,2008,Sex Offenses,2
+King,271105,2008,Stolen Property,3
+King,271105,2008,Trespass,36
+King,271105,2008,Vandalism,155
+King,271105,2008,Weapons,21
+King,271105,2009,Aggravated Assault,30
+King,271105,2009,Arson,
+King,271105,2009,"Assault, Simple",42
+King,271105,2009,Burglary,170
+King,271105,2009,Curfew,12
+King,271105,2009,Disorderly Conduct,46
+King,271105,2009,Drugs,63
+King,271105,2009,DUII,40
+King,271105,2009,Embezzlement,1
+King,271105,2009,Forgery,12
+King,271105,2009,Fraud,37
+King,271105,2009,Gambling,
+King,271105,2009,Homicide,1
+King,271105,2009,Kidnap,
+King,271105,2009,Larceny,348
+King,271105,2009,Liquor Laws,32
+King,271105,2009,Motor Vehicle Theft,52
+King,271105,2009,Offenses Against Family,
+King,271105,2009,Prostitution,
+King,271105,2009,Rape,
+King,271105,2009,Robbery,19
+King,271105,2009,Runaway,1
+King,271105,2009,Sex Offenses,
+King,271105,2009,Stolen Property,2
+King,271105,2009,Trespass,44
+King,271105,2009,Vandalism,96
+King,271105,2009,Weapons,9
+King,271105,2010,Aggravated Assault,25
+King,271105,2010,Arson,
+King,271105,2010,"Assault, Simple",35
+King,271105,2010,Burglary,94
+King,271105,2010,Curfew,1
+King,271105,2010,Disorderly Conduct,39
+King,271105,2010,Drugs,25
+King,271105,2010,DUII,18
+King,271105,2010,Embezzlement,4
+King,271105,2010,Forgery,13
+King,271105,2010,Fraud,36
+King,271105,2010,Gambling,
+King,271105,2010,Homicide,
+King,271105,2010,Kidnap,1
+King,271105,2010,Larceny,310
+King,271105,2010,Liquor Laws,13
+King,271105,2010,Motor Vehicle Theft,49
+King,271105,2010,Offenses Against Family,
+King,271105,2010,Prostitution,
+King,271105,2010,Rape,
+King,271105,2010,Robbery,14
+King,271105,2010,Runaway,
+King,271105,2010,Sex Offenses,1
+King,271105,2010,Stolen Property,1
+King,271105,2010,Trespass,30
+King,271105,2010,Vandalism,111
+King,271105,2010,Weapons,3
+King,271105,2011,Aggravated Assault,30
+King,271105,2011,Arson,
+King,271105,2011,"Assault, Simple",52
+King,271105,2011,Burglary,86
+King,271105,2011,Curfew,1
+King,271105,2011,Disorderly Conduct,47
+King,271105,2011,Drugs,27
+King,271105,2011,DUII,30
+King,271105,2011,Embezzlement,2
+King,271105,2011,Forgery,14
+King,271105,2011,Fraud,24
+King,271105,2011,Gambling,
+King,271105,2011,Homicide,
+King,271105,2011,Kidnap,1
+King,271105,2011,Larceny,353
+King,271105,2011,Liquor Laws,6
+King,271105,2011,Motor Vehicle Theft,53
+King,271105,2011,Offenses Against Family,
+King,271105,2011,Prostitution,2
+King,271105,2011,Rape,2
+King,271105,2011,Robbery,19
+King,271105,2011,Runaway,
+King,271105,2011,Sex Offenses,2
+King,271105,2011,Stolen Property,
+King,271105,2011,Trespass,40
+King,271105,2011,Vandalism,106
+King,271105,2011,Weapons,4
+King,271105,2012,Aggravated Assault,27
+King,271105,2012,Arson,4
+King,271105,2012,"Assault, Simple",49
+King,271105,2012,Burglary,75
+King,271105,2012,Curfew,
+King,271105,2012,Disorderly Conduct,41
+King,271105,2012,Drugs,28
+King,271105,2012,DUII,30
+King,271105,2012,Embezzlement,1
+King,271105,2012,Forgery,12
+King,271105,2012,Fraud,27
+King,271105,2012,Gambling,
+King,271105,2012,Homicide,2
+King,271105,2012,Kidnap,
+King,271105,2012,Larceny,379
+King,271105,2012,Liquor Laws,12
+King,271105,2012,Motor Vehicle Theft,50
+King,271105,2012,Offenses Against Family,
+King,271105,2012,Prostitution,1
+King,271105,2012,Rape,2
+King,271105,2012,Robbery,30
+King,271105,2012,Runaway,1
+King,271105,2012,Sex Offenses,
+King,271105,2012,Stolen Property,
+King,271105,2012,Trespass,40
+King,271105,2012,Vandalism,104
+King,271105,2012,Weapons,12
+King,271105,2013,Aggravated Assault,37
+King,271105,2013,Arson,
+King,271105,2013,"Assault, Simple",44
+King,271105,2013,Burglary,60
+King,271105,2013,Curfew,
+King,271105,2013,Disorderly Conduct,40
+King,271105,2013,Drugs,36
+King,271105,2013,DUII,28
+King,271105,2013,Embezzlement,2
+King,271105,2013,Forgery,7
+King,271105,2013,Fraud,27
+King,271105,2013,Gambling,1
+King,271105,2013,Homicide,1
+King,271105,2013,Kidnap,
+King,271105,2013,Larceny,341
+King,271105,2013,Liquor Laws,16
+King,271105,2013,Motor Vehicle Theft,48
+King,271105,2013,Offenses Against Family,
+King,271105,2013,Prostitution,
+King,271105,2013,Rape,1
+King,271105,2013,Robbery,19
+King,271105,2013,Runaway,1
+King,271105,2013,Sex Offenses,2
+King,271105,2013,Stolen Property,1
+King,271105,2013,Trespass,38
+King,271105,2013,Vandalism,146
+King,271105,2013,Weapons,9
+King,271105,2014,Aggravated Assault,19
+King,271105,2014,Arson,
+King,271105,2014,"Assault, Simple",27
+King,271105,2014,Burglary,84
+King,271105,2014,Curfew,
+King,271105,2014,Disorderly Conduct,41
+King,271105,2014,Drugs,25
+King,271105,2014,DUII,22
+King,271105,2014,Embezzlement,2
+King,271105,2014,Forgery,12
+King,271105,2014,Fraud,26
+King,271105,2014,Gambling,
+King,271105,2014,Homicide,
+King,271105,2014,Kidnap,
+King,271105,2014,Larceny,367
+King,271105,2014,Liquor Laws,17
+King,271105,2014,Motor Vehicle Theft,37
+King,271105,2014,Offenses Against Family,
+King,271105,2014,Prostitution,
+King,271105,2014,Rape,
+King,271105,2014,Robbery,20
+King,271105,2014,Runaway,
+King,271105,2014,Sex Offenses,
+King,271105,2014,Stolen Property,
+King,271105,2014,Trespass,38
+King,271105,2014,Vandalism,112
+King,271105,2014,Weapons,7
+Lake Road,274239,2004,Aggravated Assault,
+Lake Road,274239,2004,Arson,
+Lake Road,274239,2004,"Assault, Simple",
+Lake Road,274239,2004,Burglary,
+Lake Road,274239,2004,Curfew,
+Lake Road,274239,2004,Disorderly Conduct,
+Lake Road,274239,2004,Drugs,
+Lake Road,274239,2004,DUII,
+Lake Road,274239,2004,Embezzlement,
+Lake Road,274239,2004,Forgery,
+Lake Road,274239,2004,Fraud,
+Lake Road,274239,2004,Gambling,
+Lake Road,274239,2004,Homicide,
+Lake Road,274239,2004,Kidnap,
+Lake Road,274239,2004,Larceny,
+Lake Road,274239,2004,Liquor Laws,
+Lake Road,274239,2004,Motor Vehicle Theft,
+Lake Road,274239,2004,Offenses Against Family,
+Lake Road,274239,2004,Prostitution,
+Lake Road,274239,2004,Rape,
+Lake Road,274239,2004,Robbery,
+Lake Road,274239,2004,Runaway,
+Lake Road,274239,2004,Sex Offenses,
+Lake Road,274239,2004,Stolen Property,
+Lake Road,274239,2004,Trespass,
+Lake Road,274239,2004,Vandalism,
+Lake Road,274239,2004,Weapons,
+Lake Road,274239,2005,Aggravated Assault,
+Lake Road,274239,2005,Arson,
+Lake Road,274239,2005,"Assault, Simple",
+Lake Road,274239,2005,Burglary,
+Lake Road,274239,2005,Curfew,
+Lake Road,274239,2005,Disorderly Conduct,
+Lake Road,274239,2005,Drugs,
+Lake Road,274239,2005,DUII,
+Lake Road,274239,2005,Embezzlement,
+Lake Road,274239,2005,Forgery,
+Lake Road,274239,2005,Fraud,
+Lake Road,274239,2005,Gambling,
+Lake Road,274239,2005,Homicide,
+Lake Road,274239,2005,Kidnap,
+Lake Road,274239,2005,Larceny,
+Lake Road,274239,2005,Liquor Laws,
+Lake Road,274239,2005,Motor Vehicle Theft,
+Lake Road,274239,2005,Offenses Against Family,
+Lake Road,274239,2005,Prostitution,
+Lake Road,274239,2005,Rape,
+Lake Road,274239,2005,Robbery,
+Lake Road,274239,2005,Runaway,
+Lake Road,274239,2005,Sex Offenses,
+Lake Road,274239,2005,Stolen Property,
+Lake Road,274239,2005,Trespass,
+Lake Road,274239,2005,Vandalism,
+Lake Road,274239,2005,Weapons,
+Lake Road,274239,2006,Aggravated Assault,
+Lake Road,274239,2006,Arson,
+Lake Road,274239,2006,"Assault, Simple",
+Lake Road,274239,2006,Burglary,
+Lake Road,274239,2006,Curfew,
+Lake Road,274239,2006,Disorderly Conduct,
+Lake Road,274239,2006,Drugs,
+Lake Road,274239,2006,DUII,
+Lake Road,274239,2006,Embezzlement,
+Lake Road,274239,2006,Forgery,
+Lake Road,274239,2006,Fraud,
+Lake Road,274239,2006,Gambling,
+Lake Road,274239,2006,Homicide,
+Lake Road,274239,2006,Kidnap,
+Lake Road,274239,2006,Larceny,
+Lake Road,274239,2006,Liquor Laws,
+Lake Road,274239,2006,Motor Vehicle Theft,
+Lake Road,274239,2006,Offenses Against Family,
+Lake Road,274239,2006,Prostitution,
+Lake Road,274239,2006,Rape,
+Lake Road,274239,2006,Robbery,
+Lake Road,274239,2006,Runaway,
+Lake Road,274239,2006,Sex Offenses,
+Lake Road,274239,2006,Stolen Property,
+Lake Road,274239,2006,Trespass,
+Lake Road,274239,2006,Vandalism,
+Lake Road,274239,2006,Weapons,
+Lake Road,274239,2007,Aggravated Assault,
+Lake Road,274239,2007,Arson,
+Lake Road,274239,2007,"Assault, Simple",
+Lake Road,274239,2007,Burglary,
+Lake Road,274239,2007,Curfew,
+Lake Road,274239,2007,Disorderly Conduct,
+Lake Road,274239,2007,Drugs,
+Lake Road,274239,2007,DUII,
+Lake Road,274239,2007,Embezzlement,
+Lake Road,274239,2007,Forgery,
+Lake Road,274239,2007,Fraud,
+Lake Road,274239,2007,Gambling,
+Lake Road,274239,2007,Homicide,
+Lake Road,274239,2007,Kidnap,
+Lake Road,274239,2007,Larceny,
+Lake Road,274239,2007,Liquor Laws,
+Lake Road,274239,2007,Motor Vehicle Theft,
+Lake Road,274239,2007,Offenses Against Family,
+Lake Road,274239,2007,Prostitution,
+Lake Road,274239,2007,Rape,
+Lake Road,274239,2007,Robbery,
+Lake Road,274239,2007,Runaway,
+Lake Road,274239,2007,Sex Offenses,
+Lake Road,274239,2007,Stolen Property,
+Lake Road,274239,2007,Trespass,
+Lake Road,274239,2007,Vandalism,
+Lake Road,274239,2007,Weapons,
+Lake Road,274239,2008,Aggravated Assault,
+Lake Road,274239,2008,Arson,
+Lake Road,274239,2008,"Assault, Simple",
+Lake Road,274239,2008,Burglary,
+Lake Road,274239,2008,Curfew,
+Lake Road,274239,2008,Disorderly Conduct,
+Lake Road,274239,2008,Drugs,
+Lake Road,274239,2008,DUII,
+Lake Road,274239,2008,Embezzlement,
+Lake Road,274239,2008,Forgery,
+Lake Road,274239,2008,Fraud,
+Lake Road,274239,2008,Gambling,
+Lake Road,274239,2008,Homicide,
+Lake Road,274239,2008,Kidnap,
+Lake Road,274239,2008,Larceny,
+Lake Road,274239,2008,Liquor Laws,
+Lake Road,274239,2008,Motor Vehicle Theft,
+Lake Road,274239,2008,Offenses Against Family,
+Lake Road,274239,2008,Prostitution,
+Lake Road,274239,2008,Rape,
+Lake Road,274239,2008,Robbery,
+Lake Road,274239,2008,Runaway,
+Lake Road,274239,2008,Sex Offenses,
+Lake Road,274239,2008,Stolen Property,
+Lake Road,274239,2008,Trespass,
+Lake Road,274239,2008,Vandalism,
+Lake Road,274239,2008,Weapons,
+Lake Road,274239,2009,Aggravated Assault,
+Lake Road,274239,2009,Arson,
+Lake Road,274239,2009,"Assault, Simple",
+Lake Road,274239,2009,Burglary,
+Lake Road,274239,2009,Curfew,
+Lake Road,274239,2009,Disorderly Conduct,
+Lake Road,274239,2009,Drugs,
+Lake Road,274239,2009,DUII,
+Lake Road,274239,2009,Embezzlement,
+Lake Road,274239,2009,Forgery,
+Lake Road,274239,2009,Fraud,
+Lake Road,274239,2009,Gambling,
+Lake Road,274239,2009,Homicide,
+Lake Road,274239,2009,Kidnap,
+Lake Road,274239,2009,Larceny,
+Lake Road,274239,2009,Liquor Laws,
+Lake Road,274239,2009,Motor Vehicle Theft,
+Lake Road,274239,2009,Offenses Against Family,
+Lake Road,274239,2009,Prostitution,
+Lake Road,274239,2009,Rape,
+Lake Road,274239,2009,Robbery,
+Lake Road,274239,2009,Runaway,
+Lake Road,274239,2009,Sex Offenses,
+Lake Road,274239,2009,Stolen Property,
+Lake Road,274239,2009,Trespass,
+Lake Road,274239,2009,Vandalism,
+Lake Road,274239,2009,Weapons,
+Lake Road,274239,2010,Aggravated Assault,
+Lake Road,274239,2010,Arson,
+Lake Road,274239,2010,"Assault, Simple",
+Lake Road,274239,2010,Burglary,
+Lake Road,274239,2010,Curfew,
+Lake Road,274239,2010,Disorderly Conduct,1
+Lake Road,274239,2010,Drugs,
+Lake Road,274239,2010,DUII,
+Lake Road,274239,2010,Embezzlement,
+Lake Road,274239,2010,Forgery,
+Lake Road,274239,2010,Fraud,
+Lake Road,274239,2010,Gambling,
+Lake Road,274239,2010,Homicide,
+Lake Road,274239,2010,Kidnap,
+Lake Road,274239,2010,Larceny,
+Lake Road,274239,2010,Liquor Laws,
+Lake Road,274239,2010,Motor Vehicle Theft,
+Lake Road,274239,2010,Offenses Against Family,
+Lake Road,274239,2010,Prostitution,
+Lake Road,274239,2010,Rape,
+Lake Road,274239,2010,Robbery,
+Lake Road,274239,2010,Runaway,
+Lake Road,274239,2010,Sex Offenses,
+Lake Road,274239,2010,Stolen Property,
+Lake Road,274239,2010,Trespass,
+Lake Road,274239,2010,Vandalism,
+Lake Road,274239,2010,Weapons,
+Lake Road,274239,2011,Aggravated Assault,
+Lake Road,274239,2011,Arson,
+Lake Road,274239,2011,"Assault, Simple",
+Lake Road,274239,2011,Burglary,
+Lake Road,274239,2011,Curfew,
+Lake Road,274239,2011,Disorderly Conduct,
+Lake Road,274239,2011,Drugs,
+Lake Road,274239,2011,DUII,
+Lake Road,274239,2011,Embezzlement,
+Lake Road,274239,2011,Forgery,
+Lake Road,274239,2011,Fraud,
+Lake Road,274239,2011,Gambling,
+Lake Road,274239,2011,Homicide,
+Lake Road,274239,2011,Kidnap,
+Lake Road,274239,2011,Larceny,
+Lake Road,274239,2011,Liquor Laws,
+Lake Road,274239,2011,Motor Vehicle Theft,
+Lake Road,274239,2011,Offenses Against Family,
+Lake Road,274239,2011,Prostitution,
+Lake Road,274239,2011,Rape,
+Lake Road,274239,2011,Robbery,
+Lake Road,274239,2011,Runaway,
+Lake Road,274239,2011,Sex Offenses,
+Lake Road,274239,2011,Stolen Property,
+Lake Road,274239,2011,Trespass,
+Lake Road,274239,2011,Vandalism,
+Lake Road,274239,2011,Weapons,
+Lake Road,274239,2012,Aggravated Assault,
+Lake Road,274239,2012,Arson,
+Lake Road,274239,2012,"Assault, Simple",
+Lake Road,274239,2012,Burglary,
+Lake Road,274239,2012,Curfew,
+Lake Road,274239,2012,Disorderly Conduct,
+Lake Road,274239,2012,Drugs,
+Lake Road,274239,2012,DUII,
+Lake Road,274239,2012,Embezzlement,
+Lake Road,274239,2012,Forgery,
+Lake Road,274239,2012,Fraud,
+Lake Road,274239,2012,Gambling,
+Lake Road,274239,2012,Homicide,
+Lake Road,274239,2012,Kidnap,
+Lake Road,274239,2012,Larceny,
+Lake Road,274239,2012,Liquor Laws,
+Lake Road,274239,2012,Motor Vehicle Theft,
+Lake Road,274239,2012,Offenses Against Family,
+Lake Road,274239,2012,Prostitution,
+Lake Road,274239,2012,Rape,
+Lake Road,274239,2012,Robbery,
+Lake Road,274239,2012,Runaway,
+Lake Road,274239,2012,Sex Offenses,
+Lake Road,274239,2012,Stolen Property,
+Lake Road,274239,2012,Trespass,
+Lake Road,274239,2012,Vandalism,
+Lake Road,274239,2012,Weapons,
+Lake Road,274239,2013,Aggravated Assault,
+Lake Road,274239,2013,Arson,
+Lake Road,274239,2013,"Assault, Simple",
+Lake Road,274239,2013,Burglary,
+Lake Road,274239,2013,Curfew,
+Lake Road,274239,2013,Disorderly Conduct,
+Lake Road,274239,2013,Drugs,
+Lake Road,274239,2013,DUII,
+Lake Road,274239,2013,Embezzlement,
+Lake Road,274239,2013,Forgery,
+Lake Road,274239,2013,Fraud,
+Lake Road,274239,2013,Gambling,
+Lake Road,274239,2013,Homicide,
+Lake Road,274239,2013,Kidnap,
+Lake Road,274239,2013,Larceny,
+Lake Road,274239,2013,Liquor Laws,
+Lake Road,274239,2013,Motor Vehicle Theft,
+Lake Road,274239,2013,Offenses Against Family,
+Lake Road,274239,2013,Prostitution,
+Lake Road,274239,2013,Rape,
+Lake Road,274239,2013,Robbery,
+Lake Road,274239,2013,Runaway,
+Lake Road,274239,2013,Sex Offenses,
+Lake Road,274239,2013,Stolen Property,
+Lake Road,274239,2013,Trespass,
+Lake Road,274239,2013,Vandalism,
+Lake Road,274239,2013,Weapons,
+Lake Road,274239,2014,Aggravated Assault,
+Lake Road,274239,2014,Arson,
+Lake Road,274239,2014,"Assault, Simple",
+Lake Road,274239,2014,Burglary,
+Lake Road,274239,2014,Curfew,
+Lake Road,274239,2014,Disorderly Conduct,
+Lake Road,274239,2014,Drugs,
+Lake Road,274239,2014,DUII,
+Lake Road,274239,2014,Embezzlement,
+Lake Road,274239,2014,Forgery,
+Lake Road,274239,2014,Fraud,
+Lake Road,274239,2014,Gambling,
+Lake Road,274239,2014,Homicide,
+Lake Road,274239,2014,Kidnap,
+Lake Road,274239,2014,Larceny,
+Lake Road,274239,2014,Liquor Laws,
+Lake Road,274239,2014,Motor Vehicle Theft,
+Lake Road,274239,2014,Offenses Against Family,
+Lake Road,274239,2014,Prostitution,
+Lake Road,274239,2014,Rape,
+Lake Road,274239,2014,Robbery,
+Lake Road,274239,2014,Runaway,
+Lake Road,274239,2014,Sex Offenses,
+Lake Road,274239,2014,Stolen Property,
+Lake Road,274239,2014,Trespass,
+Lake Road,274239,2014,Vandalism,
+Lake Road,274239,2014,Weapons,
+Lents,207108,2004,Aggravated Assault,14
+Lents,207108,2004,Arson,1
+Lents,207108,2004,"Assault, Simple",19
+Lents,207108,2004,Burglary,69
+Lents,207108,2004,Curfew,2
+Lents,207108,2004,Disorderly Conduct,10
+Lents,207108,2004,Drugs,24
+Lents,207108,2004,DUII,11
+Lents,207108,2004,Embezzlement,
+Lents,207108,2004,Forgery,6
+Lents,207108,2004,Fraud,22
+Lents,207108,2004,Gambling,
+Lents,207108,2004,Homicide,
+Lents,207108,2004,Kidnap,
+Lents,207108,2004,Larceny,142
+Lents,207108,2004,Liquor Laws,2
+Lents,207108,2004,Motor Vehicle Theft,59
+Lents,207108,2004,Offenses Against Family,
+Lents,207108,2004,Prostitution,3
+Lents,207108,2004,Rape,
+Lents,207108,2004,Robbery,10
+Lents,207108,2004,Runaway,
+Lents,207108,2004,Sex Offenses,
+Lents,207108,2004,Stolen Property,
+Lents,207108,2004,Trespass,19
+Lents,207108,2004,Vandalism,38
+Lents,207108,2004,Weapons,6
+Lents,207108,2005,Aggravated Assault,74
+Lents,207108,2005,Arson,5
+Lents,207108,2005,"Assault, Simple",92
+Lents,207108,2005,Burglary,244
+Lents,207108,2005,Curfew,4
+Lents,207108,2005,Disorderly Conduct,56
+Lents,207108,2005,Drugs,122
+Lents,207108,2005,DUII,62
+Lents,207108,2005,Embezzlement,4
+Lents,207108,2005,Forgery,33
+Lents,207108,2005,Fraud,88
+Lents,207108,2005,Gambling,
+Lents,207108,2005,Homicide,1
+Lents,207108,2005,Kidnap,3
+Lents,207108,2005,Larceny,749
+Lents,207108,2005,Liquor Laws,12
+Lents,207108,2005,Motor Vehicle Theft,293
+Lents,207108,2005,Offenses Against Family,
+Lents,207108,2005,Prostitution,3
+Lents,207108,2005,Rape,1
+Lents,207108,2005,Robbery,20
+Lents,207108,2005,Runaway,
+Lents,207108,2005,Sex Offenses,1
+Lents,207108,2005,Stolen Property,6
+Lents,207108,2005,Trespass,68
+Lents,207108,2005,Vandalism,216
+Lents,207108,2005,Weapons,24
+Lents,207108,2006,Aggravated Assault,59
+Lents,207108,2006,Arson,6
+Lents,207108,2006,"Assault, Simple",93
+Lents,207108,2006,Burglary,208
+Lents,207108,2006,Curfew,1
+Lents,207108,2006,Disorderly Conduct,70
+Lents,207108,2006,Drugs,121
+Lents,207108,2006,DUII,61
+Lents,207108,2006,Embezzlement,3
+Lents,207108,2006,Forgery,35
+Lents,207108,2006,Fraud,105
+Lents,207108,2006,Gambling,
+Lents,207108,2006,Homicide,2
+Lents,207108,2006,Kidnap,1
+Lents,207108,2006,Larceny,660
+Lents,207108,2006,Liquor Laws,22
+Lents,207108,2006,Motor Vehicle Theft,204
+Lents,207108,2006,Offenses Against Family,
+Lents,207108,2006,Prostitution,4
+Lents,207108,2006,Rape,1
+Lents,207108,2006,Robbery,23
+Lents,207108,2006,Runaway,1
+Lents,207108,2006,Sex Offenses,4
+Lents,207108,2006,Stolen Property,2
+Lents,207108,2006,Trespass,68
+Lents,207108,2006,Vandalism,289
+Lents,207108,2006,Weapons,28
+Lents,207108,2007,Aggravated Assault,64
+Lents,207108,2007,Arson,5
+Lents,207108,2007,"Assault, Simple",107
+Lents,207108,2007,Burglary,190
+Lents,207108,2007,Curfew,5
+Lents,207108,2007,Disorderly Conduct,66
+Lents,207108,2007,Drugs,88
+Lents,207108,2007,DUII,63
+Lents,207108,2007,Embezzlement,6
+Lents,207108,2007,Forgery,30
+Lents,207108,2007,Fraud,85
+Lents,207108,2007,Gambling,1
+Lents,207108,2007,Homicide,1
+Lents,207108,2007,Kidnap,2
+Lents,207108,2007,Larceny,657
+Lents,207108,2007,Liquor Laws,19
+Lents,207108,2007,Motor Vehicle Theft,252
+Lents,207108,2007,Offenses Against Family,
+Lents,207108,2007,Prostitution,1
+Lents,207108,2007,Rape,1
+Lents,207108,2007,Robbery,35
+Lents,207108,2007,Runaway,
+Lents,207108,2007,Sex Offenses,
+Lents,207108,2007,Stolen Property,4
+Lents,207108,2007,Trespass,70
+Lents,207108,2007,Vandalism,287
+Lents,207108,2007,Weapons,21
+Lents,207108,2008,Aggravated Assault,59
+Lents,207108,2008,Arson,2
+Lents,207108,2008,"Assault, Simple",107
+Lents,207108,2008,Burglary,131
+Lents,207108,2008,Curfew,5
+Lents,207108,2008,Disorderly Conduct,60
+Lents,207108,2008,Drugs,75
+Lents,207108,2008,DUII,66
+Lents,207108,2008,Embezzlement,4
+Lents,207108,2008,Forgery,23
+Lents,207108,2008,Fraud,70
+Lents,207108,2008,Gambling,
+Lents,207108,2008,Homicide,1
+Lents,207108,2008,Kidnap,1
+Lents,207108,2008,Larceny,485
+Lents,207108,2008,Liquor Laws,25
+Lents,207108,2008,Motor Vehicle Theft,132
+Lents,207108,2008,Offenses Against Family,
+Lents,207108,2008,Prostitution,11
+Lents,207108,2008,Rape,1
+Lents,207108,2008,Robbery,32
+Lents,207108,2008,Runaway,1
+Lents,207108,2008,Sex Offenses,2
+Lents,207108,2008,Stolen Property,2
+Lents,207108,2008,Trespass,51
+Lents,207108,2008,Vandalism,171
+Lents,207108,2008,Weapons,18
+Lents,207108,2009,Aggravated Assault,49
+Lents,207108,2009,Arson,6
+Lents,207108,2009,"Assault, Simple",119
+Lents,207108,2009,Burglary,147
+Lents,207108,2009,Curfew,1
+Lents,207108,2009,Disorderly Conduct,99
+Lents,207108,2009,Drugs,77
+Lents,207108,2009,DUII,49
+Lents,207108,2009,Embezzlement,4
+Lents,207108,2009,Forgery,26
+Lents,207108,2009,Fraud,62
+Lents,207108,2009,Gambling,
+Lents,207108,2009,Homicide,
+Lents,207108,2009,Kidnap,2
+Lents,207108,2009,Larceny,434
+Lents,207108,2009,Liquor Laws,31
+Lents,207108,2009,Motor Vehicle Theft,132
+Lents,207108,2009,Offenses Against Family,1
+Lents,207108,2009,Prostitution,7
+Lents,207108,2009,Rape,4
+Lents,207108,2009,Robbery,39
+Lents,207108,2009,Runaway,
+Lents,207108,2009,Sex Offenses,6
+Lents,207108,2009,Stolen Property,
+Lents,207108,2009,Trespass,63
+Lents,207108,2009,Vandalism,195
+Lents,207108,2009,Weapons,17
+Lents,207108,2010,Aggravated Assault,56
+Lents,207108,2010,Arson,3
+Lents,207108,2010,"Assault, Simple",120
+Lents,207108,2010,Burglary,191
+Lents,207108,2010,Curfew,2
+Lents,207108,2010,Disorderly Conduct,98
+Lents,207108,2010,Drugs,88
+Lents,207108,2010,DUII,54
+Lents,207108,2010,Embezzlement,1
+Lents,207108,2010,Forgery,21
+Lents,207108,2010,Fraud,44
+Lents,207108,2010,Gambling,
+Lents,207108,2010,Homicide,1
+Lents,207108,2010,Kidnap,
+Lents,207108,2010,Larceny,437
+Lents,207108,2010,Liquor Laws,18
+Lents,207108,2010,Motor Vehicle Theft,141
+Lents,207108,2010,Offenses Against Family,
+Lents,207108,2010,Prostitution,2
+Lents,207108,2010,Rape,2
+Lents,207108,2010,Robbery,40
+Lents,207108,2010,Runaway,1
+Lents,207108,2010,Sex Offenses,4
+Lents,207108,2010,Stolen Property,10
+Lents,207108,2010,Trespass,52
+Lents,207108,2010,Vandalism,193
+Lents,207108,2010,Weapons,15
+Lents,207108,2011,Aggravated Assault,54
+Lents,207108,2011,Arson,1
+Lents,207108,2011,"Assault, Simple",88
+Lents,207108,2011,Burglary,196
+Lents,207108,2011,Curfew,
+Lents,207108,2011,Disorderly Conduct,75
+Lents,207108,2011,Drugs,72
+Lents,207108,2011,DUII,61
+Lents,207108,2011,Embezzlement,3
+Lents,207108,2011,Forgery,151
+Lents,207108,2011,Fraud,59
+Lents,207108,2011,Gambling,
+Lents,207108,2011,Homicide,3
+Lents,207108,2011,Kidnap,
+Lents,207108,2011,Larceny,518
+Lents,207108,2011,Liquor Laws,12
+Lents,207108,2011,Motor Vehicle Theft,152
+Lents,207108,2011,Offenses Against Family,
+Lents,207108,2011,Prostitution,5
+Lents,207108,2011,Rape,3
+Lents,207108,2011,Robbery,28
+Lents,207108,2011,Runaway,1
+Lents,207108,2011,Sex Offenses,1
+Lents,207108,2011,Stolen Property,
+Lents,207108,2011,Trespass,63
+Lents,207108,2011,Vandalism,174
+Lents,207108,2011,Weapons,16
+Lents,207108,2012,Aggravated Assault,35
+Lents,207108,2012,Arson,6
+Lents,207108,2012,"Assault, Simple",74
+Lents,207108,2012,Burglary,172
+Lents,207108,2012,Curfew,
+Lents,207108,2012,Disorderly Conduct,77
+Lents,207108,2012,Drugs,82
+Lents,207108,2012,DUII,57
+Lents,207108,2012,Embezzlement,2
+Lents,207108,2012,Forgery,23
+Lents,207108,2012,Fraud,33
+Lents,207108,2012,Gambling,
+Lents,207108,2012,Homicide,
+Lents,207108,2012,Kidnap,1
+Lents,207108,2012,Larceny,508
+Lents,207108,2012,Liquor Laws,12
+Lents,207108,2012,Motor Vehicle Theft,167
+Lents,207108,2012,Offenses Against Family,
+Lents,207108,2012,Prostitution,3
+Lents,207108,2012,Rape,
+Lents,207108,2012,Robbery,25
+Lents,207108,2012,Runaway,3
+Lents,207108,2012,Sex Offenses,4
+Lents,207108,2012,Stolen Property,3
+Lents,207108,2012,Trespass,48
+Lents,207108,2012,Vandalism,157
+Lents,207108,2012,Weapons,13
+Lents,207108,2013,Aggravated Assault,54
+Lents,207108,2013,Arson,6
+Lents,207108,2013,"Assault, Simple",98
+Lents,207108,2013,Burglary,159
+Lents,207108,2013,Curfew,
+Lents,207108,2013,Disorderly Conduct,68
+Lents,207108,2013,Drugs,97
+Lents,207108,2013,DUII,44
+Lents,207108,2013,Embezzlement,3
+Lents,207108,2013,Forgery,20
+Lents,207108,2013,Fraud,49
+Lents,207108,2013,Gambling,
+Lents,207108,2013,Homicide,2
+Lents,207108,2013,Kidnap,
+Lents,207108,2013,Larceny,570
+Lents,207108,2013,Liquor Laws,6
+Lents,207108,2013,Motor Vehicle Theft,143
+Lents,207108,2013,Offenses Against Family,
+Lents,207108,2013,Prostitution,3
+Lents,207108,2013,Rape,3
+Lents,207108,2013,Robbery,36
+Lents,207108,2013,Runaway,1
+Lents,207108,2013,Sex Offenses,2
+Lents,207108,2013,Stolen Property,6
+Lents,207108,2013,Trespass,47
+Lents,207108,2013,Vandalism,139
+Lents,207108,2013,Weapons,17
+Lents,207108,2014,Aggravated Assault,45
+Lents,207108,2014,Arson,2
+Lents,207108,2014,"Assault, Simple",79
+Lents,207108,2014,Burglary,161
+Lents,207108,2014,Curfew,
+Lents,207108,2014,Disorderly Conduct,79
+Lents,207108,2014,Drugs,97
+Lents,207108,2014,DUII,30
+Lents,207108,2014,Embezzlement,2
+Lents,207108,2014,Forgery,27
+Lents,207108,2014,Fraud,46
+Lents,207108,2014,Gambling,
+Lents,207108,2014,Homicide,2
+Lents,207108,2014,Kidnap,
+Lents,207108,2014,Larceny,545
+Lents,207108,2014,Liquor Laws,3
+Lents,207108,2014,Motor Vehicle Theft,165
+Lents,207108,2014,Offenses Against Family,
+Lents,207108,2014,Prostitution,3
+Lents,207108,2014,Rape,4
+Lents,207108,2014,Robbery,30
+Lents,207108,2014,Runaway,1
+Lents,207108,2014,Sex Offenses,6
+Lents,207108,2014,Stolen Property,5
+Lents,207108,2014,Trespass,62
+Lents,207108,2014,Vandalism,154
+Lents,207108,2014,Weapons,7
+Lewelling,274295,2004,Aggravated Assault,
+Lewelling,274295,2004,Arson,
+Lewelling,274295,2004,"Assault, Simple",
+Lewelling,274295,2004,Burglary,
+Lewelling,274295,2004,Curfew,
+Lewelling,274295,2004,Disorderly Conduct,
+Lewelling,274295,2004,Drugs,
+Lewelling,274295,2004,DUII,
+Lewelling,274295,2004,Embezzlement,
+Lewelling,274295,2004,Forgery,
+Lewelling,274295,2004,Fraud,
+Lewelling,274295,2004,Gambling,
+Lewelling,274295,2004,Homicide,
+Lewelling,274295,2004,Kidnap,
+Lewelling,274295,2004,Larceny,
+Lewelling,274295,2004,Liquor Laws,
+Lewelling,274295,2004,Motor Vehicle Theft,
+Lewelling,274295,2004,Offenses Against Family,
+Lewelling,274295,2004,Prostitution,
+Lewelling,274295,2004,Rape,
+Lewelling,274295,2004,Robbery,
+Lewelling,274295,2004,Runaway,
+Lewelling,274295,2004,Sex Offenses,
+Lewelling,274295,2004,Stolen Property,
+Lewelling,274295,2004,Trespass,
+Lewelling,274295,2004,Vandalism,
+Lewelling,274295,2004,Weapons,
+Lewelling,274295,2005,Aggravated Assault,
+Lewelling,274295,2005,Arson,
+Lewelling,274295,2005,"Assault, Simple",
+Lewelling,274295,2005,Burglary,
+Lewelling,274295,2005,Curfew,
+Lewelling,274295,2005,Disorderly Conduct,
+Lewelling,274295,2005,Drugs,
+Lewelling,274295,2005,DUII,
+Lewelling,274295,2005,Embezzlement,
+Lewelling,274295,2005,Forgery,
+Lewelling,274295,2005,Fraud,
+Lewelling,274295,2005,Gambling,
+Lewelling,274295,2005,Homicide,
+Lewelling,274295,2005,Kidnap,
+Lewelling,274295,2005,Larceny,
+Lewelling,274295,2005,Liquor Laws,
+Lewelling,274295,2005,Motor Vehicle Theft,
+Lewelling,274295,2005,Offenses Against Family,
+Lewelling,274295,2005,Prostitution,
+Lewelling,274295,2005,Rape,
+Lewelling,274295,2005,Robbery,
+Lewelling,274295,2005,Runaway,
+Lewelling,274295,2005,Sex Offenses,
+Lewelling,274295,2005,Stolen Property,
+Lewelling,274295,2005,Trespass,
+Lewelling,274295,2005,Vandalism,
+Lewelling,274295,2005,Weapons,
+Lewelling,274295,2006,Aggravated Assault,
+Lewelling,274295,2006,Arson,
+Lewelling,274295,2006,"Assault, Simple",
+Lewelling,274295,2006,Burglary,
+Lewelling,274295,2006,Curfew,
+Lewelling,274295,2006,Disorderly Conduct,
+Lewelling,274295,2006,Drugs,
+Lewelling,274295,2006,DUII,
+Lewelling,274295,2006,Embezzlement,
+Lewelling,274295,2006,Forgery,
+Lewelling,274295,2006,Fraud,
+Lewelling,274295,2006,Gambling,
+Lewelling,274295,2006,Homicide,
+Lewelling,274295,2006,Kidnap,
+Lewelling,274295,2006,Larceny,
+Lewelling,274295,2006,Liquor Laws,
+Lewelling,274295,2006,Motor Vehicle Theft,
+Lewelling,274295,2006,Offenses Against Family,
+Lewelling,274295,2006,Prostitution,
+Lewelling,274295,2006,Rape,
+Lewelling,274295,2006,Robbery,
+Lewelling,274295,2006,Runaway,
+Lewelling,274295,2006,Sex Offenses,
+Lewelling,274295,2006,Stolen Property,
+Lewelling,274295,2006,Trespass,
+Lewelling,274295,2006,Vandalism,
+Lewelling,274295,2006,Weapons,
+Lewelling,274295,2007,Aggravated Assault,
+Lewelling,274295,2007,Arson,
+Lewelling,274295,2007,"Assault, Simple",
+Lewelling,274295,2007,Burglary,
+Lewelling,274295,2007,Curfew,
+Lewelling,274295,2007,Disorderly Conduct,
+Lewelling,274295,2007,Drugs,
+Lewelling,274295,2007,DUII,
+Lewelling,274295,2007,Embezzlement,
+Lewelling,274295,2007,Forgery,
+Lewelling,274295,2007,Fraud,
+Lewelling,274295,2007,Gambling,
+Lewelling,274295,2007,Homicide,
+Lewelling,274295,2007,Kidnap,
+Lewelling,274295,2007,Larceny,2
+Lewelling,274295,2007,Liquor Laws,
+Lewelling,274295,2007,Motor Vehicle Theft,1
+Lewelling,274295,2007,Offenses Against Family,
+Lewelling,274295,2007,Prostitution,
+Lewelling,274295,2007,Rape,
+Lewelling,274295,2007,Robbery,
+Lewelling,274295,2007,Runaway,
+Lewelling,274295,2007,Sex Offenses,
+Lewelling,274295,2007,Stolen Property,
+Lewelling,274295,2007,Trespass,
+Lewelling,274295,2007,Vandalism,
+Lewelling,274295,2007,Weapons,
+Lewelling,274295,2008,Aggravated Assault,
+Lewelling,274295,2008,Arson,
+Lewelling,274295,2008,"Assault, Simple",
+Lewelling,274295,2008,Burglary,
+Lewelling,274295,2008,Curfew,
+Lewelling,274295,2008,Disorderly Conduct,
+Lewelling,274295,2008,Drugs,
+Lewelling,274295,2008,DUII,
+Lewelling,274295,2008,Embezzlement,
+Lewelling,274295,2008,Forgery,
+Lewelling,274295,2008,Fraud,1
+Lewelling,274295,2008,Gambling,
+Lewelling,274295,2008,Homicide,
+Lewelling,274295,2008,Kidnap,
+Lewelling,274295,2008,Larceny,2
+Lewelling,274295,2008,Liquor Laws,
+Lewelling,274295,2008,Motor Vehicle Theft,1
+Lewelling,274295,2008,Offenses Against Family,
+Lewelling,274295,2008,Prostitution,
+Lewelling,274295,2008,Rape,
+Lewelling,274295,2008,Robbery,
+Lewelling,274295,2008,Runaway,
+Lewelling,274295,2008,Sex Offenses,
+Lewelling,274295,2008,Stolen Property,
+Lewelling,274295,2008,Trespass,
+Lewelling,274295,2008,Vandalism,
+Lewelling,274295,2008,Weapons,
+Lewelling,274295,2009,Aggravated Assault,
+Lewelling,274295,2009,Arson,
+Lewelling,274295,2009,"Assault, Simple",
+Lewelling,274295,2009,Burglary,
+Lewelling,274295,2009,Curfew,
+Lewelling,274295,2009,Disorderly Conduct,
+Lewelling,274295,2009,Drugs,
+Lewelling,274295,2009,DUII,
+Lewelling,274295,2009,Embezzlement,
+Lewelling,274295,2009,Forgery,
+Lewelling,274295,2009,Fraud,1
+Lewelling,274295,2009,Gambling,
+Lewelling,274295,2009,Homicide,
+Lewelling,274295,2009,Kidnap,
+Lewelling,274295,2009,Larceny,
+Lewelling,274295,2009,Liquor Laws,
+Lewelling,274295,2009,Motor Vehicle Theft,
+Lewelling,274295,2009,Offenses Against Family,
+Lewelling,274295,2009,Prostitution,
+Lewelling,274295,2009,Rape,
+Lewelling,274295,2009,Robbery,
+Lewelling,274295,2009,Runaway,
+Lewelling,274295,2009,Sex Offenses,
+Lewelling,274295,2009,Stolen Property,
+Lewelling,274295,2009,Trespass,
+Lewelling,274295,2009,Vandalism,
+Lewelling,274295,2009,Weapons,
+Lewelling,274295,2010,Aggravated Assault,
+Lewelling,274295,2010,Arson,
+Lewelling,274295,2010,"Assault, Simple",
+Lewelling,274295,2010,Burglary,
+Lewelling,274295,2010,Curfew,
+Lewelling,274295,2010,Disorderly Conduct,
+Lewelling,274295,2010,Drugs,
+Lewelling,274295,2010,DUII,
+Lewelling,274295,2010,Embezzlement,
+Lewelling,274295,2010,Forgery,
+Lewelling,274295,2010,Fraud,
+Lewelling,274295,2010,Gambling,
+Lewelling,274295,2010,Homicide,
+Lewelling,274295,2010,Kidnap,
+Lewelling,274295,2010,Larceny,
+Lewelling,274295,2010,Liquor Laws,
+Lewelling,274295,2010,Motor Vehicle Theft,
+Lewelling,274295,2010,Offenses Against Family,
+Lewelling,274295,2010,Prostitution,
+Lewelling,274295,2010,Rape,
+Lewelling,274295,2010,Robbery,
+Lewelling,274295,2010,Runaway,
+Lewelling,274295,2010,Sex Offenses,
+Lewelling,274295,2010,Stolen Property,
+Lewelling,274295,2010,Trespass,
+Lewelling,274295,2010,Vandalism,
+Lewelling,274295,2010,Weapons,
+Lewelling,274295,2011,Aggravated Assault,
+Lewelling,274295,2011,Arson,
+Lewelling,274295,2011,"Assault, Simple",
+Lewelling,274295,2011,Burglary,
+Lewelling,274295,2011,Curfew,
+Lewelling,274295,2011,Disorderly Conduct,
+Lewelling,274295,2011,Drugs,
+Lewelling,274295,2011,DUII,1
+Lewelling,274295,2011,Embezzlement,
+Lewelling,274295,2011,Forgery,
+Lewelling,274295,2011,Fraud,
+Lewelling,274295,2011,Gambling,
+Lewelling,274295,2011,Homicide,
+Lewelling,274295,2011,Kidnap,
+Lewelling,274295,2011,Larceny,1
+Lewelling,274295,2011,Liquor Laws,
+Lewelling,274295,2011,Motor Vehicle Theft,
+Lewelling,274295,2011,Offenses Against Family,
+Lewelling,274295,2011,Prostitution,
+Lewelling,274295,2011,Rape,
+Lewelling,274295,2011,Robbery,
+Lewelling,274295,2011,Runaway,
+Lewelling,274295,2011,Sex Offenses,
+Lewelling,274295,2011,Stolen Property,
+Lewelling,274295,2011,Trespass,
+Lewelling,274295,2011,Vandalism,
+Lewelling,274295,2011,Weapons,
+Lewelling,274295,2012,Aggravated Assault,
+Lewelling,274295,2012,Arson,
+Lewelling,274295,2012,"Assault, Simple",
+Lewelling,274295,2012,Burglary,
+Lewelling,274295,2012,Curfew,
+Lewelling,274295,2012,Disorderly Conduct,
+Lewelling,274295,2012,Drugs,
+Lewelling,274295,2012,DUII,
+Lewelling,274295,2012,Embezzlement,2
+Lewelling,274295,2012,Forgery,
+Lewelling,274295,2012,Fraud,
+Lewelling,274295,2012,Gambling,
+Lewelling,274295,2012,Homicide,
+Lewelling,274295,2012,Kidnap,
+Lewelling,274295,2012,Larceny,3
+Lewelling,274295,2012,Liquor Laws,
+Lewelling,274295,2012,Motor Vehicle Theft,
+Lewelling,274295,2012,Offenses Against Family,
+Lewelling,274295,2012,Prostitution,
+Lewelling,274295,2012,Rape,
+Lewelling,274295,2012,Robbery,
+Lewelling,274295,2012,Runaway,
+Lewelling,274295,2012,Sex Offenses,
+Lewelling,274295,2012,Stolen Property,
+Lewelling,274295,2012,Trespass,
+Lewelling,274295,2012,Vandalism,
+Lewelling,274295,2012,Weapons,1
+Lewelling,274295,2013,Aggravated Assault,
+Lewelling,274295,2013,Arson,
+Lewelling,274295,2013,"Assault, Simple",
+Lewelling,274295,2013,Burglary,
+Lewelling,274295,2013,Curfew,
+Lewelling,274295,2013,Disorderly Conduct,
+Lewelling,274295,2013,Drugs,1
+Lewelling,274295,2013,DUII,
+Lewelling,274295,2013,Embezzlement,
+Lewelling,274295,2013,Forgery,
+Lewelling,274295,2013,Fraud,
+Lewelling,274295,2013,Gambling,
+Lewelling,274295,2013,Homicide,
+Lewelling,274295,2013,Kidnap,
+Lewelling,274295,2013,Larceny,5
+Lewelling,274295,2013,Liquor Laws,
+Lewelling,274295,2013,Motor Vehicle Theft,
+Lewelling,274295,2013,Offenses Against Family,
+Lewelling,274295,2013,Prostitution,
+Lewelling,274295,2013,Rape,
+Lewelling,274295,2013,Robbery,
+Lewelling,274295,2013,Runaway,
+Lewelling,274295,2013,Sex Offenses,
+Lewelling,274295,2013,Stolen Property,
+Lewelling,274295,2013,Trespass,
+Lewelling,274295,2013,Vandalism,
+Lewelling,274295,2013,Weapons,
+Lewelling,274295,2014,Aggravated Assault,
+Lewelling,274295,2014,Arson,
+Lewelling,274295,2014,"Assault, Simple",
+Lewelling,274295,2014,Burglary,
+Lewelling,274295,2014,Curfew,
+Lewelling,274295,2014,Disorderly Conduct,
+Lewelling,274295,2014,Drugs,
+Lewelling,274295,2014,DUII,
+Lewelling,274295,2014,Embezzlement,1
+Lewelling,274295,2014,Forgery,
+Lewelling,274295,2014,Fraud,
+Lewelling,274295,2014,Gambling,
+Lewelling,274295,2014,Homicide,
+Lewelling,274295,2014,Kidnap,
+Lewelling,274295,2014,Larceny,2
+Lewelling,274295,2014,Liquor Laws,
+Lewelling,274295,2014,Motor Vehicle Theft,
+Lewelling,274295,2014,Offenses Against Family,
+Lewelling,274295,2014,Prostitution,
+Lewelling,274295,2014,Rape,
+Lewelling,274295,2014,Robbery,
+Lewelling,274295,2014,Runaway,
+Lewelling,274295,2014,Sex Offenses,
+Lewelling,274295,2014,Stolen Property,
+Lewelling,274295,2014,Trespass,
+Lewelling,274295,2014,Vandalism,
+Lewelling,274295,2014,Weapons,1
+Linnton,207125,2004,Aggravated Assault,
+Linnton,207125,2004,Arson,
+Linnton,207125,2004,"Assault, Simple",1
+Linnton,207125,2004,Burglary,3
+Linnton,207125,2004,Curfew,
+Linnton,207125,2004,Disorderly Conduct,
+Linnton,207125,2004,Drugs,
+Linnton,207125,2004,DUII,2
+Linnton,207125,2004,Embezzlement,
+Linnton,207125,2004,Forgery,
+Linnton,207125,2004,Fraud,1
+Linnton,207125,2004,Gambling,
+Linnton,207125,2004,Homicide,
+Linnton,207125,2004,Kidnap,
+Linnton,207125,2004,Larceny,
+Linnton,207125,2004,Liquor Laws,
+Linnton,207125,2004,Motor Vehicle Theft,
+Linnton,207125,2004,Offenses Against Family,
+Linnton,207125,2004,Prostitution,
+Linnton,207125,2004,Rape,
+Linnton,207125,2004,Robbery,
+Linnton,207125,2004,Runaway,
+Linnton,207125,2004,Sex Offenses,
+Linnton,207125,2004,Stolen Property,
+Linnton,207125,2004,Trespass,1
+Linnton,207125,2004,Vandalism,1
+Linnton,207125,2004,Weapons,
+Linnton,207125,2005,Aggravated Assault,5
+Linnton,207125,2005,Arson,
+Linnton,207125,2005,"Assault, Simple",1
+Linnton,207125,2005,Burglary,13
+Linnton,207125,2005,Curfew,
+Linnton,207125,2005,Disorderly Conduct,5
+Linnton,207125,2005,Drugs,2
+Linnton,207125,2005,DUII,7
+Linnton,207125,2005,Embezzlement,
+Linnton,207125,2005,Forgery,
+Linnton,207125,2005,Fraud,1
+Linnton,207125,2005,Gambling,
+Linnton,207125,2005,Homicide,
+Linnton,207125,2005,Kidnap,
+Linnton,207125,2005,Larceny,25
+Linnton,207125,2005,Liquor Laws,2
+Linnton,207125,2005,Motor Vehicle Theft,5
+Linnton,207125,2005,Offenses Against Family,
+Linnton,207125,2005,Prostitution,
+Linnton,207125,2005,Rape,
+Linnton,207125,2005,Robbery,
+Linnton,207125,2005,Runaway,
+Linnton,207125,2005,Sex Offenses,
+Linnton,207125,2005,Stolen Property,
+Linnton,207125,2005,Trespass,2
+Linnton,207125,2005,Vandalism,6
+Linnton,207125,2005,Weapons,
+Linnton,207125,2006,Aggravated Assault,1
+Linnton,207125,2006,Arson,
+Linnton,207125,2006,"Assault, Simple",1
+Linnton,207125,2006,Burglary,3
+Linnton,207125,2006,Curfew,
+Linnton,207125,2006,Disorderly Conduct,3
+Linnton,207125,2006,Drugs,3
+Linnton,207125,2006,DUII,11
+Linnton,207125,2006,Embezzlement,
+Linnton,207125,2006,Forgery,1
+Linnton,207125,2006,Fraud,4
+Linnton,207125,2006,Gambling,
+Linnton,207125,2006,Homicide,
+Linnton,207125,2006,Kidnap,
+Linnton,207125,2006,Larceny,34
+Linnton,207125,2006,Liquor Laws,1
+Linnton,207125,2006,Motor Vehicle Theft,4
+Linnton,207125,2006,Offenses Against Family,
+Linnton,207125,2006,Prostitution,
+Linnton,207125,2006,Rape,
+Linnton,207125,2006,Robbery,
+Linnton,207125,2006,Runaway,
+Linnton,207125,2006,Sex Offenses,
+Linnton,207125,2006,Stolen Property,
+Linnton,207125,2006,Trespass,1
+Linnton,207125,2006,Vandalism,6
+Linnton,207125,2006,Weapons,
+Linnton,207125,2007,Aggravated Assault,
+Linnton,207125,2007,Arson,
+Linnton,207125,2007,"Assault, Simple",3
+Linnton,207125,2007,Burglary,10
+Linnton,207125,2007,Curfew,1
+Linnton,207125,2007,Disorderly Conduct,2
+Linnton,207125,2007,Drugs,2
+Linnton,207125,2007,DUII,11
+Linnton,207125,2007,Embezzlement,
+Linnton,207125,2007,Forgery,1
+Linnton,207125,2007,Fraud,2
+Linnton,207125,2007,Gambling,
+Linnton,207125,2007,Homicide,
+Linnton,207125,2007,Kidnap,
+Linnton,207125,2007,Larceny,40
+Linnton,207125,2007,Liquor Laws,2
+Linnton,207125,2007,Motor Vehicle Theft,9
+Linnton,207125,2007,Offenses Against Family,
+Linnton,207125,2007,Prostitution,
+Linnton,207125,2007,Rape,1
+Linnton,207125,2007,Robbery,1
+Linnton,207125,2007,Runaway,
+Linnton,207125,2007,Sex Offenses,
+Linnton,207125,2007,Stolen Property,
+Linnton,207125,2007,Trespass,5
+Linnton,207125,2007,Vandalism,9
+Linnton,207125,2007,Weapons,
+Linnton,207125,2008,Aggravated Assault,2
+Linnton,207125,2008,Arson,1
+Linnton,207125,2008,"Assault, Simple",2
+Linnton,207125,2008,Burglary,10
+Linnton,207125,2008,Curfew,
+Linnton,207125,2008,Disorderly Conduct,1
+Linnton,207125,2008,Drugs,1
+Linnton,207125,2008,DUII,3
+Linnton,207125,2008,Embezzlement,
+Linnton,207125,2008,Forgery,1
+Linnton,207125,2008,Fraud,2
+Linnton,207125,2008,Gambling,
+Linnton,207125,2008,Homicide,
+Linnton,207125,2008,Kidnap,
+Linnton,207125,2008,Larceny,65
+Linnton,207125,2008,Liquor Laws,2
+Linnton,207125,2008,Motor Vehicle Theft,3
+Linnton,207125,2008,Offenses Against Family,
+Linnton,207125,2008,Prostitution,
+Linnton,207125,2008,Rape,
+Linnton,207125,2008,Robbery,
+Linnton,207125,2008,Runaway,
+Linnton,207125,2008,Sex Offenses,
+Linnton,207125,2008,Stolen Property,
+Linnton,207125,2008,Trespass,3
+Linnton,207125,2008,Vandalism,7
+Linnton,207125,2008,Weapons,
+Linnton,207125,2009,Aggravated Assault,
+Linnton,207125,2009,Arson,
+Linnton,207125,2009,"Assault, Simple",
+Linnton,207125,2009,Burglary,10
+Linnton,207125,2009,Curfew,
+Linnton,207125,2009,Disorderly Conduct,
+Linnton,207125,2009,Drugs,2
+Linnton,207125,2009,DUII,8
+Linnton,207125,2009,Embezzlement,
+Linnton,207125,2009,Forgery,
+Linnton,207125,2009,Fraud,2
+Linnton,207125,2009,Gambling,
+Linnton,207125,2009,Homicide,
+Linnton,207125,2009,Kidnap,
+Linnton,207125,2009,Larceny,44
+Linnton,207125,2009,Liquor Laws,
+Linnton,207125,2009,Motor Vehicle Theft,3
+Linnton,207125,2009,Offenses Against Family,
+Linnton,207125,2009,Prostitution,
+Linnton,207125,2009,Rape,
+Linnton,207125,2009,Robbery,1
+Linnton,207125,2009,Runaway,
+Linnton,207125,2009,Sex Offenses,
+Linnton,207125,2009,Stolen Property,
+Linnton,207125,2009,Trespass,
+Linnton,207125,2009,Vandalism,8
+Linnton,207125,2009,Weapons,
+Linnton,207125,2010,Aggravated Assault,1
+Linnton,207125,2010,Arson,
+Linnton,207125,2010,"Assault, Simple",
+Linnton,207125,2010,Burglary,11
+Linnton,207125,2010,Curfew,
+Linnton,207125,2010,Disorderly Conduct,1
+Linnton,207125,2010,Drugs,1
+Linnton,207125,2010,DUII,7
+Linnton,207125,2010,Embezzlement,
+Linnton,207125,2010,Forgery,
+Linnton,207125,2010,Fraud,1
+Linnton,207125,2010,Gambling,
+Linnton,207125,2010,Homicide,
+Linnton,207125,2010,Kidnap,
+Linnton,207125,2010,Larceny,52
+Linnton,207125,2010,Liquor Laws,
+Linnton,207125,2010,Motor Vehicle Theft,3
+Linnton,207125,2010,Offenses Against Family,
+Linnton,207125,2010,Prostitution,
+Linnton,207125,2010,Rape,
+Linnton,207125,2010,Robbery,
+Linnton,207125,2010,Runaway,
+Linnton,207125,2010,Sex Offenses,
+Linnton,207125,2010,Stolen Property,
+Linnton,207125,2010,Trespass,3
+Linnton,207125,2010,Vandalism,8
+Linnton,207125,2010,Weapons,1
+Linnton,207125,2011,Aggravated Assault,2
+Linnton,207125,2011,Arson,1
+Linnton,207125,2011,"Assault, Simple",1
+Linnton,207125,2011,Burglary,6
+Linnton,207125,2011,Curfew,
+Linnton,207125,2011,Disorderly Conduct,2
+Linnton,207125,2011,Drugs,
+Linnton,207125,2011,DUII,7
+Linnton,207125,2011,Embezzlement,
+Linnton,207125,2011,Forgery,
+Linnton,207125,2011,Fraud,
+Linnton,207125,2011,Gambling,
+Linnton,207125,2011,Homicide,
+Linnton,207125,2011,Kidnap,
+Linnton,207125,2011,Larceny,43
+Linnton,207125,2011,Liquor Laws,
+Linnton,207125,2011,Motor Vehicle Theft,
+Linnton,207125,2011,Offenses Against Family,
+Linnton,207125,2011,Prostitution,
+Linnton,207125,2011,Rape,1
+Linnton,207125,2011,Robbery,
+Linnton,207125,2011,Runaway,
+Linnton,207125,2011,Sex Offenses,
+Linnton,207125,2011,Stolen Property,
+Linnton,207125,2011,Trespass,2
+Linnton,207125,2011,Vandalism,5
+Linnton,207125,2011,Weapons,
+Linnton,207125,2012,Aggravated Assault,
+Linnton,207125,2012,Arson,
+Linnton,207125,2012,"Assault, Simple",3
+Linnton,207125,2012,Burglary,8
+Linnton,207125,2012,Curfew,
+Linnton,207125,2012,Disorderly Conduct,1
+Linnton,207125,2012,Drugs,1
+Linnton,207125,2012,DUII,6
+Linnton,207125,2012,Embezzlement,
+Linnton,207125,2012,Forgery,
+Linnton,207125,2012,Fraud,2
+Linnton,207125,2012,Gambling,
+Linnton,207125,2012,Homicide,
+Linnton,207125,2012,Kidnap,
+Linnton,207125,2012,Larceny,50
+Linnton,207125,2012,Liquor Laws,
+Linnton,207125,2012,Motor Vehicle Theft,1
+Linnton,207125,2012,Offenses Against Family,
+Linnton,207125,2012,Prostitution,
+Linnton,207125,2012,Rape,
+Linnton,207125,2012,Robbery,
+Linnton,207125,2012,Runaway,
+Linnton,207125,2012,Sex Offenses,
+Linnton,207125,2012,Stolen Property,
+Linnton,207125,2012,Trespass,3
+Linnton,207125,2012,Vandalism,7
+Linnton,207125,2012,Weapons,
+Linnton,207125,2013,Aggravated Assault,1
+Linnton,207125,2013,Arson,
+Linnton,207125,2013,"Assault, Simple",
+Linnton,207125,2013,Burglary,6
+Linnton,207125,2013,Curfew,
+Linnton,207125,2013,Disorderly Conduct,1
+Linnton,207125,2013,Drugs,4
+Linnton,207125,2013,DUII,9
+Linnton,207125,2013,Embezzlement,
+Linnton,207125,2013,Forgery,1
+Linnton,207125,2013,Fraud,2
+Linnton,207125,2013,Gambling,
+Linnton,207125,2013,Homicide,
+Linnton,207125,2013,Kidnap,
+Linnton,207125,2013,Larceny,68
+Linnton,207125,2013,Liquor Laws,
+Linnton,207125,2013,Motor Vehicle Theft,3
+Linnton,207125,2013,Offenses Against Family,
+Linnton,207125,2013,Prostitution,
+Linnton,207125,2013,Rape,1
+Linnton,207125,2013,Robbery,
+Linnton,207125,2013,Runaway,
+Linnton,207125,2013,Sex Offenses,1
+Linnton,207125,2013,Stolen Property,
+Linnton,207125,2013,Trespass,
+Linnton,207125,2013,Vandalism,7
+Linnton,207125,2013,Weapons,
+Linnton,207125,2014,Aggravated Assault,1
+Linnton,207125,2014,Arson,
+Linnton,207125,2014,"Assault, Simple",
+Linnton,207125,2014,Burglary,7
+Linnton,207125,2014,Curfew,
+Linnton,207125,2014,Disorderly Conduct,1
+Linnton,207125,2014,Drugs,
+Linnton,207125,2014,DUII,3
+Linnton,207125,2014,Embezzlement,1
+Linnton,207125,2014,Forgery,
+Linnton,207125,2014,Fraud,3
+Linnton,207125,2014,Gambling,
+Linnton,207125,2014,Homicide,
+Linnton,207125,2014,Kidnap,
+Linnton,207125,2014,Larceny,58
+Linnton,207125,2014,Liquor Laws,
+Linnton,207125,2014,Motor Vehicle Theft,1
+Linnton,207125,2014,Offenses Against Family,
+Linnton,207125,2014,Prostitution,
+Linnton,207125,2014,Rape,1
+Linnton,207125,2014,Robbery,
+Linnton,207125,2014,Runaway,
+Linnton,207125,2014,Sex Offenses,
+Linnton,207125,2014,Stolen Property,
+Linnton,207125,2014,Trespass,
+Linnton,207125,2014,Vandalism,6
+Linnton,207125,2014,Weapons,
+Linwood,274327,2004,Aggravated Assault,
+Linwood,274327,2004,Arson,
+Linwood,274327,2004,"Assault, Simple",
+Linwood,274327,2004,Burglary,
+Linwood,274327,2004,Curfew,
+Linwood,274327,2004,Disorderly Conduct,
+Linwood,274327,2004,Drugs,
+Linwood,274327,2004,DUII,
+Linwood,274327,2004,Embezzlement,
+Linwood,274327,2004,Forgery,
+Linwood,274327,2004,Fraud,
+Linwood,274327,2004,Gambling,
+Linwood,274327,2004,Homicide,
+Linwood,274327,2004,Kidnap,
+Linwood,274327,2004,Larceny,
+Linwood,274327,2004,Liquor Laws,
+Linwood,274327,2004,Motor Vehicle Theft,
+Linwood,274327,2004,Offenses Against Family,
+Linwood,274327,2004,Prostitution,
+Linwood,274327,2004,Rape,
+Linwood,274327,2004,Robbery,
+Linwood,274327,2004,Runaway,
+Linwood,274327,2004,Sex Offenses,
+Linwood,274327,2004,Stolen Property,
+Linwood,274327,2004,Trespass,
+Linwood,274327,2004,Vandalism,
+Linwood,274327,2004,Weapons,
+Linwood,274327,2005,Aggravated Assault,
+Linwood,274327,2005,Arson,
+Linwood,274327,2005,"Assault, Simple",
+Linwood,274327,2005,Burglary,
+Linwood,274327,2005,Curfew,
+Linwood,274327,2005,Disorderly Conduct,
+Linwood,274327,2005,Drugs,
+Linwood,274327,2005,DUII,
+Linwood,274327,2005,Embezzlement,
+Linwood,274327,2005,Forgery,
+Linwood,274327,2005,Fraud,
+Linwood,274327,2005,Gambling,
+Linwood,274327,2005,Homicide,
+Linwood,274327,2005,Kidnap,
+Linwood,274327,2005,Larceny,
+Linwood,274327,2005,Liquor Laws,
+Linwood,274327,2005,Motor Vehicle Theft,
+Linwood,274327,2005,Offenses Against Family,
+Linwood,274327,2005,Prostitution,
+Linwood,274327,2005,Rape,
+Linwood,274327,2005,Robbery,
+Linwood,274327,2005,Runaway,
+Linwood,274327,2005,Sex Offenses,
+Linwood,274327,2005,Stolen Property,
+Linwood,274327,2005,Trespass,
+Linwood,274327,2005,Vandalism,
+Linwood,274327,2005,Weapons,
+Linwood,274327,2006,Aggravated Assault,
+Linwood,274327,2006,Arson,
+Linwood,274327,2006,"Assault, Simple",
+Linwood,274327,2006,Burglary,
+Linwood,274327,2006,Curfew,
+Linwood,274327,2006,Disorderly Conduct,
+Linwood,274327,2006,Drugs,
+Linwood,274327,2006,DUII,
+Linwood,274327,2006,Embezzlement,
+Linwood,274327,2006,Forgery,
+Linwood,274327,2006,Fraud,
+Linwood,274327,2006,Gambling,
+Linwood,274327,2006,Homicide,
+Linwood,274327,2006,Kidnap,
+Linwood,274327,2006,Larceny,
+Linwood,274327,2006,Liquor Laws,
+Linwood,274327,2006,Motor Vehicle Theft,
+Linwood,274327,2006,Offenses Against Family,
+Linwood,274327,2006,Prostitution,
+Linwood,274327,2006,Rape,
+Linwood,274327,2006,Robbery,
+Linwood,274327,2006,Runaway,
+Linwood,274327,2006,Sex Offenses,
+Linwood,274327,2006,Stolen Property,
+Linwood,274327,2006,Trespass,
+Linwood,274327,2006,Vandalism,
+Linwood,274327,2006,Weapons,
+Linwood,274327,2007,Aggravated Assault,
+Linwood,274327,2007,Arson,
+Linwood,274327,2007,"Assault, Simple",
+Linwood,274327,2007,Burglary,
+Linwood,274327,2007,Curfew,
+Linwood,274327,2007,Disorderly Conduct,
+Linwood,274327,2007,Drugs,
+Linwood,274327,2007,DUII,
+Linwood,274327,2007,Embezzlement,
+Linwood,274327,2007,Forgery,
+Linwood,274327,2007,Fraud,
+Linwood,274327,2007,Gambling,
+Linwood,274327,2007,Homicide,
+Linwood,274327,2007,Kidnap,
+Linwood,274327,2007,Larceny,
+Linwood,274327,2007,Liquor Laws,
+Linwood,274327,2007,Motor Vehicle Theft,
+Linwood,274327,2007,Offenses Against Family,
+Linwood,274327,2007,Prostitution,
+Linwood,274327,2007,Rape,
+Linwood,274327,2007,Robbery,
+Linwood,274327,2007,Runaway,
+Linwood,274327,2007,Sex Offenses,
+Linwood,274327,2007,Stolen Property,
+Linwood,274327,2007,Trespass,
+Linwood,274327,2007,Vandalism,
+Linwood,274327,2007,Weapons,
+Linwood,274327,2008,Aggravated Assault,
+Linwood,274327,2008,Arson,
+Linwood,274327,2008,"Assault, Simple",
+Linwood,274327,2008,Burglary,
+Linwood,274327,2008,Curfew,
+Linwood,274327,2008,Disorderly Conduct,
+Linwood,274327,2008,Drugs,
+Linwood,274327,2008,DUII,
+Linwood,274327,2008,Embezzlement,
+Linwood,274327,2008,Forgery,
+Linwood,274327,2008,Fraud,
+Linwood,274327,2008,Gambling,
+Linwood,274327,2008,Homicide,
+Linwood,274327,2008,Kidnap,
+Linwood,274327,2008,Larceny,
+Linwood,274327,2008,Liquor Laws,
+Linwood,274327,2008,Motor Vehicle Theft,
+Linwood,274327,2008,Offenses Against Family,
+Linwood,274327,2008,Prostitution,
+Linwood,274327,2008,Rape,
+Linwood,274327,2008,Robbery,
+Linwood,274327,2008,Runaway,
+Linwood,274327,2008,Sex Offenses,
+Linwood,274327,2008,Stolen Property,
+Linwood,274327,2008,Trespass,
+Linwood,274327,2008,Vandalism,
+Linwood,274327,2008,Weapons,
+Linwood,274327,2009,Aggravated Assault,
+Linwood,274327,2009,Arson,
+Linwood,274327,2009,"Assault, Simple",
+Linwood,274327,2009,Burglary,
+Linwood,274327,2009,Curfew,
+Linwood,274327,2009,Disorderly Conduct,
+Linwood,274327,2009,Drugs,
+Linwood,274327,2009,DUII,
+Linwood,274327,2009,Embezzlement,
+Linwood,274327,2009,Forgery,
+Linwood,274327,2009,Fraud,
+Linwood,274327,2009,Gambling,
+Linwood,274327,2009,Homicide,
+Linwood,274327,2009,Kidnap,
+Linwood,274327,2009,Larceny,
+Linwood,274327,2009,Liquor Laws,
+Linwood,274327,2009,Motor Vehicle Theft,
+Linwood,274327,2009,Offenses Against Family,
+Linwood,274327,2009,Prostitution,
+Linwood,274327,2009,Rape,
+Linwood,274327,2009,Robbery,
+Linwood,274327,2009,Runaway,
+Linwood,274327,2009,Sex Offenses,
+Linwood,274327,2009,Stolen Property,
+Linwood,274327,2009,Trespass,
+Linwood,274327,2009,Vandalism,
+Linwood,274327,2009,Weapons,
+Linwood,274327,2010,Aggravated Assault,
+Linwood,274327,2010,Arson,
+Linwood,274327,2010,"Assault, Simple",
+Linwood,274327,2010,Burglary,
+Linwood,274327,2010,Curfew,
+Linwood,274327,2010,Disorderly Conduct,
+Linwood,274327,2010,Drugs,
+Linwood,274327,2010,DUII,
+Linwood,274327,2010,Embezzlement,
+Linwood,274327,2010,Forgery,
+Linwood,274327,2010,Fraud,
+Linwood,274327,2010,Gambling,
+Linwood,274327,2010,Homicide,
+Linwood,274327,2010,Kidnap,
+Linwood,274327,2010,Larceny,
+Linwood,274327,2010,Liquor Laws,
+Linwood,274327,2010,Motor Vehicle Theft,
+Linwood,274327,2010,Offenses Against Family,
+Linwood,274327,2010,Prostitution,
+Linwood,274327,2010,Rape,
+Linwood,274327,2010,Robbery,
+Linwood,274327,2010,Runaway,
+Linwood,274327,2010,Sex Offenses,
+Linwood,274327,2010,Stolen Property,
+Linwood,274327,2010,Trespass,
+Linwood,274327,2010,Vandalism,
+Linwood,274327,2010,Weapons,
+Linwood,274327,2011,Aggravated Assault,
+Linwood,274327,2011,Arson,
+Linwood,274327,2011,"Assault, Simple",
+Linwood,274327,2011,Burglary,
+Linwood,274327,2011,Curfew,
+Linwood,274327,2011,Disorderly Conduct,
+Linwood,274327,2011,Drugs,
+Linwood,274327,2011,DUII,
+Linwood,274327,2011,Embezzlement,
+Linwood,274327,2011,Forgery,
+Linwood,274327,2011,Fraud,
+Linwood,274327,2011,Gambling,
+Linwood,274327,2011,Homicide,
+Linwood,274327,2011,Kidnap,
+Linwood,274327,2011,Larceny,
+Linwood,274327,2011,Liquor Laws,
+Linwood,274327,2011,Motor Vehicle Theft,
+Linwood,274327,2011,Offenses Against Family,
+Linwood,274327,2011,Prostitution,
+Linwood,274327,2011,Rape,
+Linwood,274327,2011,Robbery,
+Linwood,274327,2011,Runaway,
+Linwood,274327,2011,Sex Offenses,
+Linwood,274327,2011,Stolen Property,
+Linwood,274327,2011,Trespass,
+Linwood,274327,2011,Vandalism,
+Linwood,274327,2011,Weapons,
+Linwood,274327,2012,Aggravated Assault,
+Linwood,274327,2012,Arson,
+Linwood,274327,2012,"Assault, Simple",
+Linwood,274327,2012,Burglary,
+Linwood,274327,2012,Curfew,
+Linwood,274327,2012,Disorderly Conduct,
+Linwood,274327,2012,Drugs,
+Linwood,274327,2012,DUII,
+Linwood,274327,2012,Embezzlement,
+Linwood,274327,2012,Forgery,
+Linwood,274327,2012,Fraud,
+Linwood,274327,2012,Gambling,
+Linwood,274327,2012,Homicide,
+Linwood,274327,2012,Kidnap,
+Linwood,274327,2012,Larceny,
+Linwood,274327,2012,Liquor Laws,
+Linwood,274327,2012,Motor Vehicle Theft,
+Linwood,274327,2012,Offenses Against Family,
+Linwood,274327,2012,Prostitution,
+Linwood,274327,2012,Rape,
+Linwood,274327,2012,Robbery,
+Linwood,274327,2012,Runaway,
+Linwood,274327,2012,Sex Offenses,
+Linwood,274327,2012,Stolen Property,
+Linwood,274327,2012,Trespass,
+Linwood,274327,2012,Vandalism,
+Linwood,274327,2012,Weapons,
+Linwood,274327,2013,Aggravated Assault,
+Linwood,274327,2013,Arson,
+Linwood,274327,2013,"Assault, Simple",1
+Linwood,274327,2013,Burglary,
+Linwood,274327,2013,Curfew,
+Linwood,274327,2013,Disorderly Conduct,
+Linwood,274327,2013,Drugs,
+Linwood,274327,2013,DUII,
+Linwood,274327,2013,Embezzlement,
+Linwood,274327,2013,Forgery,
+Linwood,274327,2013,Fraud,
+Linwood,274327,2013,Gambling,
+Linwood,274327,2013,Homicide,
+Linwood,274327,2013,Kidnap,
+Linwood,274327,2013,Larceny,
+Linwood,274327,2013,Liquor Laws,
+Linwood,274327,2013,Motor Vehicle Theft,
+Linwood,274327,2013,Offenses Against Family,
+Linwood,274327,2013,Prostitution,
+Linwood,274327,2013,Rape,
+Linwood,274327,2013,Robbery,
+Linwood,274327,2013,Runaway,
+Linwood,274327,2013,Sex Offenses,
+Linwood,274327,2013,Stolen Property,
+Linwood,274327,2013,Trespass,
+Linwood,274327,2013,Vandalism,
+Linwood,274327,2013,Weapons,
+Linwood,274327,2014,Aggravated Assault,
+Linwood,274327,2014,Arson,
+Linwood,274327,2014,"Assault, Simple",
+Linwood,274327,2014,Burglary,
+Linwood,274327,2014,Curfew,
+Linwood,274327,2014,Disorderly Conduct,
+Linwood,274327,2014,Drugs,
+Linwood,274327,2014,DUII,
+Linwood,274327,2014,Embezzlement,
+Linwood,274327,2014,Forgery,
+Linwood,274327,2014,Fraud,
+Linwood,274327,2014,Gambling,
+Linwood,274327,2014,Homicide,
+Linwood,274327,2014,Kidnap,
+Linwood,274327,2014,Larceny,
+Linwood,274327,2014,Liquor Laws,
+Linwood,274327,2014,Motor Vehicle Theft,
+Linwood,274327,2014,Offenses Against Family,
+Linwood,274327,2014,Prostitution,
+Linwood,274327,2014,Rape,
+Linwood,274327,2014,Robbery,
+Linwood,274327,2014,Runaway,
+Linwood,274327,2014,Sex Offenses,
+Linwood,274327,2014,Stolen Property,
+Linwood,274327,2014,Trespass,
+Linwood,274327,2014,Vandalism,
+Linwood,274327,2014,Weapons,1
+Lloyd,274337,2004,Aggravated Assault,4
+Lloyd,274337,2004,Arson,
+Lloyd,274337,2004,"Assault, Simple",13
+Lloyd,274337,2004,Burglary,5
+Lloyd,274337,2004,Curfew,1
+Lloyd,274337,2004,Disorderly Conduct,12
+Lloyd,274337,2004,Drugs,20
+Lloyd,274337,2004,DUII,4
+Lloyd,274337,2004,Embezzlement,1
+Lloyd,274337,2004,Forgery,13
+Lloyd,274337,2004,Fraud,4
+Lloyd,274337,2004,Gambling,
+Lloyd,274337,2004,Homicide,1
+Lloyd,274337,2004,Kidnap,
+Lloyd,274337,2004,Larceny,102
+Lloyd,274337,2004,Liquor Laws,6
+Lloyd,274337,2004,Motor Vehicle Theft,29
+Lloyd,274337,2004,Offenses Against Family,
+Lloyd,274337,2004,Prostitution,
+Lloyd,274337,2004,Rape,
+Lloyd,274337,2004,Robbery,6
+Lloyd,274337,2004,Runaway,
+Lloyd,274337,2004,Sex Offenses,1
+Lloyd,274337,2004,Stolen Property,
+Lloyd,274337,2004,Trespass,16
+Lloyd,274337,2004,Vandalism,9
+Lloyd,274337,2004,Weapons,
+Lloyd,274337,2005,Aggravated Assault,40
+Lloyd,274337,2005,Arson,1
+Lloyd,274337,2005,"Assault, Simple",67
+Lloyd,274337,2005,Burglary,25
+Lloyd,274337,2005,Curfew,4
+Lloyd,274337,2005,Disorderly Conduct,110
+Lloyd,274337,2005,Drugs,82
+Lloyd,274337,2005,DUII,28
+Lloyd,274337,2005,Embezzlement,16
+Lloyd,274337,2005,Forgery,45
+Lloyd,274337,2005,Fraud,61
+Lloyd,274337,2005,Gambling,1
+Lloyd,274337,2005,Homicide,
+Lloyd,274337,2005,Kidnap,2
+Lloyd,274337,2005,Larceny,929
+Lloyd,274337,2005,Liquor Laws,46
+Lloyd,274337,2005,Motor Vehicle Theft,158
+Lloyd,274337,2005,Offenses Against Family,
+Lloyd,274337,2005,Prostitution,3
+Lloyd,274337,2005,Rape,1
+Lloyd,274337,2005,Robbery,60
+Lloyd,274337,2005,Runaway,
+Lloyd,274337,2005,Sex Offenses,3
+Lloyd,274337,2005,Stolen Property,2
+Lloyd,274337,2005,Trespass,178
+Lloyd,274337,2005,Vandalism,54
+Lloyd,274337,2005,Weapons,12
+Lloyd,274337,2006,Aggravated Assault,28
+Lloyd,274337,2006,Arson,1
+Lloyd,274337,2006,"Assault, Simple",78
+Lloyd,274337,2006,Burglary,24
+Lloyd,274337,2006,Curfew,4
+Lloyd,274337,2006,Disorderly Conduct,115
+Lloyd,274337,2006,Drugs,81
+Lloyd,274337,2006,DUII,33
+Lloyd,274337,2006,Embezzlement,19
+Lloyd,274337,2006,Forgery,40
+Lloyd,274337,2006,Fraud,54
+Lloyd,274337,2006,Gambling,1
+Lloyd,274337,2006,Homicide,
+Lloyd,274337,2006,Kidnap,
+Lloyd,274337,2006,Larceny,951
+Lloyd,274337,2006,Liquor Laws,51
+Lloyd,274337,2006,Motor Vehicle Theft,133
+Lloyd,274337,2006,Offenses Against Family,
+Lloyd,274337,2006,Prostitution,
+Lloyd,274337,2006,Rape,2
+Lloyd,274337,2006,Robbery,51
+Lloyd,274337,2006,Runaway,
+Lloyd,274337,2006,Sex Offenses,2
+Lloyd,274337,2006,Stolen Property,2
+Lloyd,274337,2006,Trespass,241
+Lloyd,274337,2006,Vandalism,73
+Lloyd,274337,2006,Weapons,7
+Lloyd,274337,2007,Aggravated Assault,27
+Lloyd,274337,2007,Arson,
+Lloyd,274337,2007,"Assault, Simple",61
+Lloyd,274337,2007,Burglary,24
+Lloyd,274337,2007,Curfew,2
+Lloyd,274337,2007,Disorderly Conduct,110
+Lloyd,274337,2007,Drugs,52
+Lloyd,274337,2007,DUII,32
+Lloyd,274337,2007,Embezzlement,26
+Lloyd,274337,2007,Forgery,42
+Lloyd,274337,2007,Fraud,59
+Lloyd,274337,2007,Gambling,1
+Lloyd,274337,2007,Homicide,
+Lloyd,274337,2007,Kidnap,
+Lloyd,274337,2007,Larceny,1023
+Lloyd,274337,2007,Liquor Laws,104
+Lloyd,274337,2007,Motor Vehicle Theft,157
+Lloyd,274337,2007,Offenses Against Family,1
+Lloyd,274337,2007,Prostitution,1
+Lloyd,274337,2007,Rape,2
+Lloyd,274337,2007,Robbery,46
+Lloyd,274337,2007,Runaway,
+Lloyd,274337,2007,Sex Offenses,
+Lloyd,274337,2007,Stolen Property,2
+Lloyd,274337,2007,Trespass,206
+Lloyd,274337,2007,Vandalism,83
+Lloyd,274337,2007,Weapons,8
+Lloyd,274337,2008,Aggravated Assault,27
+Lloyd,274337,2008,Arson,
+Lloyd,274337,2008,"Assault, Simple",59
+Lloyd,274337,2008,Burglary,26
+Lloyd,274337,2008,Curfew,
+Lloyd,274337,2008,Disorderly Conduct,117
+Lloyd,274337,2008,Drugs,34
+Lloyd,274337,2008,DUII,38
+Lloyd,274337,2008,Embezzlement,17
+Lloyd,274337,2008,Forgery,37
+Lloyd,274337,2008,Fraud,62
+Lloyd,274337,2008,Gambling,1
+Lloyd,274337,2008,Homicide,
+Lloyd,274337,2008,Kidnap,
+Lloyd,274337,2008,Larceny,885
+Lloyd,274337,2008,Liquor Laws,101
+Lloyd,274337,2008,Motor Vehicle Theft,100
+Lloyd,274337,2008,Offenses Against Family,
+Lloyd,274337,2008,Prostitution,1
+Lloyd,274337,2008,Rape,1
+Lloyd,274337,2008,Robbery,44
+Lloyd,274337,2008,Runaway,1
+Lloyd,274337,2008,Sex Offenses,13
+Lloyd,274337,2008,Stolen Property,
+Lloyd,274337,2008,Trespass,180
+Lloyd,274337,2008,Vandalism,70
+Lloyd,274337,2008,Weapons,11
+Lloyd,274337,2009,Aggravated Assault,40
+Lloyd,274337,2009,Arson,3
+Lloyd,274337,2009,"Assault, Simple",56
+Lloyd,274337,2009,Burglary,24
+Lloyd,274337,2009,Curfew,5
+Lloyd,274337,2009,Disorderly Conduct,155
+Lloyd,274337,2009,Drugs,58
+Lloyd,274337,2009,DUII,30
+Lloyd,274337,2009,Embezzlement,9
+Lloyd,274337,2009,Forgery,21
+Lloyd,274337,2009,Fraud,53
+Lloyd,274337,2009,Gambling,
+Lloyd,274337,2009,Homicide,2
+Lloyd,274337,2009,Kidnap,
+Lloyd,274337,2009,Larceny,942
+Lloyd,274337,2009,Liquor Laws,118
+Lloyd,274337,2009,Motor Vehicle Theft,57
+Lloyd,274337,2009,Offenses Against Family,
+Lloyd,274337,2009,Prostitution,1
+Lloyd,274337,2009,Rape,4
+Lloyd,274337,2009,Robbery,39
+Lloyd,274337,2009,Runaway,1
+Lloyd,274337,2009,Sex Offenses,6
+Lloyd,274337,2009,Stolen Property,1
+Lloyd,274337,2009,Trespass,156
+Lloyd,274337,2009,Vandalism,55
+Lloyd,274337,2009,Weapons,11
+Lloyd,274337,2010,Aggravated Assault,32
+Lloyd,274337,2010,Arson,3
+Lloyd,274337,2010,"Assault, Simple",66
+Lloyd,274337,2010,Burglary,14
+Lloyd,274337,2010,Curfew,2
+Lloyd,274337,2010,Disorderly Conduct,125
+Lloyd,274337,2010,Drugs,51
+Lloyd,274337,2010,DUII,31
+Lloyd,274337,2010,Embezzlement,8
+Lloyd,274337,2010,Forgery,17
+Lloyd,274337,2010,Fraud,46
+Lloyd,274337,2010,Gambling,
+Lloyd,274337,2010,Homicide,1
+Lloyd,274337,2010,Kidnap,
+Lloyd,274337,2010,Larceny,851
+Lloyd,274337,2010,Liquor Laws,148
+Lloyd,274337,2010,Motor Vehicle Theft,57
+Lloyd,274337,2010,Offenses Against Family,
+Lloyd,274337,2010,Prostitution,
+Lloyd,274337,2010,Rape,
+Lloyd,274337,2010,Robbery,33
+Lloyd,274337,2010,Runaway,
+Lloyd,274337,2010,Sex Offenses,1
+Lloyd,274337,2010,Stolen Property,4
+Lloyd,274337,2010,Trespass,109
+Lloyd,274337,2010,Vandalism,58
+Lloyd,274337,2010,Weapons,12
+Lloyd,274337,2011,Aggravated Assault,44
+Lloyd,274337,2011,Arson,1
+Lloyd,274337,2011,"Assault, Simple",79
+Lloyd,274337,2011,Burglary,10
+Lloyd,274337,2011,Curfew,
+Lloyd,274337,2011,Disorderly Conduct,117
+Lloyd,274337,2011,Drugs,57
+Lloyd,274337,2011,DUII,39
+Lloyd,274337,2011,Embezzlement,8
+Lloyd,274337,2011,Forgery,22
+Lloyd,274337,2011,Fraud,43
+Lloyd,274337,2011,Gambling,1
+Lloyd,274337,2011,Homicide,1
+Lloyd,274337,2011,Kidnap,
+Lloyd,274337,2011,Larceny,695
+Lloyd,274337,2011,Liquor Laws,115
+Lloyd,274337,2011,Motor Vehicle Theft,41
+Lloyd,274337,2011,Offenses Against Family,
+Lloyd,274337,2011,Prostitution,
+Lloyd,274337,2011,Rape,2
+Lloyd,274337,2011,Robbery,31
+Lloyd,274337,2011,Runaway,
+Lloyd,274337,2011,Sex Offenses,
+Lloyd,274337,2011,Stolen Property,2
+Lloyd,274337,2011,Trespass,111
+Lloyd,274337,2011,Vandalism,55
+Lloyd,274337,2011,Weapons,8
+Lloyd,274337,2012,Aggravated Assault,31
+Lloyd,274337,2012,Arson,
+Lloyd,274337,2012,"Assault, Simple",67
+Lloyd,274337,2012,Burglary,13
+Lloyd,274337,2012,Curfew,
+Lloyd,274337,2012,Disorderly Conduct,139
+Lloyd,274337,2012,Drugs,82
+Lloyd,274337,2012,DUII,66
+Lloyd,274337,2012,Embezzlement,10
+Lloyd,274337,2012,Forgery,34
+Lloyd,274337,2012,Fraud,66
+Lloyd,274337,2012,Gambling,
+Lloyd,274337,2012,Homicide,
+Lloyd,274337,2012,Kidnap,1
+Lloyd,274337,2012,Larceny,879
+Lloyd,274337,2012,Liquor Laws,109
+Lloyd,274337,2012,Motor Vehicle Theft,69
+Lloyd,274337,2012,Offenses Against Family,
+Lloyd,274337,2012,Prostitution,3
+Lloyd,274337,2012,Rape,1
+Lloyd,274337,2012,Robbery,46
+Lloyd,274337,2012,Runaway,1
+Lloyd,274337,2012,Sex Offenses,2
+Lloyd,274337,2012,Stolen Property,3
+Lloyd,274337,2012,Trespass,122
+Lloyd,274337,2012,Vandalism,50
+Lloyd,274337,2012,Weapons,13
+Lloyd,274337,2013,Aggravated Assault,35
+Lloyd,274337,2013,Arson,
+Lloyd,274337,2013,"Assault, Simple",61
+Lloyd,274337,2013,Burglary,25
+Lloyd,274337,2013,Curfew,
+Lloyd,274337,2013,Disorderly Conduct,111
+Lloyd,274337,2013,Drugs,105
+Lloyd,274337,2013,DUII,34
+Lloyd,274337,2013,Embezzlement,7
+Lloyd,274337,2013,Forgery,31
+Lloyd,274337,2013,Fraud,55
+Lloyd,274337,2013,Gambling,
+Lloyd,274337,2013,Homicide,1
+Lloyd,274337,2013,Kidnap,
+Lloyd,274337,2013,Larceny,786
+Lloyd,274337,2013,Liquor Laws,147
+Lloyd,274337,2013,Motor Vehicle Theft,61
+Lloyd,274337,2013,Offenses Against Family,
+Lloyd,274337,2013,Prostitution,4
+Lloyd,274337,2013,Rape,2
+Lloyd,274337,2013,Robbery,56
+Lloyd,274337,2013,Runaway,
+Lloyd,274337,2013,Sex Offenses,
+Lloyd,274337,2013,Stolen Property,4
+Lloyd,274337,2013,Trespass,153
+Lloyd,274337,2013,Vandalism,40
+Lloyd,274337,2013,Weapons,10
+Lloyd,274337,2014,Aggravated Assault,26
+Lloyd,274337,2014,Arson,1
+Lloyd,274337,2014,"Assault, Simple",62
+Lloyd,274337,2014,Burglary,21
+Lloyd,274337,2014,Curfew,1
+Lloyd,274337,2014,Disorderly Conduct,105
+Lloyd,274337,2014,Drugs,74
+Lloyd,274337,2014,DUII,25
+Lloyd,274337,2014,Embezzlement,5
+Lloyd,274337,2014,Forgery,13
+Lloyd,274337,2014,Fraud,73
+Lloyd,274337,2014,Gambling,
+Lloyd,274337,2014,Homicide,1
+Lloyd,274337,2014,Kidnap,1
+Lloyd,274337,2014,Larceny,684
+Lloyd,274337,2014,Liquor Laws,122
+Lloyd,274337,2014,Motor Vehicle Theft,70
+Lloyd,274337,2014,Offenses Against Family,1
+Lloyd,274337,2014,Prostitution,2
+Lloyd,274337,2014,Rape,2
+Lloyd,274337,2014,Robbery,34
+Lloyd,274337,2014,Runaway,
+Lloyd,274337,2014,Sex Offenses,2
+Lloyd,274337,2014,Stolen Property,2
+Lloyd,274337,2014,Trespass,153
+Lloyd,274337,2014,Vandalism,53
+Lloyd,274337,2014,Weapons,9
+Madison South,271108,2004,Aggravated Assault,3
+Madison South,271108,2004,Arson,
+Madison South,271108,2004,"Assault, Simple",6
+Madison South,271108,2004,Burglary,26
+Madison South,271108,2004,Curfew,
+Madison South,271108,2004,Disorderly Conduct,2
+Madison South,271108,2004,Drugs,8
+Madison South,271108,2004,DUII,2
+Madison South,271108,2004,Embezzlement,
+Madison South,271108,2004,Forgery,
+Madison South,271108,2004,Fraud,7
+Madison South,271108,2004,Gambling,
+Madison South,271108,2004,Homicide,
+Madison South,271108,2004,Kidnap,
+Madison South,271108,2004,Larceny,46
+Madison South,271108,2004,Liquor Laws,2
+Madison South,271108,2004,Motor Vehicle Theft,25
+Madison South,271108,2004,Offenses Against Family,
+Madison South,271108,2004,Prostitution,1
+Madison South,271108,2004,Rape,1
+Madison South,271108,2004,Robbery,3
+Madison South,271108,2004,Runaway,1
+Madison South,271108,2004,Sex Offenses,
+Madison South,271108,2004,Stolen Property,
+Madison South,271108,2004,Trespass,8
+Madison South,271108,2004,Vandalism,15
+Madison South,271108,2004,Weapons,1
+Madison South,271108,2005,Aggravated Assault,20
+Madison South,271108,2005,Arson,
+Madison South,271108,2005,"Assault, Simple",33
+Madison South,271108,2005,Burglary,64
+Madison South,271108,2005,Curfew,2
+Madison South,271108,2005,Disorderly Conduct,56
+Madison South,271108,2005,Drugs,42
+Madison South,271108,2005,DUII,13
+Madison South,271108,2005,Embezzlement,
+Madison South,271108,2005,Forgery,13
+Madison South,271108,2005,Fraud,101
+Madison South,271108,2005,Gambling,
+Madison South,271108,2005,Homicide,
+Madison South,271108,2005,Kidnap,
+Madison South,271108,2005,Larceny,202
+Madison South,271108,2005,Liquor Laws,21
+Madison South,271108,2005,Motor Vehicle Theft,81
+Madison South,271108,2005,Offenses Against Family,1
+Madison South,271108,2005,Prostitution,31
+Madison South,271108,2005,Rape,1
+Madison South,271108,2005,Robbery,28
+Madison South,271108,2005,Runaway,1
+Madison South,271108,2005,Sex Offenses,
+Madison South,271108,2005,Stolen Property,1
+Madison South,271108,2005,Trespass,47
+Madison South,271108,2005,Vandalism,57
+Madison South,271108,2005,Weapons,8
+Madison South,271108,2006,Aggravated Assault,22
+Madison South,271108,2006,Arson,
+Madison South,271108,2006,"Assault, Simple",41
+Madison South,271108,2006,Burglary,47
+Madison South,271108,2006,Curfew,1
+Madison South,271108,2006,Disorderly Conduct,72
+Madison South,271108,2006,Drugs,55
+Madison South,271108,2006,DUII,18
+Madison South,271108,2006,Embezzlement,1
+Madison South,271108,2006,Forgery,5
+Madison South,271108,2006,Fraud,39
+Madison South,271108,2006,Gambling,2
+Madison South,271108,2006,Homicide,
+Madison South,271108,2006,Kidnap,2
+Madison South,271108,2006,Larceny,101
+Madison South,271108,2006,Liquor Laws,13
+Madison South,271108,2006,Motor Vehicle Theft,39
+Madison South,271108,2006,Offenses Against Family,
+Madison South,271108,2006,Prostitution,39
+Madison South,271108,2006,Rape,
+Madison South,271108,2006,Robbery,25
+Madison South,271108,2006,Runaway,
+Madison South,271108,2006,Sex Offenses,
+Madison South,271108,2006,Stolen Property,
+Madison South,271108,2006,Trespass,43
+Madison South,271108,2006,Vandalism,54
+Madison South,271108,2006,Weapons,9
+Madison South,271108,2007,Aggravated Assault,14
+Madison South,271108,2007,Arson,1
+Madison South,271108,2007,"Assault, Simple",46
+Madison South,271108,2007,Burglary,46
+Madison South,271108,2007,Curfew,1
+Madison South,271108,2007,Disorderly Conduct,71
+Madison South,271108,2007,Drugs,31
+Madison South,271108,2007,DUII,21
+Madison South,271108,2007,Embezzlement,1
+Madison South,271108,2007,Forgery,21
+Madison South,271108,2007,Fraud,44
+Madison South,271108,2007,Gambling,
+Madison South,271108,2007,Homicide,1
+Madison South,271108,2007,Kidnap,
+Madison South,271108,2007,Larceny,147
+Madison South,271108,2007,Liquor Laws,23
+Madison South,271108,2007,Motor Vehicle Theft,37
+Madison South,271108,2007,Offenses Against Family,
+Madison South,271108,2007,Prostitution,11
+Madison South,271108,2007,Rape,
+Madison South,271108,2007,Robbery,14
+Madison South,271108,2007,Runaway,
+Madison South,271108,2007,Sex Offenses,1
+Madison South,271108,2007,Stolen Property,1
+Madison South,271108,2007,Trespass,37
+Madison South,271108,2007,Vandalism,75
+Madison South,271108,2007,Weapons,9
+Madison South,271108,2008,Aggravated Assault,10
+Madison South,271108,2008,Arson,
+Madison South,271108,2008,"Assault, Simple",26
+Madison South,271108,2008,Burglary,37
+Madison South,271108,2008,Curfew,3
+Madison South,271108,2008,Disorderly Conduct,59
+Madison South,271108,2008,Drugs,18
+Madison South,271108,2008,DUII,17
+Madison South,271108,2008,Embezzlement,
+Madison South,271108,2008,Forgery,12
+Madison South,271108,2008,Fraud,25
+Madison South,271108,2008,Gambling,
+Madison South,271108,2008,Homicide,
+Madison South,271108,2008,Kidnap,1
+Madison South,271108,2008,Larceny,135
+Madison South,271108,2008,Liquor Laws,16
+Madison South,271108,2008,Motor Vehicle Theft,22
+Madison South,271108,2008,Offenses Against Family,
+Madison South,271108,2008,Prostitution,27
+Madison South,271108,2008,Rape,
+Madison South,271108,2008,Robbery,11
+Madison South,271108,2008,Runaway,
+Madison South,271108,2008,Sex Offenses,2
+Madison South,271108,2008,Stolen Property,1
+Madison South,271108,2008,Trespass,32
+Madison South,271108,2008,Vandalism,37
+Madison South,271108,2008,Weapons,4
+Madison South,271108,2009,Aggravated Assault,12
+Madison South,271108,2009,Arson,1
+Madison South,271108,2009,"Assault, Simple",22
+Madison South,271108,2009,Burglary,28
+Madison South,271108,2009,Curfew,2
+Madison South,271108,2009,Disorderly Conduct,118
+Madison South,271108,2009,Drugs,31
+Madison South,271108,2009,DUII,16
+Madison South,271108,2009,Embezzlement,
+Madison South,271108,2009,Forgery,12
+Madison South,271108,2009,Fraud,32
+Madison South,271108,2009,Gambling,
+Madison South,271108,2009,Homicide,
+Madison South,271108,2009,Kidnap,
+Madison South,271108,2009,Larceny,118
+Madison South,271108,2009,Liquor Laws,11
+Madison South,271108,2009,Motor Vehicle Theft,53
+Madison South,271108,2009,Offenses Against Family,
+Madison South,271108,2009,Prostitution,14
+Madison South,271108,2009,Rape,1
+Madison South,271108,2009,Robbery,9
+Madison South,271108,2009,Runaway,
+Madison South,271108,2009,Sex Offenses,1
+Madison South,271108,2009,Stolen Property,1
+Madison South,271108,2009,Trespass,28
+Madison South,271108,2009,Vandalism,33
+Madison South,271108,2009,Weapons,4
+Madison South,271108,2010,Aggravated Assault,14
+Madison South,271108,2010,Arson,
+Madison South,271108,2010,"Assault, Simple",20
+Madison South,271108,2010,Burglary,54
+Madison South,271108,2010,Curfew,
+Madison South,271108,2010,Disorderly Conduct,49
+Madison South,271108,2010,Drugs,20
+Madison South,271108,2010,DUII,10
+Madison South,271108,2010,Embezzlement,1
+Madison South,271108,2010,Forgery,4
+Madison South,271108,2010,Fraud,13
+Madison South,271108,2010,Gambling,
+Madison South,271108,2010,Homicide,
+Madison South,271108,2010,Kidnap,
+Madison South,271108,2010,Larceny,95
+Madison South,271108,2010,Liquor Laws,5
+Madison South,271108,2010,Motor Vehicle Theft,29
+Madison South,271108,2010,Offenses Against Family,
+Madison South,271108,2010,Prostitution,10
+Madison South,271108,2010,Rape,
+Madison South,271108,2010,Robbery,10
+Madison South,271108,2010,Runaway,1
+Madison South,271108,2010,Sex Offenses,
+Madison South,271108,2010,Stolen Property,3
+Madison South,271108,2010,Trespass,19
+Madison South,271108,2010,Vandalism,42
+Madison South,271108,2010,Weapons,3
+Madison South,271108,2011,Aggravated Assault,12
+Madison South,271108,2011,Arson,
+Madison South,271108,2011,"Assault, Simple",25
+Madison South,271108,2011,Burglary,46
+Madison South,271108,2011,Curfew,2
+Madison South,271108,2011,Disorderly Conduct,29
+Madison South,271108,2011,Drugs,21
+Madison South,271108,2011,DUII,14
+Madison South,271108,2011,Embezzlement,
+Madison South,271108,2011,Forgery,15
+Madison South,271108,2011,Fraud,31
+Madison South,271108,2011,Gambling,
+Madison South,271108,2011,Homicide,2
+Madison South,271108,2011,Kidnap,
+Madison South,271108,2011,Larceny,146
+Madison South,271108,2011,Liquor Laws,4
+Madison South,271108,2011,Motor Vehicle Theft,34
+Madison South,271108,2011,Offenses Against Family,
+Madison South,271108,2011,Prostitution,17
+Madison South,271108,2011,Rape,1
+Madison South,271108,2011,Robbery,5
+Madison South,271108,2011,Runaway,
+Madison South,271108,2011,Sex Offenses,
+Madison South,271108,2011,Stolen Property,
+Madison South,271108,2011,Trespass,33
+Madison South,271108,2011,Vandalism,41
+Madison South,271108,2011,Weapons,4
+Madison South,271108,2012,Aggravated Assault,14
+Madison South,271108,2012,Arson,
+Madison South,271108,2012,"Assault, Simple",27
+Madison South,271108,2012,Burglary,38
+Madison South,271108,2012,Curfew,3
+Madison South,271108,2012,Disorderly Conduct,49
+Madison South,271108,2012,Drugs,28
+Madison South,271108,2012,DUII,15
+Madison South,271108,2012,Embezzlement,2
+Madison South,271108,2012,Forgery,4
+Madison South,271108,2012,Fraud,22
+Madison South,271108,2012,Gambling,
+Madison South,271108,2012,Homicide,
+Madison South,271108,2012,Kidnap,2
+Madison South,271108,2012,Larceny,105
+Madison South,271108,2012,Liquor Laws,5
+Madison South,271108,2012,Motor Vehicle Theft,28
+Madison South,271108,2012,Offenses Against Family,
+Madison South,271108,2012,Prostitution,31
+Madison South,271108,2012,Rape,2
+Madison South,271108,2012,Robbery,9
+Madison South,271108,2012,Runaway,
+Madison South,271108,2012,Sex Offenses,2
+Madison South,271108,2012,Stolen Property,3
+Madison South,271108,2012,Trespass,60
+Madison South,271108,2012,Vandalism,40
+Madison South,271108,2012,Weapons,2
+Madison South,271108,2013,Aggravated Assault,16
+Madison South,271108,2013,Arson,1
+Madison South,271108,2013,"Assault, Simple",19
+Madison South,271108,2013,Burglary,58
+Madison South,271108,2013,Curfew,
+Madison South,271108,2013,Disorderly Conduct,37
+Madison South,271108,2013,Drugs,34
+Madison South,271108,2013,DUII,15
+Madison South,271108,2013,Embezzlement,1
+Madison South,271108,2013,Forgery,6
+Madison South,271108,2013,Fraud,24
+Madison South,271108,2013,Gambling,
+Madison South,271108,2013,Homicide,
+Madison South,271108,2013,Kidnap,
+Madison South,271108,2013,Larceny,92
+Madison South,271108,2013,Liquor Laws,5
+Madison South,271108,2013,Motor Vehicle Theft,19
+Madison South,271108,2013,Offenses Against Family,
+Madison South,271108,2013,Prostitution,13
+Madison South,271108,2013,Rape,2
+Madison South,271108,2013,Robbery,6
+Madison South,271108,2013,Runaway,1
+Madison South,271108,2013,Sex Offenses,
+Madison South,271108,2013,Stolen Property,
+Madison South,271108,2013,Trespass,33
+Madison South,271108,2013,Vandalism,33
+Madison South,271108,2013,Weapons,3
+Madison South,271108,2014,Aggravated Assault,9
+Madison South,271108,2014,Arson,
+Madison South,271108,2014,"Assault, Simple",25
+Madison South,271108,2014,Burglary,39
+Madison South,271108,2014,Curfew,2
+Madison South,271108,2014,Disorderly Conduct,29
+Madison South,271108,2014,Drugs,27
+Madison South,271108,2014,DUII,13
+Madison South,271108,2014,Embezzlement,
+Madison South,271108,2014,Forgery,1
+Madison South,271108,2014,Fraud,21
+Madison South,271108,2014,Gambling,
+Madison South,271108,2014,Homicide,
+Madison South,271108,2014,Kidnap,
+Madison South,271108,2014,Larceny,97
+Madison South,271108,2014,Liquor Laws,10
+Madison South,271108,2014,Motor Vehicle Theft,36
+Madison South,271108,2014,Offenses Against Family,
+Madison South,271108,2014,Prostitution,4
+Madison South,271108,2014,Rape,
+Madison South,271108,2014,Robbery,6
+Madison South,271108,2014,Runaway,
+Madison South,271108,2014,Sex Offenses,1
+Madison South,271108,2014,Stolen Property,1
+Madison South,271108,2014,Trespass,29
+Madison South,271108,2014,Vandalism,36
+Madison South,271108,2014,Weapons,4
+Maplewood-Ashcreek,274417,2004,Aggravated Assault,
+Maplewood-Ashcreek,274417,2004,Arson,1
+Maplewood-Ashcreek,274417,2004,"Assault, Simple",
+Maplewood-Ashcreek,274417,2004,Burglary,12
+Maplewood-Ashcreek,274417,2004,Curfew,
+Maplewood-Ashcreek,274417,2004,Disorderly Conduct,6
+Maplewood-Ashcreek,274417,2004,Drugs,2
+Maplewood-Ashcreek,274417,2004,DUII,7
+Maplewood-Ashcreek,274417,2004,Embezzlement,2
+Maplewood-Ashcreek,274417,2004,Forgery,4
+Maplewood-Ashcreek,274417,2004,Fraud,12
+Maplewood-Ashcreek,274417,2004,Gambling,
+Maplewood-Ashcreek,274417,2004,Homicide,
+Maplewood-Ashcreek,274417,2004,Kidnap,
+Maplewood-Ashcreek,274417,2004,Larceny,35
+Maplewood-Ashcreek,274417,2004,Liquor Laws,3
+Maplewood-Ashcreek,274417,2004,Motor Vehicle Theft,2
+Maplewood-Ashcreek,274417,2004,Offenses Against Family,
+Maplewood-Ashcreek,274417,2004,Prostitution,
+Maplewood-Ashcreek,274417,2004,Rape,
+Maplewood-Ashcreek,274417,2004,Robbery,
+Maplewood-Ashcreek,274417,2004,Runaway,
+Maplewood-Ashcreek,274417,2004,Sex Offenses,
+Maplewood-Ashcreek,274417,2004,Stolen Property,
+Maplewood-Ashcreek,274417,2004,Trespass,6
+Maplewood-Ashcreek,274417,2004,Vandalism,20
+Maplewood-Ashcreek,274417,2004,Weapons,
+Maplewood-Ashcreek,274417,2005,Aggravated Assault,7
+Maplewood-Ashcreek,274417,2005,Arson,3
+Maplewood-Ashcreek,274417,2005,"Assault, Simple",11
+Maplewood-Ashcreek,274417,2005,Burglary,71
+Maplewood-Ashcreek,274417,2005,Curfew,1
+Maplewood-Ashcreek,274417,2005,Disorderly Conduct,23
+Maplewood-Ashcreek,274417,2005,Drugs,28
+Maplewood-Ashcreek,274417,2005,DUII,39
+Maplewood-Ashcreek,274417,2005,Embezzlement,6
+Maplewood-Ashcreek,274417,2005,Forgery,13
+Maplewood-Ashcreek,274417,2005,Fraud,49
+Maplewood-Ashcreek,274417,2005,Gambling,
+Maplewood-Ashcreek,274417,2005,Homicide,
+Maplewood-Ashcreek,274417,2005,Kidnap,2
+Maplewood-Ashcreek,274417,2005,Larceny,282
+Maplewood-Ashcreek,274417,2005,Liquor Laws,5
+Maplewood-Ashcreek,274417,2005,Motor Vehicle Theft,43
+Maplewood-Ashcreek,274417,2005,Offenses Against Family,
+Maplewood-Ashcreek,274417,2005,Prostitution,1
+Maplewood-Ashcreek,274417,2005,Rape,1
+Maplewood-Ashcreek,274417,2005,Robbery,4
+Maplewood-Ashcreek,274417,2005,Runaway,1
+Maplewood-Ashcreek,274417,2005,Sex Offenses,
+Maplewood-Ashcreek,274417,2005,Stolen Property,1
+Maplewood-Ashcreek,274417,2005,Trespass,20
+Maplewood-Ashcreek,274417,2005,Vandalism,95
+Maplewood-Ashcreek,274417,2005,Weapons,5
+Maplewood-Ashcreek,274417,2006,Aggravated Assault,12
+Maplewood-Ashcreek,274417,2006,Arson,3
+Maplewood-Ashcreek,274417,2006,"Assault, Simple",10
+Maplewood-Ashcreek,274417,2006,Burglary,56
+Maplewood-Ashcreek,274417,2006,Curfew,
+Maplewood-Ashcreek,274417,2006,Disorderly Conduct,23
+Maplewood-Ashcreek,274417,2006,Drugs,37
+Maplewood-Ashcreek,274417,2006,DUII,57
+Maplewood-Ashcreek,274417,2006,Embezzlement,1
+Maplewood-Ashcreek,274417,2006,Forgery,13
+Maplewood-Ashcreek,274417,2006,Fraud,37
+Maplewood-Ashcreek,274417,2006,Gambling,
+Maplewood-Ashcreek,274417,2006,Homicide,
+Maplewood-Ashcreek,274417,2006,Kidnap,
+Maplewood-Ashcreek,274417,2006,Larceny,199
+Maplewood-Ashcreek,274417,2006,Liquor Laws,12
+Maplewood-Ashcreek,274417,2006,Motor Vehicle Theft,26
+Maplewood-Ashcreek,274417,2006,Offenses Against Family,
+Maplewood-Ashcreek,274417,2006,Prostitution,
+Maplewood-Ashcreek,274417,2006,Rape,
+Maplewood-Ashcreek,274417,2006,Robbery,6
+Maplewood-Ashcreek,274417,2006,Runaway,
+Maplewood-Ashcreek,274417,2006,Sex Offenses,
+Maplewood-Ashcreek,274417,2006,Stolen Property,
+Maplewood-Ashcreek,274417,2006,Trespass,16
+Maplewood-Ashcreek,274417,2006,Vandalism,60
+Maplewood-Ashcreek,274417,2006,Weapons,5
+Maplewood-Ashcreek,274417,2007,Aggravated Assault,9
+Maplewood-Ashcreek,274417,2007,Arson,
+Maplewood-Ashcreek,274417,2007,"Assault, Simple",15
+Maplewood-Ashcreek,274417,2007,Burglary,64
+Maplewood-Ashcreek,274417,2007,Curfew,
+Maplewood-Ashcreek,274417,2007,Disorderly Conduct,31
+Maplewood-Ashcreek,274417,2007,Drugs,29
+Maplewood-Ashcreek,274417,2007,DUII,41
+Maplewood-Ashcreek,274417,2007,Embezzlement,2
+Maplewood-Ashcreek,274417,2007,Forgery,10
+Maplewood-Ashcreek,274417,2007,Fraud,34
+Maplewood-Ashcreek,274417,2007,Gambling,
+Maplewood-Ashcreek,274417,2007,Homicide,
+Maplewood-Ashcreek,274417,2007,Kidnap,
+Maplewood-Ashcreek,274417,2007,Larceny,178
+Maplewood-Ashcreek,274417,2007,Liquor Laws,4
+Maplewood-Ashcreek,274417,2007,Motor Vehicle Theft,19
+Maplewood-Ashcreek,274417,2007,Offenses Against Family,
+Maplewood-Ashcreek,274417,2007,Prostitution,1
+Maplewood-Ashcreek,274417,2007,Rape,1
+Maplewood-Ashcreek,274417,2007,Robbery,4
+Maplewood-Ashcreek,274417,2007,Runaway,
+Maplewood-Ashcreek,274417,2007,Sex Offenses,1
+Maplewood-Ashcreek,274417,2007,Stolen Property,
+Maplewood-Ashcreek,274417,2007,Trespass,12
+Maplewood-Ashcreek,274417,2007,Vandalism,72
+Maplewood-Ashcreek,274417,2007,Weapons,3
+Maplewood-Ashcreek,274417,2008,Aggravated Assault,9
+Maplewood-Ashcreek,274417,2008,Arson,1
+Maplewood-Ashcreek,274417,2008,"Assault, Simple",17
+Maplewood-Ashcreek,274417,2008,Burglary,41
+Maplewood-Ashcreek,274417,2008,Curfew,
+Maplewood-Ashcreek,274417,2008,Disorderly Conduct,18
+Maplewood-Ashcreek,274417,2008,Drugs,9
+Maplewood-Ashcreek,274417,2008,DUII,35
+Maplewood-Ashcreek,274417,2008,Embezzlement,1
+Maplewood-Ashcreek,274417,2008,Forgery,6
+Maplewood-Ashcreek,274417,2008,Fraud,17
+Maplewood-Ashcreek,274417,2008,Gambling,
+Maplewood-Ashcreek,274417,2008,Homicide,
+Maplewood-Ashcreek,274417,2008,Kidnap,1
+Maplewood-Ashcreek,274417,2008,Larceny,150
+Maplewood-Ashcreek,274417,2008,Liquor Laws,8
+Maplewood-Ashcreek,274417,2008,Motor Vehicle Theft,25
+Maplewood-Ashcreek,274417,2008,Offenses Against Family,
+Maplewood-Ashcreek,274417,2008,Prostitution,
+Maplewood-Ashcreek,274417,2008,Rape,
+Maplewood-Ashcreek,274417,2008,Robbery,5
+Maplewood-Ashcreek,274417,2008,Runaway,
+Maplewood-Ashcreek,274417,2008,Sex Offenses,
+Maplewood-Ashcreek,274417,2008,Stolen Property,1
+Maplewood-Ashcreek,274417,2008,Trespass,20
+Maplewood-Ashcreek,274417,2008,Vandalism,77
+Maplewood-Ashcreek,274417,2008,Weapons,1
+Maplewood-Ashcreek,274417,2009,Aggravated Assault,3
+Maplewood-Ashcreek,274417,2009,Arson,
+Maplewood-Ashcreek,274417,2009,"Assault, Simple",13
+Maplewood-Ashcreek,274417,2009,Burglary,47
+Maplewood-Ashcreek,274417,2009,Curfew,
+Maplewood-Ashcreek,274417,2009,Disorderly Conduct,22
+Maplewood-Ashcreek,274417,2009,Drugs,17
+Maplewood-Ashcreek,274417,2009,DUII,21
+Maplewood-Ashcreek,274417,2009,Embezzlement,7
+Maplewood-Ashcreek,274417,2009,Forgery,1
+Maplewood-Ashcreek,274417,2009,Fraud,44
+Maplewood-Ashcreek,274417,2009,Gambling,
+Maplewood-Ashcreek,274417,2009,Homicide,
+Maplewood-Ashcreek,274417,2009,Kidnap,
+Maplewood-Ashcreek,274417,2009,Larceny,203
+Maplewood-Ashcreek,274417,2009,Liquor Laws,6
+Maplewood-Ashcreek,274417,2009,Motor Vehicle Theft,22
+Maplewood-Ashcreek,274417,2009,Offenses Against Family,
+Maplewood-Ashcreek,274417,2009,Prostitution,
+Maplewood-Ashcreek,274417,2009,Rape,
+Maplewood-Ashcreek,274417,2009,Robbery,5
+Maplewood-Ashcreek,274417,2009,Runaway,1
+Maplewood-Ashcreek,274417,2009,Sex Offenses,2
+Maplewood-Ashcreek,274417,2009,Stolen Property,
+Maplewood-Ashcreek,274417,2009,Trespass,17
+Maplewood-Ashcreek,274417,2009,Vandalism,60
+Maplewood-Ashcreek,274417,2009,Weapons,1
+Maplewood-Ashcreek,274417,2010,Aggravated Assault,3
+Maplewood-Ashcreek,274417,2010,Arson,
+Maplewood-Ashcreek,274417,2010,"Assault, Simple",19
+Maplewood-Ashcreek,274417,2010,Burglary,44
+Maplewood-Ashcreek,274417,2010,Curfew,
+Maplewood-Ashcreek,274417,2010,Disorderly Conduct,20
+Maplewood-Ashcreek,274417,2010,Drugs,8
+Maplewood-Ashcreek,274417,2010,DUII,32
+Maplewood-Ashcreek,274417,2010,Embezzlement,2
+Maplewood-Ashcreek,274417,2010,Forgery,3
+Maplewood-Ashcreek,274417,2010,Fraud,22
+Maplewood-Ashcreek,274417,2010,Gambling,
+Maplewood-Ashcreek,274417,2010,Homicide,
+Maplewood-Ashcreek,274417,2010,Kidnap,
+Maplewood-Ashcreek,274417,2010,Larceny,173
+Maplewood-Ashcreek,274417,2010,Liquor Laws,9
+Maplewood-Ashcreek,274417,2010,Motor Vehicle Theft,24
+Maplewood-Ashcreek,274417,2010,Offenses Against Family,
+Maplewood-Ashcreek,274417,2010,Prostitution,
+Maplewood-Ashcreek,274417,2010,Rape,
+Maplewood-Ashcreek,274417,2010,Robbery,3
+Maplewood-Ashcreek,274417,2010,Runaway,
+Maplewood-Ashcreek,274417,2010,Sex Offenses,2
+Maplewood-Ashcreek,274417,2010,Stolen Property,
+Maplewood-Ashcreek,274417,2010,Trespass,19
+Maplewood-Ashcreek,274417,2010,Vandalism,46
+Maplewood-Ashcreek,274417,2010,Weapons,1
+Maplewood-Ashcreek,274417,2011,Aggravated Assault,7
+Maplewood-Ashcreek,274417,2011,Arson,
+Maplewood-Ashcreek,274417,2011,"Assault, Simple",14
+Maplewood-Ashcreek,274417,2011,Burglary,52
+Maplewood-Ashcreek,274417,2011,Curfew,
+Maplewood-Ashcreek,274417,2011,Disorderly Conduct,17
+Maplewood-Ashcreek,274417,2011,Drugs,9
+Maplewood-Ashcreek,274417,2011,DUII,24
+Maplewood-Ashcreek,274417,2011,Embezzlement,1
+Maplewood-Ashcreek,274417,2011,Forgery,5
+Maplewood-Ashcreek,274417,2011,Fraud,16
+Maplewood-Ashcreek,274417,2011,Gambling,
+Maplewood-Ashcreek,274417,2011,Homicide,
+Maplewood-Ashcreek,274417,2011,Kidnap,
+Maplewood-Ashcreek,274417,2011,Larceny,178
+Maplewood-Ashcreek,274417,2011,Liquor Laws,6
+Maplewood-Ashcreek,274417,2011,Motor Vehicle Theft,23
+Maplewood-Ashcreek,274417,2011,Offenses Against Family,
+Maplewood-Ashcreek,274417,2011,Prostitution,
+Maplewood-Ashcreek,274417,2011,Rape,
+Maplewood-Ashcreek,274417,2011,Robbery,2
+Maplewood-Ashcreek,274417,2011,Runaway,
+Maplewood-Ashcreek,274417,2011,Sex Offenses,
+Maplewood-Ashcreek,274417,2011,Stolen Property,
+Maplewood-Ashcreek,274417,2011,Trespass,10
+Maplewood-Ashcreek,274417,2011,Vandalism,37
+Maplewood-Ashcreek,274417,2011,Weapons,
+Maplewood-Ashcreek,274417,2012,Aggravated Assault,6
+Maplewood-Ashcreek,274417,2012,Arson,1
+Maplewood-Ashcreek,274417,2012,"Assault, Simple",11
+Maplewood-Ashcreek,274417,2012,Burglary,69
+Maplewood-Ashcreek,274417,2012,Curfew,
+Maplewood-Ashcreek,274417,2012,Disorderly Conduct,17
+Maplewood-Ashcreek,274417,2012,Drugs,5
+Maplewood-Ashcreek,274417,2012,DUII,30
+Maplewood-Ashcreek,274417,2012,Embezzlement,
+Maplewood-Ashcreek,274417,2012,Forgery,11
+Maplewood-Ashcreek,274417,2012,Fraud,17
+Maplewood-Ashcreek,274417,2012,Gambling,
+Maplewood-Ashcreek,274417,2012,Homicide,
+Maplewood-Ashcreek,274417,2012,Kidnap,
+Maplewood-Ashcreek,274417,2012,Larceny,215
+Maplewood-Ashcreek,274417,2012,Liquor Laws,1
+Maplewood-Ashcreek,274417,2012,Motor Vehicle Theft,26
+Maplewood-Ashcreek,274417,2012,Offenses Against Family,
+Maplewood-Ashcreek,274417,2012,Prostitution,
+Maplewood-Ashcreek,274417,2012,Rape,
+Maplewood-Ashcreek,274417,2012,Robbery,5
+Maplewood-Ashcreek,274417,2012,Runaway,
+Maplewood-Ashcreek,274417,2012,Sex Offenses,
+Maplewood-Ashcreek,274417,2012,Stolen Property,
+Maplewood-Ashcreek,274417,2012,Trespass,14
+Maplewood-Ashcreek,274417,2012,Vandalism,73
+Maplewood-Ashcreek,274417,2012,Weapons,4
+Maplewood-Ashcreek,274417,2013,Aggravated Assault,8
+Maplewood-Ashcreek,274417,2013,Arson,
+Maplewood-Ashcreek,274417,2013,"Assault, Simple",9
+Maplewood-Ashcreek,274417,2013,Burglary,35
+Maplewood-Ashcreek,274417,2013,Curfew,
+Maplewood-Ashcreek,274417,2013,Disorderly Conduct,8
+Maplewood-Ashcreek,274417,2013,Drugs,8
+Maplewood-Ashcreek,274417,2013,DUII,18
+Maplewood-Ashcreek,274417,2013,Embezzlement,2
+Maplewood-Ashcreek,274417,2013,Forgery,7
+Maplewood-Ashcreek,274417,2013,Fraud,23
+Maplewood-Ashcreek,274417,2013,Gambling,
+Maplewood-Ashcreek,274417,2013,Homicide,
+Maplewood-Ashcreek,274417,2013,Kidnap,
+Maplewood-Ashcreek,274417,2013,Larceny,142
+Maplewood-Ashcreek,274417,2013,Liquor Laws,5
+Maplewood-Ashcreek,274417,2013,Motor Vehicle Theft,15
+Maplewood-Ashcreek,274417,2013,Offenses Against Family,
+Maplewood-Ashcreek,274417,2013,Prostitution,
+Maplewood-Ashcreek,274417,2013,Rape,
+Maplewood-Ashcreek,274417,2013,Robbery,5
+Maplewood-Ashcreek,274417,2013,Runaway,
+Maplewood-Ashcreek,274417,2013,Sex Offenses,
+Maplewood-Ashcreek,274417,2013,Stolen Property,
+Maplewood-Ashcreek,274417,2013,Trespass,11
+Maplewood-Ashcreek,274417,2013,Vandalism,32
+Maplewood-Ashcreek,274417,2013,Weapons,1
+Maplewood-Ashcreek,274417,2014,Aggravated Assault,4
+Maplewood-Ashcreek,274417,2014,Arson,
+Maplewood-Ashcreek,274417,2014,"Assault, Simple",11
+Maplewood-Ashcreek,274417,2014,Burglary,43
+Maplewood-Ashcreek,274417,2014,Curfew,
+Maplewood-Ashcreek,274417,2014,Disorderly Conduct,15
+Maplewood-Ashcreek,274417,2014,Drugs,7
+Maplewood-Ashcreek,274417,2014,DUII,29
+Maplewood-Ashcreek,274417,2014,Embezzlement,
+Maplewood-Ashcreek,274417,2014,Forgery,2
+Maplewood-Ashcreek,274417,2014,Fraud,34
+Maplewood-Ashcreek,274417,2014,Gambling,
+Maplewood-Ashcreek,274417,2014,Homicide,
+Maplewood-Ashcreek,274417,2014,Kidnap,
+Maplewood-Ashcreek,274417,2014,Larceny,148
+Maplewood-Ashcreek,274417,2014,Liquor Laws,1
+Maplewood-Ashcreek,274417,2014,Motor Vehicle Theft,22
+Maplewood-Ashcreek,274417,2014,Offenses Against Family,
+Maplewood-Ashcreek,274417,2014,Prostitution,
+Maplewood-Ashcreek,274417,2014,Rape,
+Maplewood-Ashcreek,274417,2014,Robbery,3
+Maplewood-Ashcreek,274417,2014,Runaway,
+Maplewood-Ashcreek,274417,2014,Sex Offenses,
+Maplewood-Ashcreek,274417,2014,Stolen Property,
+Maplewood-Ashcreek,274417,2014,Trespass,3
+Maplewood-Ashcreek,274417,2014,Vandalism,33
+Maplewood-Ashcreek,274417,2014,Weapons,
+McLoughlin Industrial,274478,2004,Aggravated Assault,
+McLoughlin Industrial,274478,2004,Arson,
+McLoughlin Industrial,274478,2004,"Assault, Simple",
+McLoughlin Industrial,274478,2004,Burglary,
+McLoughlin Industrial,274478,2004,Curfew,
+McLoughlin Industrial,274478,2004,Disorderly Conduct,
+McLoughlin Industrial,274478,2004,Drugs,
+McLoughlin Industrial,274478,2004,DUII,
+McLoughlin Industrial,274478,2004,Embezzlement,
+McLoughlin Industrial,274478,2004,Forgery,
+McLoughlin Industrial,274478,2004,Fraud,
+McLoughlin Industrial,274478,2004,Gambling,
+McLoughlin Industrial,274478,2004,Homicide,
+McLoughlin Industrial,274478,2004,Kidnap,
+McLoughlin Industrial,274478,2004,Larceny,
+McLoughlin Industrial,274478,2004,Liquor Laws,
+McLoughlin Industrial,274478,2004,Motor Vehicle Theft,
+McLoughlin Industrial,274478,2004,Offenses Against Family,
+McLoughlin Industrial,274478,2004,Prostitution,
+McLoughlin Industrial,274478,2004,Rape,
+McLoughlin Industrial,274478,2004,Robbery,
+McLoughlin Industrial,274478,2004,Runaway,
+McLoughlin Industrial,274478,2004,Sex Offenses,
+McLoughlin Industrial,274478,2004,Stolen Property,
+McLoughlin Industrial,274478,2004,Trespass,
+McLoughlin Industrial,274478,2004,Vandalism,
+McLoughlin Industrial,274478,2004,Weapons,
+McLoughlin Industrial,274478,2005,Aggravated Assault,
+McLoughlin Industrial,274478,2005,Arson,
+McLoughlin Industrial,274478,2005,"Assault, Simple",
+McLoughlin Industrial,274478,2005,Burglary,
+McLoughlin Industrial,274478,2005,Curfew,
+McLoughlin Industrial,274478,2005,Disorderly Conduct,
+McLoughlin Industrial,274478,2005,Drugs,
+McLoughlin Industrial,274478,2005,DUII,
+McLoughlin Industrial,274478,2005,Embezzlement,
+McLoughlin Industrial,274478,2005,Forgery,
+McLoughlin Industrial,274478,2005,Fraud,
+McLoughlin Industrial,274478,2005,Gambling,
+McLoughlin Industrial,274478,2005,Homicide,
+McLoughlin Industrial,274478,2005,Kidnap,
+McLoughlin Industrial,274478,2005,Larceny,
+McLoughlin Industrial,274478,2005,Liquor Laws,
+McLoughlin Industrial,274478,2005,Motor Vehicle Theft,
+McLoughlin Industrial,274478,2005,Offenses Against Family,
+McLoughlin Industrial,274478,2005,Prostitution,
+McLoughlin Industrial,274478,2005,Rape,
+McLoughlin Industrial,274478,2005,Robbery,
+McLoughlin Industrial,274478,2005,Runaway,
+McLoughlin Industrial,274478,2005,Sex Offenses,
+McLoughlin Industrial,274478,2005,Stolen Property,
+McLoughlin Industrial,274478,2005,Trespass,1
+McLoughlin Industrial,274478,2005,Vandalism,
+McLoughlin Industrial,274478,2005,Weapons,
+McLoughlin Industrial,274478,2006,Aggravated Assault,
+McLoughlin Industrial,274478,2006,Arson,
+McLoughlin Industrial,274478,2006,"Assault, Simple",
+McLoughlin Industrial,274478,2006,Burglary,
+McLoughlin Industrial,274478,2006,Curfew,
+McLoughlin Industrial,274478,2006,Disorderly Conduct,
+McLoughlin Industrial,274478,2006,Drugs,
+McLoughlin Industrial,274478,2006,DUII,
+McLoughlin Industrial,274478,2006,Embezzlement,
+McLoughlin Industrial,274478,2006,Forgery,
+McLoughlin Industrial,274478,2006,Fraud,
+McLoughlin Industrial,274478,2006,Gambling,
+McLoughlin Industrial,274478,2006,Homicide,
+McLoughlin Industrial,274478,2006,Kidnap,
+McLoughlin Industrial,274478,2006,Larceny,
+McLoughlin Industrial,274478,2006,Liquor Laws,
+McLoughlin Industrial,274478,2006,Motor Vehicle Theft,
+McLoughlin Industrial,274478,2006,Offenses Against Family,
+McLoughlin Industrial,274478,2006,Prostitution,
+McLoughlin Industrial,274478,2006,Rape,
+McLoughlin Industrial,274478,2006,Robbery,
+McLoughlin Industrial,274478,2006,Runaway,
+McLoughlin Industrial,274478,2006,Sex Offenses,
+McLoughlin Industrial,274478,2006,Stolen Property,
+McLoughlin Industrial,274478,2006,Trespass,
+McLoughlin Industrial,274478,2006,Vandalism,
+McLoughlin Industrial,274478,2006,Weapons,
+McLoughlin Industrial,274478,2007,Aggravated Assault,
+McLoughlin Industrial,274478,2007,Arson,
+McLoughlin Industrial,274478,2007,"Assault, Simple",
+McLoughlin Industrial,274478,2007,Burglary,
+McLoughlin Industrial,274478,2007,Curfew,
+McLoughlin Industrial,274478,2007,Disorderly Conduct,
+McLoughlin Industrial,274478,2007,Drugs,
+McLoughlin Industrial,274478,2007,DUII,
+McLoughlin Industrial,274478,2007,Embezzlement,
+McLoughlin Industrial,274478,2007,Forgery,
+McLoughlin Industrial,274478,2007,Fraud,
+McLoughlin Industrial,274478,2007,Gambling,
+McLoughlin Industrial,274478,2007,Homicide,
+McLoughlin Industrial,274478,2007,Kidnap,
+McLoughlin Industrial,274478,2007,Larceny,
+McLoughlin Industrial,274478,2007,Liquor Laws,
+McLoughlin Industrial,274478,2007,Motor Vehicle Theft,
+McLoughlin Industrial,274478,2007,Offenses Against Family,
+McLoughlin Industrial,274478,2007,Prostitution,
+McLoughlin Industrial,274478,2007,Rape,
+McLoughlin Industrial,274478,2007,Robbery,
+McLoughlin Industrial,274478,2007,Runaway,
+McLoughlin Industrial,274478,2007,Sex Offenses,
+McLoughlin Industrial,274478,2007,Stolen Property,
+McLoughlin Industrial,274478,2007,Trespass,
+McLoughlin Industrial,274478,2007,Vandalism,
+McLoughlin Industrial,274478,2007,Weapons,
+McLoughlin Industrial,274478,2008,Aggravated Assault,
+McLoughlin Industrial,274478,2008,Arson,
+McLoughlin Industrial,274478,2008,"Assault, Simple",
+McLoughlin Industrial,274478,2008,Burglary,
+McLoughlin Industrial,274478,2008,Curfew,
+McLoughlin Industrial,274478,2008,Disorderly Conduct,
+McLoughlin Industrial,274478,2008,Drugs,
+McLoughlin Industrial,274478,2008,DUII,
+McLoughlin Industrial,274478,2008,Embezzlement,
+McLoughlin Industrial,274478,2008,Forgery,
+McLoughlin Industrial,274478,2008,Fraud,
+McLoughlin Industrial,274478,2008,Gambling,
+McLoughlin Industrial,274478,2008,Homicide,
+McLoughlin Industrial,274478,2008,Kidnap,
+McLoughlin Industrial,274478,2008,Larceny,
+McLoughlin Industrial,274478,2008,Liquor Laws,
+McLoughlin Industrial,274478,2008,Motor Vehicle Theft,
+McLoughlin Industrial,274478,2008,Offenses Against Family,
+McLoughlin Industrial,274478,2008,Prostitution,
+McLoughlin Industrial,274478,2008,Rape,
+McLoughlin Industrial,274478,2008,Robbery,
+McLoughlin Industrial,274478,2008,Runaway,
+McLoughlin Industrial,274478,2008,Sex Offenses,
+McLoughlin Industrial,274478,2008,Stolen Property,
+McLoughlin Industrial,274478,2008,Trespass,
+McLoughlin Industrial,274478,2008,Vandalism,
+McLoughlin Industrial,274478,2008,Weapons,
+McLoughlin Industrial,274478,2009,Aggravated Assault,
+McLoughlin Industrial,274478,2009,Arson,
+McLoughlin Industrial,274478,2009,"Assault, Simple",
+McLoughlin Industrial,274478,2009,Burglary,
+McLoughlin Industrial,274478,2009,Curfew,
+McLoughlin Industrial,274478,2009,Disorderly Conduct,
+McLoughlin Industrial,274478,2009,Drugs,
+McLoughlin Industrial,274478,2009,DUII,
+McLoughlin Industrial,274478,2009,Embezzlement,
+McLoughlin Industrial,274478,2009,Forgery,
+McLoughlin Industrial,274478,2009,Fraud,
+McLoughlin Industrial,274478,2009,Gambling,
+McLoughlin Industrial,274478,2009,Homicide,
+McLoughlin Industrial,274478,2009,Kidnap,
+McLoughlin Industrial,274478,2009,Larceny,
+McLoughlin Industrial,274478,2009,Liquor Laws,
+McLoughlin Industrial,274478,2009,Motor Vehicle Theft,
+McLoughlin Industrial,274478,2009,Offenses Against Family,
+McLoughlin Industrial,274478,2009,Prostitution,
+McLoughlin Industrial,274478,2009,Rape,
+McLoughlin Industrial,274478,2009,Robbery,
+McLoughlin Industrial,274478,2009,Runaway,
+McLoughlin Industrial,274478,2009,Sex Offenses,
+McLoughlin Industrial,274478,2009,Stolen Property,
+McLoughlin Industrial,274478,2009,Trespass,
+McLoughlin Industrial,274478,2009,Vandalism,
+McLoughlin Industrial,274478,2009,Weapons,
+McLoughlin Industrial,274478,2010,Aggravated Assault,
+McLoughlin Industrial,274478,2010,Arson,
+McLoughlin Industrial,274478,2010,"Assault, Simple",
+McLoughlin Industrial,274478,2010,Burglary,
+McLoughlin Industrial,274478,2010,Curfew,
+McLoughlin Industrial,274478,2010,Disorderly Conduct,
+McLoughlin Industrial,274478,2010,Drugs,
+McLoughlin Industrial,274478,2010,DUII,
+McLoughlin Industrial,274478,2010,Embezzlement,
+McLoughlin Industrial,274478,2010,Forgery,
+McLoughlin Industrial,274478,2010,Fraud,
+McLoughlin Industrial,274478,2010,Gambling,
+McLoughlin Industrial,274478,2010,Homicide,
+McLoughlin Industrial,274478,2010,Kidnap,
+McLoughlin Industrial,274478,2010,Larceny,
+McLoughlin Industrial,274478,2010,Liquor Laws,
+McLoughlin Industrial,274478,2010,Motor Vehicle Theft,
+McLoughlin Industrial,274478,2010,Offenses Against Family,
+McLoughlin Industrial,274478,2010,Prostitution,
+McLoughlin Industrial,274478,2010,Rape,
+McLoughlin Industrial,274478,2010,Robbery,
+McLoughlin Industrial,274478,2010,Runaway,
+McLoughlin Industrial,274478,2010,Sex Offenses,
+McLoughlin Industrial,274478,2010,Stolen Property,
+McLoughlin Industrial,274478,2010,Trespass,
+McLoughlin Industrial,274478,2010,Vandalism,
+McLoughlin Industrial,274478,2010,Weapons,
+McLoughlin Industrial,274478,2011,Aggravated Assault,
+McLoughlin Industrial,274478,2011,Arson,
+McLoughlin Industrial,274478,2011,"Assault, Simple",
+McLoughlin Industrial,274478,2011,Burglary,
+McLoughlin Industrial,274478,2011,Curfew,
+McLoughlin Industrial,274478,2011,Disorderly Conduct,
+McLoughlin Industrial,274478,2011,Drugs,
+McLoughlin Industrial,274478,2011,DUII,1
+McLoughlin Industrial,274478,2011,Embezzlement,
+McLoughlin Industrial,274478,2011,Forgery,
+McLoughlin Industrial,274478,2011,Fraud,
+McLoughlin Industrial,274478,2011,Gambling,
+McLoughlin Industrial,274478,2011,Homicide,
+McLoughlin Industrial,274478,2011,Kidnap,
+McLoughlin Industrial,274478,2011,Larceny,
+McLoughlin Industrial,274478,2011,Liquor Laws,
+McLoughlin Industrial,274478,2011,Motor Vehicle Theft,
+McLoughlin Industrial,274478,2011,Offenses Against Family,
+McLoughlin Industrial,274478,2011,Prostitution,
+McLoughlin Industrial,274478,2011,Rape,
+McLoughlin Industrial,274478,2011,Robbery,
+McLoughlin Industrial,274478,2011,Runaway,
+McLoughlin Industrial,274478,2011,Sex Offenses,
+McLoughlin Industrial,274478,2011,Stolen Property,
+McLoughlin Industrial,274478,2011,Trespass,
+McLoughlin Industrial,274478,2011,Vandalism,
+McLoughlin Industrial,274478,2011,Weapons,
+McLoughlin Industrial,274478,2012,Aggravated Assault,
+McLoughlin Industrial,274478,2012,Arson,
+McLoughlin Industrial,274478,2012,"Assault, Simple",
+McLoughlin Industrial,274478,2012,Burglary,
+McLoughlin Industrial,274478,2012,Curfew,
+McLoughlin Industrial,274478,2012,Disorderly Conduct,
+McLoughlin Industrial,274478,2012,Drugs,
+McLoughlin Industrial,274478,2012,DUII,1
+McLoughlin Industrial,274478,2012,Embezzlement,
+McLoughlin Industrial,274478,2012,Forgery,
+McLoughlin Industrial,274478,2012,Fraud,
+McLoughlin Industrial,274478,2012,Gambling,
+McLoughlin Industrial,274478,2012,Homicide,
+McLoughlin Industrial,274478,2012,Kidnap,
+McLoughlin Industrial,274478,2012,Larceny,1
+McLoughlin Industrial,274478,2012,Liquor Laws,
+McLoughlin Industrial,274478,2012,Motor Vehicle Theft,
+McLoughlin Industrial,274478,2012,Offenses Against Family,
+McLoughlin Industrial,274478,2012,Prostitution,
+McLoughlin Industrial,274478,2012,Rape,
+McLoughlin Industrial,274478,2012,Robbery,
+McLoughlin Industrial,274478,2012,Runaway,
+McLoughlin Industrial,274478,2012,Sex Offenses,
+McLoughlin Industrial,274478,2012,Stolen Property,
+McLoughlin Industrial,274478,2012,Trespass,
+McLoughlin Industrial,274478,2012,Vandalism,
+McLoughlin Industrial,274478,2012,Weapons,
+McLoughlin Industrial,274478,2013,Aggravated Assault,
+McLoughlin Industrial,274478,2013,Arson,
+McLoughlin Industrial,274478,2013,"Assault, Simple",
+McLoughlin Industrial,274478,2013,Burglary,
+McLoughlin Industrial,274478,2013,Curfew,
+McLoughlin Industrial,274478,2013,Disorderly Conduct,
+McLoughlin Industrial,274478,2013,Drugs,
+McLoughlin Industrial,274478,2013,DUII,
+McLoughlin Industrial,274478,2013,Embezzlement,
+McLoughlin Industrial,274478,2013,Forgery,
+McLoughlin Industrial,274478,2013,Fraud,
+McLoughlin Industrial,274478,2013,Gambling,
+McLoughlin Industrial,274478,2013,Homicide,
+McLoughlin Industrial,274478,2013,Kidnap,
+McLoughlin Industrial,274478,2013,Larceny,
+McLoughlin Industrial,274478,2013,Liquor Laws,
+McLoughlin Industrial,274478,2013,Motor Vehicle Theft,
+McLoughlin Industrial,274478,2013,Offenses Against Family,
+McLoughlin Industrial,274478,2013,Prostitution,
+McLoughlin Industrial,274478,2013,Rape,
+McLoughlin Industrial,274478,2013,Robbery,
+McLoughlin Industrial,274478,2013,Runaway,
+McLoughlin Industrial,274478,2013,Sex Offenses,
+McLoughlin Industrial,274478,2013,Stolen Property,
+McLoughlin Industrial,274478,2013,Trespass,
+McLoughlin Industrial,274478,2013,Vandalism,
+McLoughlin Industrial,274478,2013,Weapons,
+McLoughlin Industrial,274478,2014,Aggravated Assault,1
+McLoughlin Industrial,274478,2014,Arson,
+McLoughlin Industrial,274478,2014,"Assault, Simple",
+McLoughlin Industrial,274478,2014,Burglary,
+McLoughlin Industrial,274478,2014,Curfew,
+McLoughlin Industrial,274478,2014,Disorderly Conduct,
+McLoughlin Industrial,274478,2014,Drugs,
+McLoughlin Industrial,274478,2014,DUII,2
+McLoughlin Industrial,274478,2014,Embezzlement,
+McLoughlin Industrial,274478,2014,Forgery,
+McLoughlin Industrial,274478,2014,Fraud,
+McLoughlin Industrial,274478,2014,Gambling,
+McLoughlin Industrial,274478,2014,Homicide,
+McLoughlin Industrial,274478,2014,Kidnap,
+McLoughlin Industrial,274478,2014,Larceny,
+McLoughlin Industrial,274478,2014,Liquor Laws,
+McLoughlin Industrial,274478,2014,Motor Vehicle Theft,
+McLoughlin Industrial,274478,2014,Offenses Against Family,
+McLoughlin Industrial,274478,2014,Prostitution,
+McLoughlin Industrial,274478,2014,Rape,
+McLoughlin Industrial,274478,2014,Robbery,
+McLoughlin Industrial,274478,2014,Runaway,
+McLoughlin Industrial,274478,2014,Sex Offenses,
+McLoughlin Industrial,274478,2014,Stolen Property,
+McLoughlin Industrial,274478,2014,Trespass,
+McLoughlin Industrial,274478,2014,Vandalism,
+McLoughlin Industrial,274478,2014,Weapons,
+Mill Park,271111,2004,Aggravated Assault,4
+Mill Park,271111,2004,Arson,
+Mill Park,271111,2004,"Assault, Simple",7
+Mill Park,271111,2004,Burglary,21
+Mill Park,271111,2004,Curfew,1
+Mill Park,271111,2004,Disorderly Conduct,2
+Mill Park,271111,2004,Drugs,3
+Mill Park,271111,2004,DUII,8
+Mill Park,271111,2004,Embezzlement,1
+Mill Park,271111,2004,Forgery,51
+Mill Park,271111,2004,Fraud,18
+Mill Park,271111,2004,Gambling,
+Mill Park,271111,2004,Homicide,
+Mill Park,271111,2004,Kidnap,
+Mill Park,271111,2004,Larceny,67
+Mill Park,271111,2004,Liquor Laws,1
+Mill Park,271111,2004,Motor Vehicle Theft,18
+Mill Park,271111,2004,Offenses Against Family,
+Mill Park,271111,2004,Prostitution,
+Mill Park,271111,2004,Rape,
+Mill Park,271111,2004,Robbery,3
+Mill Park,271111,2004,Runaway,
+Mill Park,271111,2004,Sex Offenses,
+Mill Park,271111,2004,Stolen Property,
+Mill Park,271111,2004,Trespass,10
+Mill Park,271111,2004,Vandalism,16
+Mill Park,271111,2004,Weapons,1
+Mill Park,271111,2005,Aggravated Assault,17
+Mill Park,271111,2005,Arson,
+Mill Park,271111,2005,"Assault, Simple",29
+Mill Park,271111,2005,Burglary,95
+Mill Park,271111,2005,Curfew,1
+Mill Park,271111,2005,Disorderly Conduct,22
+Mill Park,271111,2005,Drugs,24
+Mill Park,271111,2005,DUII,29
+Mill Park,271111,2005,Embezzlement,3
+Mill Park,271111,2005,Forgery,82
+Mill Park,271111,2005,Fraud,38
+Mill Park,271111,2005,Gambling,
+Mill Park,271111,2005,Homicide,
+Mill Park,271111,2005,Kidnap,1
+Mill Park,271111,2005,Larceny,253
+Mill Park,271111,2005,Liquor Laws,3
+Mill Park,271111,2005,Motor Vehicle Theft,79
+Mill Park,271111,2005,Offenses Against Family,
+Mill Park,271111,2005,Prostitution,
+Mill Park,271111,2005,Rape,
+Mill Park,271111,2005,Robbery,12
+Mill Park,271111,2005,Runaway,
+Mill Park,271111,2005,Sex Offenses,
+Mill Park,271111,2005,Stolen Property,2
+Mill Park,271111,2005,Trespass,22
+Mill Park,271111,2005,Vandalism,71
+Mill Park,271111,2005,Weapons,5
+Mill Park,271111,2006,Aggravated Assault,9
+Mill Park,271111,2006,Arson,1
+Mill Park,271111,2006,"Assault, Simple",22
+Mill Park,271111,2006,Burglary,49
+Mill Park,271111,2006,Curfew,
+Mill Park,271111,2006,Disorderly Conduct,24
+Mill Park,271111,2006,Drugs,15
+Mill Park,271111,2006,DUII,42
+Mill Park,271111,2006,Embezzlement,3
+Mill Park,271111,2006,Forgery,60
+Mill Park,271111,2006,Fraud,31
+Mill Park,271111,2006,Gambling,
+Mill Park,271111,2006,Homicide,
+Mill Park,271111,2006,Kidnap,1
+Mill Park,271111,2006,Larceny,272
+Mill Park,271111,2006,Liquor Laws,5
+Mill Park,271111,2006,Motor Vehicle Theft,74
+Mill Park,271111,2006,Offenses Against Family,
+Mill Park,271111,2006,Prostitution,
+Mill Park,271111,2006,Rape,
+Mill Park,271111,2006,Robbery,16
+Mill Park,271111,2006,Runaway,
+Mill Park,271111,2006,Sex Offenses,1
+Mill Park,271111,2006,Stolen Property,
+Mill Park,271111,2006,Trespass,16
+Mill Park,271111,2006,Vandalism,101
+Mill Park,271111,2006,Weapons,2
+Mill Park,271111,2007,Aggravated Assault,23
+Mill Park,271111,2007,Arson,
+Mill Park,271111,2007,"Assault, Simple",33
+Mill Park,271111,2007,Burglary,64
+Mill Park,271111,2007,Curfew,2
+Mill Park,271111,2007,Disorderly Conduct,21
+Mill Park,271111,2007,Drugs,20
+Mill Park,271111,2007,DUII,46
+Mill Park,271111,2007,Embezzlement,1
+Mill Park,271111,2007,Forgery,57
+Mill Park,271111,2007,Fraud,32
+Mill Park,271111,2007,Gambling,
+Mill Park,271111,2007,Homicide,
+Mill Park,271111,2007,Kidnap,
+Mill Park,271111,2007,Larceny,299
+Mill Park,271111,2007,Liquor Laws,5
+Mill Park,271111,2007,Motor Vehicle Theft,93
+Mill Park,271111,2007,Offenses Against Family,
+Mill Park,271111,2007,Prostitution,1
+Mill Park,271111,2007,Rape,
+Mill Park,271111,2007,Robbery,15
+Mill Park,271111,2007,Runaway,2
+Mill Park,271111,2007,Sex Offenses,1
+Mill Park,271111,2007,Stolen Property,2
+Mill Park,271111,2007,Trespass,19
+Mill Park,271111,2007,Vandalism,80
+Mill Park,271111,2007,Weapons,3
+Mill Park,271111,2008,Aggravated Assault,21
+Mill Park,271111,2008,Arson,1
+Mill Park,271111,2008,"Assault, Simple",39
+Mill Park,271111,2008,Burglary,63
+Mill Park,271111,2008,Curfew,5
+Mill Park,271111,2008,Disorderly Conduct,19
+Mill Park,271111,2008,Drugs,26
+Mill Park,271111,2008,DUII,37
+Mill Park,271111,2008,Embezzlement,4
+Mill Park,271111,2008,Forgery,58
+Mill Park,271111,2008,Fraud,29
+Mill Park,271111,2008,Gambling,
+Mill Park,271111,2008,Homicide,
+Mill Park,271111,2008,Kidnap,1
+Mill Park,271111,2008,Larceny,274
+Mill Park,271111,2008,Liquor Laws,7
+Mill Park,271111,2008,Motor Vehicle Theft,42
+Mill Park,271111,2008,Offenses Against Family,
+Mill Park,271111,2008,Prostitution,1
+Mill Park,271111,2008,Rape,
+Mill Park,271111,2008,Robbery,18
+Mill Park,271111,2008,Runaway,
+Mill Park,271111,2008,Sex Offenses,
+Mill Park,271111,2008,Stolen Property,3
+Mill Park,271111,2008,Trespass,18
+Mill Park,271111,2008,Vandalism,107
+Mill Park,271111,2008,Weapons,7
+Mill Park,271111,2009,Aggravated Assault,18
+Mill Park,271111,2009,Arson,
+Mill Park,271111,2009,"Assault, Simple",33
+Mill Park,271111,2009,Burglary,54
+Mill Park,271111,2009,Curfew,2
+Mill Park,271111,2009,Disorderly Conduct,29
+Mill Park,271111,2009,Drugs,20
+Mill Park,271111,2009,DUII,29
+Mill Park,271111,2009,Embezzlement,5
+Mill Park,271111,2009,Forgery,29
+Mill Park,271111,2009,Fraud,45
+Mill Park,271111,2009,Gambling,
+Mill Park,271111,2009,Homicide,1
+Mill Park,271111,2009,Kidnap,
+Mill Park,271111,2009,Larceny,210
+Mill Park,271111,2009,Liquor Laws,2
+Mill Park,271111,2009,Motor Vehicle Theft,44
+Mill Park,271111,2009,Offenses Against Family,
+Mill Park,271111,2009,Prostitution,
+Mill Park,271111,2009,Rape,1
+Mill Park,271111,2009,Robbery,14
+Mill Park,271111,2009,Runaway,2
+Mill Park,271111,2009,Sex Offenses,2
+Mill Park,271111,2009,Stolen Property,
+Mill Park,271111,2009,Trespass,33
+Mill Park,271111,2009,Vandalism,68
+Mill Park,271111,2009,Weapons,3
+Mill Park,271111,2010,Aggravated Assault,17
+Mill Park,271111,2010,Arson,
+Mill Park,271111,2010,"Assault, Simple",41
+Mill Park,271111,2010,Burglary,64
+Mill Park,271111,2010,Curfew,1
+Mill Park,271111,2010,Disorderly Conduct,26
+Mill Park,271111,2010,Drugs,17
+Mill Park,271111,2010,DUII,32
+Mill Park,271111,2010,Embezzlement,3
+Mill Park,271111,2010,Forgery,41
+Mill Park,271111,2010,Fraud,37
+Mill Park,271111,2010,Gambling,
+Mill Park,271111,2010,Homicide,
+Mill Park,271111,2010,Kidnap,
+Mill Park,271111,2010,Larceny,230
+Mill Park,271111,2010,Liquor Laws,5
+Mill Park,271111,2010,Motor Vehicle Theft,44
+Mill Park,271111,2010,Offenses Against Family,
+Mill Park,271111,2010,Prostitution,1
+Mill Park,271111,2010,Rape,
+Mill Park,271111,2010,Robbery,14
+Mill Park,271111,2010,Runaway,
+Mill Park,271111,2010,Sex Offenses,
+Mill Park,271111,2010,Stolen Property,2
+Mill Park,271111,2010,Trespass,25
+Mill Park,271111,2010,Vandalism,60
+Mill Park,271111,2010,Weapons,5
+Mill Park,271111,2011,Aggravated Assault,14
+Mill Park,271111,2011,Arson,
+Mill Park,271111,2011,"Assault, Simple",29
+Mill Park,271111,2011,Burglary,90
+Mill Park,271111,2011,Curfew,1
+Mill Park,271111,2011,Disorderly Conduct,25
+Mill Park,271111,2011,Drugs,25
+Mill Park,271111,2011,DUII,26
+Mill Park,271111,2011,Embezzlement,
+Mill Park,271111,2011,Forgery,37
+Mill Park,271111,2011,Fraud,22
+Mill Park,271111,2011,Gambling,
+Mill Park,271111,2011,Homicide,
+Mill Park,271111,2011,Kidnap,
+Mill Park,271111,2011,Larceny,278
+Mill Park,271111,2011,Liquor Laws,3
+Mill Park,271111,2011,Motor Vehicle Theft,49
+Mill Park,271111,2011,Offenses Against Family,
+Mill Park,271111,2011,Prostitution,1
+Mill Park,271111,2011,Rape,2
+Mill Park,271111,2011,Robbery,15
+Mill Park,271111,2011,Runaway,
+Mill Park,271111,2011,Sex Offenses,
+Mill Park,271111,2011,Stolen Property,
+Mill Park,271111,2011,Trespass,17
+Mill Park,271111,2011,Vandalism,65
+Mill Park,271111,2011,Weapons,5
+Mill Park,271111,2012,Aggravated Assault,36
+Mill Park,271111,2012,Arson,
+Mill Park,271111,2012,"Assault, Simple",31
+Mill Park,271111,2012,Burglary,63
+Mill Park,271111,2012,Curfew,
+Mill Park,271111,2012,Disorderly Conduct,21
+Mill Park,271111,2012,Drugs,25
+Mill Park,271111,2012,DUII,34
+Mill Park,271111,2012,Embezzlement,2
+Mill Park,271111,2012,Forgery,24
+Mill Park,271111,2012,Fraud,35
+Mill Park,271111,2012,Gambling,
+Mill Park,271111,2012,Homicide,
+Mill Park,271111,2012,Kidnap,
+Mill Park,271111,2012,Larceny,190
+Mill Park,271111,2012,Liquor Laws,3
+Mill Park,271111,2012,Motor Vehicle Theft,54
+Mill Park,271111,2012,Offenses Against Family,
+Mill Park,271111,2012,Prostitution,
+Mill Park,271111,2012,Rape,1
+Mill Park,271111,2012,Robbery,13
+Mill Park,271111,2012,Runaway,
+Mill Park,271111,2012,Sex Offenses,
+Mill Park,271111,2012,Stolen Property,
+Mill Park,271111,2012,Trespass,21
+Mill Park,271111,2012,Vandalism,67
+Mill Park,271111,2012,Weapons,4
+Mill Park,271111,2013,Aggravated Assault,14
+Mill Park,271111,2013,Arson,
+Mill Park,271111,2013,"Assault, Simple",31
+Mill Park,271111,2013,Burglary,66
+Mill Park,271111,2013,Curfew,
+Mill Park,271111,2013,Disorderly Conduct,30
+Mill Park,271111,2013,Drugs,24
+Mill Park,271111,2013,DUII,31
+Mill Park,271111,2013,Embezzlement,1
+Mill Park,271111,2013,Forgery,27
+Mill Park,271111,2013,Fraud,22
+Mill Park,271111,2013,Gambling,
+Mill Park,271111,2013,Homicide,
+Mill Park,271111,2013,Kidnap,
+Mill Park,271111,2013,Larceny,304
+Mill Park,271111,2013,Liquor Laws,5
+Mill Park,271111,2013,Motor Vehicle Theft,64
+Mill Park,271111,2013,Offenses Against Family,
+Mill Park,271111,2013,Prostitution,3
+Mill Park,271111,2013,Rape,
+Mill Park,271111,2013,Robbery,8
+Mill Park,271111,2013,Runaway,
+Mill Park,271111,2013,Sex Offenses,
+Mill Park,271111,2013,Stolen Property,
+Mill Park,271111,2013,Trespass,15
+Mill Park,271111,2013,Vandalism,53
+Mill Park,271111,2013,Weapons,10
+Mill Park,271111,2014,Aggravated Assault,18
+Mill Park,271111,2014,Arson,
+Mill Park,271111,2014,"Assault, Simple",33
+Mill Park,271111,2014,Burglary,73
+Mill Park,271111,2014,Curfew,
+Mill Park,271111,2014,Disorderly Conduct,23
+Mill Park,271111,2014,Drugs,22
+Mill Park,271111,2014,DUII,35
+Mill Park,271111,2014,Embezzlement,2
+Mill Park,271111,2014,Forgery,21
+Mill Park,271111,2014,Fraud,31
+Mill Park,271111,2014,Gambling,
+Mill Park,271111,2014,Homicide,
+Mill Park,271111,2014,Kidnap,1
+Mill Park,271111,2014,Larceny,245
+Mill Park,271111,2014,Liquor Laws,4
+Mill Park,271111,2014,Motor Vehicle Theft,72
+Mill Park,271111,2014,Offenses Against Family,
+Mill Park,271111,2014,Prostitution,2
+Mill Park,271111,2014,Rape,
+Mill Park,271111,2014,Robbery,11
+Mill Park,271111,2014,Runaway,
+Mill Park,271111,2014,Sex Offenses,
+Mill Park,271111,2014,Stolen Property,
+Mill Park,271111,2014,Trespass,17
+Mill Park,271111,2014,Vandalism,68
+Mill Park,271111,2014,Weapons,5
+Milwaukie Business-Industry,274545,2004,Aggravated Assault,
+Milwaukie Business-Industry,274545,2004,Arson,
+Milwaukie Business-Industry,274545,2004,"Assault, Simple",
+Milwaukie Business-Industry,274545,2004,Burglary,
+Milwaukie Business-Industry,274545,2004,Curfew,
+Milwaukie Business-Industry,274545,2004,Disorderly Conduct,
+Milwaukie Business-Industry,274545,2004,Drugs,
+Milwaukie Business-Industry,274545,2004,DUII,
+Milwaukie Business-Industry,274545,2004,Embezzlement,
+Milwaukie Business-Industry,274545,2004,Forgery,
+Milwaukie Business-Industry,274545,2004,Fraud,
+Milwaukie Business-Industry,274545,2004,Gambling,
+Milwaukie Business-Industry,274545,2004,Homicide,
+Milwaukie Business-Industry,274545,2004,Kidnap,
+Milwaukie Business-Industry,274545,2004,Larceny,
+Milwaukie Business-Industry,274545,2004,Liquor Laws,
+Milwaukie Business-Industry,274545,2004,Motor Vehicle Theft,
+Milwaukie Business-Industry,274545,2004,Offenses Against Family,
+Milwaukie Business-Industry,274545,2004,Prostitution,
+Milwaukie Business-Industry,274545,2004,Rape,
+Milwaukie Business-Industry,274545,2004,Robbery,
+Milwaukie Business-Industry,274545,2004,Runaway,
+Milwaukie Business-Industry,274545,2004,Sex Offenses,
+Milwaukie Business-Industry,274545,2004,Stolen Property,
+Milwaukie Business-Industry,274545,2004,Trespass,
+Milwaukie Business-Industry,274545,2004,Vandalism,
+Milwaukie Business-Industry,274545,2004,Weapons,
+Milwaukie Business-Industry,274545,2005,Aggravated Assault,
+Milwaukie Business-Industry,274545,2005,Arson,
+Milwaukie Business-Industry,274545,2005,"Assault, Simple",
+Milwaukie Business-Industry,274545,2005,Burglary,
+Milwaukie Business-Industry,274545,2005,Curfew,
+Milwaukie Business-Industry,274545,2005,Disorderly Conduct,
+Milwaukie Business-Industry,274545,2005,Drugs,
+Milwaukie Business-Industry,274545,2005,DUII,
+Milwaukie Business-Industry,274545,2005,Embezzlement,
+Milwaukie Business-Industry,274545,2005,Forgery,
+Milwaukie Business-Industry,274545,2005,Fraud,
+Milwaukie Business-Industry,274545,2005,Gambling,
+Milwaukie Business-Industry,274545,2005,Homicide,
+Milwaukie Business-Industry,274545,2005,Kidnap,
+Milwaukie Business-Industry,274545,2005,Larceny,
+Milwaukie Business-Industry,274545,2005,Liquor Laws,
+Milwaukie Business-Industry,274545,2005,Motor Vehicle Theft,
+Milwaukie Business-Industry,274545,2005,Offenses Against Family,
+Milwaukie Business-Industry,274545,2005,Prostitution,
+Milwaukie Business-Industry,274545,2005,Rape,
+Milwaukie Business-Industry,274545,2005,Robbery,
+Milwaukie Business-Industry,274545,2005,Runaway,
+Milwaukie Business-Industry,274545,2005,Sex Offenses,
+Milwaukie Business-Industry,274545,2005,Stolen Property,
+Milwaukie Business-Industry,274545,2005,Trespass,
+Milwaukie Business-Industry,274545,2005,Vandalism,
+Milwaukie Business-Industry,274545,2005,Weapons,
+Milwaukie Business-Industry,274545,2006,Aggravated Assault,
+Milwaukie Business-Industry,274545,2006,Arson,
+Milwaukie Business-Industry,274545,2006,"Assault, Simple",
+Milwaukie Business-Industry,274545,2006,Burglary,
+Milwaukie Business-Industry,274545,2006,Curfew,
+Milwaukie Business-Industry,274545,2006,Disorderly Conduct,
+Milwaukie Business-Industry,274545,2006,Drugs,
+Milwaukie Business-Industry,274545,2006,DUII,
+Milwaukie Business-Industry,274545,2006,Embezzlement,
+Milwaukie Business-Industry,274545,2006,Forgery,
+Milwaukie Business-Industry,274545,2006,Fraud,
+Milwaukie Business-Industry,274545,2006,Gambling,
+Milwaukie Business-Industry,274545,2006,Homicide,
+Milwaukie Business-Industry,274545,2006,Kidnap,
+Milwaukie Business-Industry,274545,2006,Larceny,
+Milwaukie Business-Industry,274545,2006,Liquor Laws,
+Milwaukie Business-Industry,274545,2006,Motor Vehicle Theft,
+Milwaukie Business-Industry,274545,2006,Offenses Against Family,
+Milwaukie Business-Industry,274545,2006,Prostitution,
+Milwaukie Business-Industry,274545,2006,Rape,
+Milwaukie Business-Industry,274545,2006,Robbery,
+Milwaukie Business-Industry,274545,2006,Runaway,
+Milwaukie Business-Industry,274545,2006,Sex Offenses,
+Milwaukie Business-Industry,274545,2006,Stolen Property,
+Milwaukie Business-Industry,274545,2006,Trespass,
+Milwaukie Business-Industry,274545,2006,Vandalism,
+Milwaukie Business-Industry,274545,2006,Weapons,
+Milwaukie Business-Industry,274545,2007,Aggravated Assault,
+Milwaukie Business-Industry,274545,2007,Arson,
+Milwaukie Business-Industry,274545,2007,"Assault, Simple",
+Milwaukie Business-Industry,274545,2007,Burglary,
+Milwaukie Business-Industry,274545,2007,Curfew,
+Milwaukie Business-Industry,274545,2007,Disorderly Conduct,
+Milwaukie Business-Industry,274545,2007,Drugs,
+Milwaukie Business-Industry,274545,2007,DUII,
+Milwaukie Business-Industry,274545,2007,Embezzlement,
+Milwaukie Business-Industry,274545,2007,Forgery,
+Milwaukie Business-Industry,274545,2007,Fraud,
+Milwaukie Business-Industry,274545,2007,Gambling,
+Milwaukie Business-Industry,274545,2007,Homicide,
+Milwaukie Business-Industry,274545,2007,Kidnap,
+Milwaukie Business-Industry,274545,2007,Larceny,
+Milwaukie Business-Industry,274545,2007,Liquor Laws,
+Milwaukie Business-Industry,274545,2007,Motor Vehicle Theft,
+Milwaukie Business-Industry,274545,2007,Offenses Against Family,
+Milwaukie Business-Industry,274545,2007,Prostitution,
+Milwaukie Business-Industry,274545,2007,Rape,
+Milwaukie Business-Industry,274545,2007,Robbery,
+Milwaukie Business-Industry,274545,2007,Runaway,
+Milwaukie Business-Industry,274545,2007,Sex Offenses,
+Milwaukie Business-Industry,274545,2007,Stolen Property,
+Milwaukie Business-Industry,274545,2007,Trespass,
+Milwaukie Business-Industry,274545,2007,Vandalism,
+Milwaukie Business-Industry,274545,2007,Weapons,
+Milwaukie Business-Industry,274545,2008,Aggravated Assault,
+Milwaukie Business-Industry,274545,2008,Arson,
+Milwaukie Business-Industry,274545,2008,"Assault, Simple",
+Milwaukie Business-Industry,274545,2008,Burglary,
+Milwaukie Business-Industry,274545,2008,Curfew,
+Milwaukie Business-Industry,274545,2008,Disorderly Conduct,
+Milwaukie Business-Industry,274545,2008,Drugs,
+Milwaukie Business-Industry,274545,2008,DUII,
+Milwaukie Business-Industry,274545,2008,Embezzlement,
+Milwaukie Business-Industry,274545,2008,Forgery,
+Milwaukie Business-Industry,274545,2008,Fraud,
+Milwaukie Business-Industry,274545,2008,Gambling,
+Milwaukie Business-Industry,274545,2008,Homicide,
+Milwaukie Business-Industry,274545,2008,Kidnap,
+Milwaukie Business-Industry,274545,2008,Larceny,
+Milwaukie Business-Industry,274545,2008,Liquor Laws,
+Milwaukie Business-Industry,274545,2008,Motor Vehicle Theft,
+Milwaukie Business-Industry,274545,2008,Offenses Against Family,
+Milwaukie Business-Industry,274545,2008,Prostitution,
+Milwaukie Business-Industry,274545,2008,Rape,
+Milwaukie Business-Industry,274545,2008,Robbery,
+Milwaukie Business-Industry,274545,2008,Runaway,
+Milwaukie Business-Industry,274545,2008,Sex Offenses,
+Milwaukie Business-Industry,274545,2008,Stolen Property,
+Milwaukie Business-Industry,274545,2008,Trespass,
+Milwaukie Business-Industry,274545,2008,Vandalism,
+Milwaukie Business-Industry,274545,2008,Weapons,
+Milwaukie Business-Industry,274545,2009,Aggravated Assault,
+Milwaukie Business-Industry,274545,2009,Arson,
+Milwaukie Business-Industry,274545,2009,"Assault, Simple",
+Milwaukie Business-Industry,274545,2009,Burglary,
+Milwaukie Business-Industry,274545,2009,Curfew,
+Milwaukie Business-Industry,274545,2009,Disorderly Conduct,
+Milwaukie Business-Industry,274545,2009,Drugs,
+Milwaukie Business-Industry,274545,2009,DUII,
+Milwaukie Business-Industry,274545,2009,Embezzlement,
+Milwaukie Business-Industry,274545,2009,Forgery,
+Milwaukie Business-Industry,274545,2009,Fraud,
+Milwaukie Business-Industry,274545,2009,Gambling,
+Milwaukie Business-Industry,274545,2009,Homicide,
+Milwaukie Business-Industry,274545,2009,Kidnap,
+Milwaukie Business-Industry,274545,2009,Larceny,
+Milwaukie Business-Industry,274545,2009,Liquor Laws,
+Milwaukie Business-Industry,274545,2009,Motor Vehicle Theft,
+Milwaukie Business-Industry,274545,2009,Offenses Against Family,
+Milwaukie Business-Industry,274545,2009,Prostitution,
+Milwaukie Business-Industry,274545,2009,Rape,
+Milwaukie Business-Industry,274545,2009,Robbery,
+Milwaukie Business-Industry,274545,2009,Runaway,
+Milwaukie Business-Industry,274545,2009,Sex Offenses,
+Milwaukie Business-Industry,274545,2009,Stolen Property,
+Milwaukie Business-Industry,274545,2009,Trespass,
+Milwaukie Business-Industry,274545,2009,Vandalism,
+Milwaukie Business-Industry,274545,2009,Weapons,
+Milwaukie Business-Industry,274545,2010,Aggravated Assault,
+Milwaukie Business-Industry,274545,2010,Arson,
+Milwaukie Business-Industry,274545,2010,"Assault, Simple",
+Milwaukie Business-Industry,274545,2010,Burglary,
+Milwaukie Business-Industry,274545,2010,Curfew,
+Milwaukie Business-Industry,274545,2010,Disorderly Conduct,
+Milwaukie Business-Industry,274545,2010,Drugs,
+Milwaukie Business-Industry,274545,2010,DUII,
+Milwaukie Business-Industry,274545,2010,Embezzlement,
+Milwaukie Business-Industry,274545,2010,Forgery,
+Milwaukie Business-Industry,274545,2010,Fraud,
+Milwaukie Business-Industry,274545,2010,Gambling,
+Milwaukie Business-Industry,274545,2010,Homicide,
+Milwaukie Business-Industry,274545,2010,Kidnap,
+Milwaukie Business-Industry,274545,2010,Larceny,
+Milwaukie Business-Industry,274545,2010,Liquor Laws,
+Milwaukie Business-Industry,274545,2010,Motor Vehicle Theft,
+Milwaukie Business-Industry,274545,2010,Offenses Against Family,
+Milwaukie Business-Industry,274545,2010,Prostitution,
+Milwaukie Business-Industry,274545,2010,Rape,
+Milwaukie Business-Industry,274545,2010,Robbery,
+Milwaukie Business-Industry,274545,2010,Runaway,
+Milwaukie Business-Industry,274545,2010,Sex Offenses,
+Milwaukie Business-Industry,274545,2010,Stolen Property,
+Milwaukie Business-Industry,274545,2010,Trespass,
+Milwaukie Business-Industry,274545,2010,Vandalism,
+Milwaukie Business-Industry,274545,2010,Weapons,
+Milwaukie Business-Industry,274545,2011,Aggravated Assault,
+Milwaukie Business-Industry,274545,2011,Arson,
+Milwaukie Business-Industry,274545,2011,"Assault, Simple",
+Milwaukie Business-Industry,274545,2011,Burglary,
+Milwaukie Business-Industry,274545,2011,Curfew,
+Milwaukie Business-Industry,274545,2011,Disorderly Conduct,
+Milwaukie Business-Industry,274545,2011,Drugs,
+Milwaukie Business-Industry,274545,2011,DUII,
+Milwaukie Business-Industry,274545,2011,Embezzlement,
+Milwaukie Business-Industry,274545,2011,Forgery,
+Milwaukie Business-Industry,274545,2011,Fraud,
+Milwaukie Business-Industry,274545,2011,Gambling,
+Milwaukie Business-Industry,274545,2011,Homicide,
+Milwaukie Business-Industry,274545,2011,Kidnap,
+Milwaukie Business-Industry,274545,2011,Larceny,
+Milwaukie Business-Industry,274545,2011,Liquor Laws,
+Milwaukie Business-Industry,274545,2011,Motor Vehicle Theft,
+Milwaukie Business-Industry,274545,2011,Offenses Against Family,
+Milwaukie Business-Industry,274545,2011,Prostitution,
+Milwaukie Business-Industry,274545,2011,Rape,
+Milwaukie Business-Industry,274545,2011,Robbery,
+Milwaukie Business-Industry,274545,2011,Runaway,
+Milwaukie Business-Industry,274545,2011,Sex Offenses,
+Milwaukie Business-Industry,274545,2011,Stolen Property,
+Milwaukie Business-Industry,274545,2011,Trespass,
+Milwaukie Business-Industry,274545,2011,Vandalism,
+Milwaukie Business-Industry,274545,2011,Weapons,
+Milwaukie Business-Industry,274545,2012,Aggravated Assault,
+Milwaukie Business-Industry,274545,2012,Arson,
+Milwaukie Business-Industry,274545,2012,"Assault, Simple",
+Milwaukie Business-Industry,274545,2012,Burglary,
+Milwaukie Business-Industry,274545,2012,Curfew,
+Milwaukie Business-Industry,274545,2012,Disorderly Conduct,
+Milwaukie Business-Industry,274545,2012,Drugs,
+Milwaukie Business-Industry,274545,2012,DUII,
+Milwaukie Business-Industry,274545,2012,Embezzlement,
+Milwaukie Business-Industry,274545,2012,Forgery,
+Milwaukie Business-Industry,274545,2012,Fraud,
+Milwaukie Business-Industry,274545,2012,Gambling,
+Milwaukie Business-Industry,274545,2012,Homicide,
+Milwaukie Business-Industry,274545,2012,Kidnap,
+Milwaukie Business-Industry,274545,2012,Larceny,
+Milwaukie Business-Industry,274545,2012,Liquor Laws,
+Milwaukie Business-Industry,274545,2012,Motor Vehicle Theft,
+Milwaukie Business-Industry,274545,2012,Offenses Against Family,
+Milwaukie Business-Industry,274545,2012,Prostitution,
+Milwaukie Business-Industry,274545,2012,Rape,
+Milwaukie Business-Industry,274545,2012,Robbery,
+Milwaukie Business-Industry,274545,2012,Runaway,
+Milwaukie Business-Industry,274545,2012,Sex Offenses,
+Milwaukie Business-Industry,274545,2012,Stolen Property,
+Milwaukie Business-Industry,274545,2012,Trespass,
+Milwaukie Business-Industry,274545,2012,Vandalism,
+Milwaukie Business-Industry,274545,2012,Weapons,
+Milwaukie Business-Industry,274545,2013,Aggravated Assault,
+Milwaukie Business-Industry,274545,2013,Arson,
+Milwaukie Business-Industry,274545,2013,"Assault, Simple",
+Milwaukie Business-Industry,274545,2013,Burglary,
+Milwaukie Business-Industry,274545,2013,Curfew,
+Milwaukie Business-Industry,274545,2013,Disorderly Conduct,
+Milwaukie Business-Industry,274545,2013,Drugs,
+Milwaukie Business-Industry,274545,2013,DUII,
+Milwaukie Business-Industry,274545,2013,Embezzlement,
+Milwaukie Business-Industry,274545,2013,Forgery,
+Milwaukie Business-Industry,274545,2013,Fraud,
+Milwaukie Business-Industry,274545,2013,Gambling,
+Milwaukie Business-Industry,274545,2013,Homicide,
+Milwaukie Business-Industry,274545,2013,Kidnap,
+Milwaukie Business-Industry,274545,2013,Larceny,
+Milwaukie Business-Industry,274545,2013,Liquor Laws,
+Milwaukie Business-Industry,274545,2013,Motor Vehicle Theft,
+Milwaukie Business-Industry,274545,2013,Offenses Against Family,
+Milwaukie Business-Industry,274545,2013,Prostitution,
+Milwaukie Business-Industry,274545,2013,Rape,
+Milwaukie Business-Industry,274545,2013,Robbery,
+Milwaukie Business-Industry,274545,2013,Runaway,
+Milwaukie Business-Industry,274545,2013,Sex Offenses,
+Milwaukie Business-Industry,274545,2013,Stolen Property,
+Milwaukie Business-Industry,274545,2013,Trespass,
+Milwaukie Business-Industry,274545,2013,Vandalism,
+Milwaukie Business-Industry,274545,2013,Weapons,
+Milwaukie Business-Industry,274545,2014,Aggravated Assault,
+Milwaukie Business-Industry,274545,2014,Arson,
+Milwaukie Business-Industry,274545,2014,"Assault, Simple",
+Milwaukie Business-Industry,274545,2014,Burglary,
+Milwaukie Business-Industry,274545,2014,Curfew,
+Milwaukie Business-Industry,274545,2014,Disorderly Conduct,
+Milwaukie Business-Industry,274545,2014,Drugs,
+Milwaukie Business-Industry,274545,2014,DUII,
+Milwaukie Business-Industry,274545,2014,Embezzlement,
+Milwaukie Business-Industry,274545,2014,Forgery,
+Milwaukie Business-Industry,274545,2014,Fraud,
+Milwaukie Business-Industry,274545,2014,Gambling,
+Milwaukie Business-Industry,274545,2014,Homicide,
+Milwaukie Business-Industry,274545,2014,Kidnap,
+Milwaukie Business-Industry,274545,2014,Larceny,
+Milwaukie Business-Industry,274545,2014,Liquor Laws,
+Milwaukie Business-Industry,274545,2014,Motor Vehicle Theft,
+Milwaukie Business-Industry,274545,2014,Offenses Against Family,
+Milwaukie Business-Industry,274545,2014,Prostitution,
+Milwaukie Business-Industry,274545,2014,Rape,
+Milwaukie Business-Industry,274545,2014,Robbery,
+Milwaukie Business-Industry,274545,2014,Runaway,
+Milwaukie Business-Industry,274545,2014,Sex Offenses,
+Milwaukie Business-Industry,274545,2014,Stolen Property,
+Milwaukie Business-Industry,274545,2014,Trespass,
+Milwaukie Business-Industry,274545,2014,Vandalism,
+Milwaukie Business-Industry,274545,2014,Weapons,
+Montavilla,207230,2004,Aggravated Assault,9
+Montavilla,207230,2004,Arson,
+Montavilla,207230,2004,"Assault, Simple",11
+Montavilla,207230,2004,Burglary,88
+Montavilla,207230,2004,Curfew,2
+Montavilla,207230,2004,Disorderly Conduct,14
+Montavilla,207230,2004,Drugs,51
+Montavilla,207230,2004,DUII,17
+Montavilla,207230,2004,Embezzlement,1
+Montavilla,207230,2004,Forgery,16
+Montavilla,207230,2004,Fraud,24
+Montavilla,207230,2004,Gambling,
+Montavilla,207230,2004,Homicide,
+Montavilla,207230,2004,Kidnap,
+Montavilla,207230,2004,Larceny,212
+Montavilla,207230,2004,Liquor Laws,4
+Montavilla,207230,2004,Motor Vehicle Theft,75
+Montavilla,207230,2004,Offenses Against Family,
+Montavilla,207230,2004,Prostitution,49
+Montavilla,207230,2004,Rape,1
+Montavilla,207230,2004,Robbery,12
+Montavilla,207230,2004,Runaway,
+Montavilla,207230,2004,Sex Offenses,1
+Montavilla,207230,2004,Stolen Property,
+Montavilla,207230,2004,Trespass,43
+Montavilla,207230,2004,Vandalism,43
+Montavilla,207230,2004,Weapons,10
+Montavilla,207230,2005,Aggravated Assault,40
+Montavilla,207230,2005,Arson,1
+Montavilla,207230,2005,"Assault, Simple",59
+Montavilla,207230,2005,Burglary,197
+Montavilla,207230,2005,Curfew,24
+Montavilla,207230,2005,Disorderly Conduct,58
+Montavilla,207230,2005,Drugs,138
+Montavilla,207230,2005,DUII,117
+Montavilla,207230,2005,Embezzlement,7
+Montavilla,207230,2005,Forgery,55
+Montavilla,207230,2005,Fraud,96
+Montavilla,207230,2005,Gambling,
+Montavilla,207230,2005,Homicide,
+Montavilla,207230,2005,Kidnap,3
+Montavilla,207230,2005,Larceny,572
+Montavilla,207230,2005,Liquor Laws,27
+Montavilla,207230,2005,Motor Vehicle Theft,252
+Montavilla,207230,2005,Offenses Against Family,
+Montavilla,207230,2005,Prostitution,207
+Montavilla,207230,2005,Rape,
+Montavilla,207230,2005,Robbery,29
+Montavilla,207230,2005,Runaway,
+Montavilla,207230,2005,Sex Offenses,11
+Montavilla,207230,2005,Stolen Property,2
+Montavilla,207230,2005,Trespass,113
+Montavilla,207230,2005,Vandalism,187
+Montavilla,207230,2005,Weapons,23
+Montavilla,207230,2006,Aggravated Assault,47
+Montavilla,207230,2006,Arson,3
+Montavilla,207230,2006,"Assault, Simple",75
+Montavilla,207230,2006,Burglary,227
+Montavilla,207230,2006,Curfew,15
+Montavilla,207230,2006,Disorderly Conduct,65
+Montavilla,207230,2006,Drugs,145
+Montavilla,207230,2006,DUII,108
+Montavilla,207230,2006,Embezzlement,1
+Montavilla,207230,2006,Forgery,21
+Montavilla,207230,2006,Fraud,96
+Montavilla,207230,2006,Gambling,
+Montavilla,207230,2006,Homicide,1
+Montavilla,207230,2006,Kidnap,1
+Montavilla,207230,2006,Larceny,459
+Montavilla,207230,2006,Liquor Laws,37
+Montavilla,207230,2006,Motor Vehicle Theft,145
+Montavilla,207230,2006,Offenses Against Family,1
+Montavilla,207230,2006,Prostitution,215
+Montavilla,207230,2006,Rape,1
+Montavilla,207230,2006,Robbery,60
+Montavilla,207230,2006,Runaway,1
+Montavilla,207230,2006,Sex Offenses,6
+Montavilla,207230,2006,Stolen Property,4
+Montavilla,207230,2006,Trespass,95
+Montavilla,207230,2006,Vandalism,212
+Montavilla,207230,2006,Weapons,15
+Montavilla,207230,2007,Aggravated Assault,31
+Montavilla,207230,2007,Arson,3
+Montavilla,207230,2007,"Assault, Simple",54
+Montavilla,207230,2007,Burglary,180
+Montavilla,207230,2007,Curfew,8
+Montavilla,207230,2007,Disorderly Conduct,66
+Montavilla,207230,2007,Drugs,124
+Montavilla,207230,2007,DUII,84
+Montavilla,207230,2007,Embezzlement,4
+Montavilla,207230,2007,Forgery,37
+Montavilla,207230,2007,Fraud,92
+Montavilla,207230,2007,Gambling,
+Montavilla,207230,2007,Homicide,
+Montavilla,207230,2007,Kidnap,
+Montavilla,207230,2007,Larceny,569
+Montavilla,207230,2007,Liquor Laws,66
+Montavilla,207230,2007,Motor Vehicle Theft,184
+Montavilla,207230,2007,Offenses Against Family,
+Montavilla,207230,2007,Prostitution,114
+Montavilla,207230,2007,Rape,2
+Montavilla,207230,2007,Robbery,34
+Montavilla,207230,2007,Runaway,
+Montavilla,207230,2007,Sex Offenses,
+Montavilla,207230,2007,Stolen Property,4
+Montavilla,207230,2007,Trespass,83
+Montavilla,207230,2007,Vandalism,192
+Montavilla,207230,2007,Weapons,17
+Montavilla,207230,2008,Aggravated Assault,55
+Montavilla,207230,2008,Arson,3
+Montavilla,207230,2008,"Assault, Simple",58
+Montavilla,207230,2008,Burglary,127
+Montavilla,207230,2008,Curfew,11
+Montavilla,207230,2008,Disorderly Conduct,48
+Montavilla,207230,2008,Drugs,98
+Montavilla,207230,2008,DUII,70
+Montavilla,207230,2008,Embezzlement,5
+Montavilla,207230,2008,Forgery,44
+Montavilla,207230,2008,Fraud,71
+Montavilla,207230,2008,Gambling,
+Montavilla,207230,2008,Homicide,3
+Montavilla,207230,2008,Kidnap,1
+Montavilla,207230,2008,Larceny,434
+Montavilla,207230,2008,Liquor Laws,67
+Montavilla,207230,2008,Motor Vehicle Theft,121
+Montavilla,207230,2008,Offenses Against Family,1
+Montavilla,207230,2008,Prostitution,215
+Montavilla,207230,2008,Rape,2
+Montavilla,207230,2008,Robbery,31
+Montavilla,207230,2008,Runaway,3
+Montavilla,207230,2008,Sex Offenses,3
+Montavilla,207230,2008,Stolen Property,1
+Montavilla,207230,2008,Trespass,70
+Montavilla,207230,2008,Vandalism,159
+Montavilla,207230,2008,Weapons,15
+Montavilla,207230,2009,Aggravated Assault,32
+Montavilla,207230,2009,Arson,
+Montavilla,207230,2009,"Assault, Simple",69
+Montavilla,207230,2009,Burglary,117
+Montavilla,207230,2009,Curfew,8
+Montavilla,207230,2009,Disorderly Conduct,45
+Montavilla,207230,2009,Drugs,72
+Montavilla,207230,2009,DUII,58
+Montavilla,207230,2009,Embezzlement,5
+Montavilla,207230,2009,Forgery,17
+Montavilla,207230,2009,Fraud,54
+Montavilla,207230,2009,Gambling,
+Montavilla,207230,2009,Homicide,
+Montavilla,207230,2009,Kidnap,
+Montavilla,207230,2009,Larceny,310
+Montavilla,207230,2009,Liquor Laws,34
+Montavilla,207230,2009,Motor Vehicle Theft,111
+Montavilla,207230,2009,Offenses Against Family,
+Montavilla,207230,2009,Prostitution,131
+Montavilla,207230,2009,Rape,2
+Montavilla,207230,2009,Robbery,20
+Montavilla,207230,2009,Runaway,1
+Montavilla,207230,2009,Sex Offenses,1
+Montavilla,207230,2009,Stolen Property,7
+Montavilla,207230,2009,Trespass,60
+Montavilla,207230,2009,Vandalism,128
+Montavilla,207230,2009,Weapons,6
+Montavilla,207230,2010,Aggravated Assault,30
+Montavilla,207230,2010,Arson,
+Montavilla,207230,2010,"Assault, Simple",49
+Montavilla,207230,2010,Burglary,132
+Montavilla,207230,2010,Curfew,1
+Montavilla,207230,2010,Disorderly Conduct,50
+Montavilla,207230,2010,Drugs,41
+Montavilla,207230,2010,DUII,61
+Montavilla,207230,2010,Embezzlement,1
+Montavilla,207230,2010,Forgery,37
+Montavilla,207230,2010,Fraud,40
+Montavilla,207230,2010,Gambling,
+Montavilla,207230,2010,Homicide,2
+Montavilla,207230,2010,Kidnap,
+Montavilla,207230,2010,Larceny,439
+Montavilla,207230,2010,Liquor Laws,44
+Montavilla,207230,2010,Motor Vehicle Theft,150
+Montavilla,207230,2010,Offenses Against Family,
+Montavilla,207230,2010,Prostitution,63
+Montavilla,207230,2010,Rape,1
+Montavilla,207230,2010,Robbery,25
+Montavilla,207230,2010,Runaway,
+Montavilla,207230,2010,Sex Offenses,3
+Montavilla,207230,2010,Stolen Property,1
+Montavilla,207230,2010,Trespass,50
+Montavilla,207230,2010,Vandalism,148
+Montavilla,207230,2010,Weapons,4
+Montavilla,207230,2011,Aggravated Assault,55
+Montavilla,207230,2011,Arson,1
+Montavilla,207230,2011,"Assault, Simple",49
+Montavilla,207230,2011,Burglary,151
+Montavilla,207230,2011,Curfew,
+Montavilla,207230,2011,Disorderly Conduct,46
+Montavilla,207230,2011,Drugs,35
+Montavilla,207230,2011,DUII,58
+Montavilla,207230,2011,Embezzlement,8
+Montavilla,207230,2011,Forgery,46
+Montavilla,207230,2011,Fraud,43
+Montavilla,207230,2011,Gambling,
+Montavilla,207230,2011,Homicide,
+Montavilla,207230,2011,Kidnap,
+Montavilla,207230,2011,Larceny,471
+Montavilla,207230,2011,Liquor Laws,33
+Montavilla,207230,2011,Motor Vehicle Theft,101
+Montavilla,207230,2011,Offenses Against Family,
+Montavilla,207230,2011,Prostitution,84
+Montavilla,207230,2011,Rape,
+Montavilla,207230,2011,Robbery,26
+Montavilla,207230,2011,Runaway,
+Montavilla,207230,2011,Sex Offenses,1
+Montavilla,207230,2011,Stolen Property,3
+Montavilla,207230,2011,Trespass,61
+Montavilla,207230,2011,Vandalism,149
+Montavilla,207230,2011,Weapons,6
+Montavilla,207230,2012,Aggravated Assault,33
+Montavilla,207230,2012,Arson,
+Montavilla,207230,2012,"Assault, Simple",45
+Montavilla,207230,2012,Burglary,157
+Montavilla,207230,2012,Curfew,
+Montavilla,207230,2012,Disorderly Conduct,61
+Montavilla,207230,2012,Drugs,35
+Montavilla,207230,2012,DUII,81
+Montavilla,207230,2012,Embezzlement,4
+Montavilla,207230,2012,Forgery,14
+Montavilla,207230,2012,Fraud,46
+Montavilla,207230,2012,Gambling,
+Montavilla,207230,2012,Homicide,1
+Montavilla,207230,2012,Kidnap,1
+Montavilla,207230,2012,Larceny,418
+Montavilla,207230,2012,Liquor Laws,22
+Montavilla,207230,2012,Motor Vehicle Theft,113
+Montavilla,207230,2012,Offenses Against Family,
+Montavilla,207230,2012,Prostitution,36
+Montavilla,207230,2012,Rape,1
+Montavilla,207230,2012,Robbery,20
+Montavilla,207230,2012,Runaway,
+Montavilla,207230,2012,Sex Offenses,1
+Montavilla,207230,2012,Stolen Property,1
+Montavilla,207230,2012,Trespass,52
+Montavilla,207230,2012,Vandalism,128
+Montavilla,207230,2012,Weapons,15
+Montavilla,207230,2013,Aggravated Assault,24
+Montavilla,207230,2013,Arson,1
+Montavilla,207230,2013,"Assault, Simple",64
+Montavilla,207230,2013,Burglary,130
+Montavilla,207230,2013,Curfew,
+Montavilla,207230,2013,Disorderly Conduct,46
+Montavilla,207230,2013,Drugs,67
+Montavilla,207230,2013,DUII,50
+Montavilla,207230,2013,Embezzlement,3
+Montavilla,207230,2013,Forgery,18
+Montavilla,207230,2013,Fraud,52
+Montavilla,207230,2013,Gambling,
+Montavilla,207230,2013,Homicide,
+Montavilla,207230,2013,Kidnap,1
+Montavilla,207230,2013,Larceny,402
+Montavilla,207230,2013,Liquor Laws,20
+Montavilla,207230,2013,Motor Vehicle Theft,87
+Montavilla,207230,2013,Offenses Against Family,
+Montavilla,207230,2013,Prostitution,25
+Montavilla,207230,2013,Rape,
+Montavilla,207230,2013,Robbery,27
+Montavilla,207230,2013,Runaway,1
+Montavilla,207230,2013,Sex Offenses,2
+Montavilla,207230,2013,Stolen Property,1
+Montavilla,207230,2013,Trespass,31
+Montavilla,207230,2013,Vandalism,145
+Montavilla,207230,2013,Weapons,5
+Montavilla,207230,2014,Aggravated Assault,28
+Montavilla,207230,2014,Arson,1
+Montavilla,207230,2014,"Assault, Simple",47
+Montavilla,207230,2014,Burglary,135
+Montavilla,207230,2014,Curfew,
+Montavilla,207230,2014,Disorderly Conduct,43
+Montavilla,207230,2014,Drugs,51
+Montavilla,207230,2014,DUII,40
+Montavilla,207230,2014,Embezzlement,2
+Montavilla,207230,2014,Forgery,10
+Montavilla,207230,2014,Fraud,39
+Montavilla,207230,2014,Gambling,
+Montavilla,207230,2014,Homicide,
+Montavilla,207230,2014,Kidnap,1
+Montavilla,207230,2014,Larceny,426
+Montavilla,207230,2014,Liquor Laws,14
+Montavilla,207230,2014,Motor Vehicle Theft,113
+Montavilla,207230,2014,Offenses Against Family,
+Montavilla,207230,2014,Prostitution,16
+Montavilla,207230,2014,Rape,
+Montavilla,207230,2014,Robbery,23
+Montavilla,207230,2014,Runaway,
+Montavilla,207230,2014,Sex Offenses,
+Montavilla,207230,2014,Stolen Property,1
+Montavilla,207230,2014,Trespass,44
+Montavilla,207230,2014,Vandalism,137
+Montavilla,207230,2014,Weapons,7
+Mount Scott,274604,2004,Aggravated Assault,12
+Mount Scott,274604,2004,Arson,
+Mount Scott,274604,2004,"Assault, Simple",17
+Mount Scott,274604,2004,Burglary,40
+Mount Scott,274604,2004,Curfew,
+Mount Scott,274604,2004,Disorderly Conduct,8
+Mount Scott,274604,2004,Drugs,29
+Mount Scott,274604,2004,DUII,7
+Mount Scott,274604,2004,Embezzlement,2
+Mount Scott,274604,2004,Forgery,10
+Mount Scott,274604,2004,Fraud,13
+Mount Scott,274604,2004,Gambling,
+Mount Scott,274604,2004,Homicide,
+Mount Scott,274604,2004,Kidnap,
+Mount Scott,274604,2004,Larceny,76
+Mount Scott,274604,2004,Liquor Laws,4
+Mount Scott,274604,2004,Motor Vehicle Theft,20
+Mount Scott,274604,2004,Offenses Against Family,
+Mount Scott,274604,2004,Prostitution,5
+Mount Scott,274604,2004,Rape,1
+Mount Scott,274604,2004,Robbery,5
+Mount Scott,274604,2004,Runaway,
+Mount Scott,274604,2004,Sex Offenses,1
+Mount Scott,274604,2004,Stolen Property,
+Mount Scott,274604,2004,Trespass,6
+Mount Scott,274604,2004,Vandalism,28
+Mount Scott,274604,2004,Weapons,3
+Mount Scott,274604,2005,Aggravated Assault,23
+Mount Scott,274604,2005,Arson,
+Mount Scott,274604,2005,"Assault, Simple",33
+Mount Scott,274604,2005,Burglary,79
+Mount Scott,274604,2005,Curfew,2
+Mount Scott,274604,2005,Disorderly Conduct,23
+Mount Scott,274604,2005,Drugs,96
+Mount Scott,274604,2005,DUII,26
+Mount Scott,274604,2005,Embezzlement,1
+Mount Scott,274604,2005,Forgery,11
+Mount Scott,274604,2005,Fraud,52
+Mount Scott,274604,2005,Gambling,
+Mount Scott,274604,2005,Homicide,
+Mount Scott,274604,2005,Kidnap,1
+Mount Scott,274604,2005,Larceny,254
+Mount Scott,274604,2005,Liquor Laws,4
+Mount Scott,274604,2005,Motor Vehicle Theft,93
+Mount Scott,274604,2005,Offenses Against Family,
+Mount Scott,274604,2005,Prostitution,4
+Mount Scott,274604,2005,Rape,3
+Mount Scott,274604,2005,Robbery,15
+Mount Scott,274604,2005,Runaway,
+Mount Scott,274604,2005,Sex Offenses,2
+Mount Scott,274604,2005,Stolen Property,2
+Mount Scott,274604,2005,Trespass,40
+Mount Scott,274604,2005,Vandalism,107
+Mount Scott,274604,2005,Weapons,6
+Mount Scott,274604,2006,Aggravated Assault,18
+Mount Scott,274604,2006,Arson,
+Mount Scott,274604,2006,"Assault, Simple",34
+Mount Scott,274604,2006,Burglary,71
+Mount Scott,274604,2006,Curfew,
+Mount Scott,274604,2006,Disorderly Conduct,13
+Mount Scott,274604,2006,Drugs,71
+Mount Scott,274604,2006,DUII,29
+Mount Scott,274604,2006,Embezzlement,1
+Mount Scott,274604,2006,Forgery,7
+Mount Scott,274604,2006,Fraud,33
+Mount Scott,274604,2006,Gambling,
+Mount Scott,274604,2006,Homicide,2
+Mount Scott,274604,2006,Kidnap,2
+Mount Scott,274604,2006,Larceny,196
+Mount Scott,274604,2006,Liquor Laws,16
+Mount Scott,274604,2006,Motor Vehicle Theft,70
+Mount Scott,274604,2006,Offenses Against Family,
+Mount Scott,274604,2006,Prostitution,2
+Mount Scott,274604,2006,Rape,
+Mount Scott,274604,2006,Robbery,13
+Mount Scott,274604,2006,Runaway,
+Mount Scott,274604,2006,Sex Offenses,3
+Mount Scott,274604,2006,Stolen Property,
+Mount Scott,274604,2006,Trespass,31
+Mount Scott,274604,2006,Vandalism,115
+Mount Scott,274604,2006,Weapons,7
+Mount Scott,274604,2007,Aggravated Assault,17
+Mount Scott,274604,2007,Arson,
+Mount Scott,274604,2007,"Assault, Simple",35
+Mount Scott,274604,2007,Burglary,88
+Mount Scott,274604,2007,Curfew,1
+Mount Scott,274604,2007,Disorderly Conduct,37
+Mount Scott,274604,2007,Drugs,57
+Mount Scott,274604,2007,DUII,25
+Mount Scott,274604,2007,Embezzlement,
+Mount Scott,274604,2007,Forgery,6
+Mount Scott,274604,2007,Fraud,36
+Mount Scott,274604,2007,Gambling,
+Mount Scott,274604,2007,Homicide,
+Mount Scott,274604,2007,Kidnap,
+Mount Scott,274604,2007,Larceny,253
+Mount Scott,274604,2007,Liquor Laws,17
+Mount Scott,274604,2007,Motor Vehicle Theft,70
+Mount Scott,274604,2007,Offenses Against Family,
+Mount Scott,274604,2007,Prostitution,3
+Mount Scott,274604,2007,Rape,
+Mount Scott,274604,2007,Robbery,12
+Mount Scott,274604,2007,Runaway,
+Mount Scott,274604,2007,Sex Offenses,2
+Mount Scott,274604,2007,Stolen Property,
+Mount Scott,274604,2007,Trespass,23
+Mount Scott,274604,2007,Vandalism,107
+Mount Scott,274604,2007,Weapons,7
+Mount Scott,274604,2008,Aggravated Assault,16
+Mount Scott,274604,2008,Arson,
+Mount Scott,274604,2008,"Assault, Simple",37
+Mount Scott,274604,2008,Burglary,51
+Mount Scott,274604,2008,Curfew,2
+Mount Scott,274604,2008,Disorderly Conduct,33
+Mount Scott,274604,2008,Drugs,37
+Mount Scott,274604,2008,DUII,23
+Mount Scott,274604,2008,Embezzlement,
+Mount Scott,274604,2008,Forgery,6
+Mount Scott,274604,2008,Fraud,25
+Mount Scott,274604,2008,Gambling,
+Mount Scott,274604,2008,Homicide,
+Mount Scott,274604,2008,Kidnap,
+Mount Scott,274604,2008,Larceny,174
+Mount Scott,274604,2008,Liquor Laws,26
+Mount Scott,274604,2008,Motor Vehicle Theft,56
+Mount Scott,274604,2008,Offenses Against Family,
+Mount Scott,274604,2008,Prostitution,10
+Mount Scott,274604,2008,Rape,
+Mount Scott,274604,2008,Robbery,13
+Mount Scott,274604,2008,Runaway,
+Mount Scott,274604,2008,Sex Offenses,
+Mount Scott,274604,2008,Stolen Property,3
+Mount Scott,274604,2008,Trespass,19
+Mount Scott,274604,2008,Vandalism,61
+Mount Scott,274604,2008,Weapons,2
+Mount Scott,274604,2009,Aggravated Assault,19
+Mount Scott,274604,2009,Arson,
+Mount Scott,274604,2009,"Assault, Simple",34
+Mount Scott,274604,2009,Burglary,55
+Mount Scott,274604,2009,Curfew,2
+Mount Scott,274604,2009,Disorderly Conduct,31
+Mount Scott,274604,2009,Drugs,22
+Mount Scott,274604,2009,DUII,19
+Mount Scott,274604,2009,Embezzlement,
+Mount Scott,274604,2009,Forgery,7
+Mount Scott,274604,2009,Fraud,19
+Mount Scott,274604,2009,Gambling,
+Mount Scott,274604,2009,Homicide,
+Mount Scott,274604,2009,Kidnap,
+Mount Scott,274604,2009,Larceny,147
+Mount Scott,274604,2009,Liquor Laws,25
+Mount Scott,274604,2009,Motor Vehicle Theft,46
+Mount Scott,274604,2009,Offenses Against Family,
+Mount Scott,274604,2009,Prostitution,9
+Mount Scott,274604,2009,Rape,1
+Mount Scott,274604,2009,Robbery,12
+Mount Scott,274604,2009,Runaway,
+Mount Scott,274604,2009,Sex Offenses,2
+Mount Scott,274604,2009,Stolen Property,
+Mount Scott,274604,2009,Trespass,27
+Mount Scott,274604,2009,Vandalism,62
+Mount Scott,274604,2009,Weapons,1
+Mount Scott,274604,2010,Aggravated Assault,14
+Mount Scott,274604,2010,Arson,2
+Mount Scott,274604,2010,"Assault, Simple",23
+Mount Scott,274604,2010,Burglary,68
+Mount Scott,274604,2010,Curfew,1
+Mount Scott,274604,2010,Disorderly Conduct,24
+Mount Scott,274604,2010,Drugs,12
+Mount Scott,274604,2010,DUII,13
+Mount Scott,274604,2010,Embezzlement,1
+Mount Scott,274604,2010,Forgery,7
+Mount Scott,274604,2010,Fraud,10
+Mount Scott,274604,2010,Gambling,
+Mount Scott,274604,2010,Homicide,3
+Mount Scott,274604,2010,Kidnap,
+Mount Scott,274604,2010,Larceny,196
+Mount Scott,274604,2010,Liquor Laws,6
+Mount Scott,274604,2010,Motor Vehicle Theft,49
+Mount Scott,274604,2010,Offenses Against Family,
+Mount Scott,274604,2010,Prostitution,2
+Mount Scott,274604,2010,Rape,2
+Mount Scott,274604,2010,Robbery,7
+Mount Scott,274604,2010,Runaway,
+Mount Scott,274604,2010,Sex Offenses,2
+Mount Scott,274604,2010,Stolen Property,
+Mount Scott,274604,2010,Trespass,24
+Mount Scott,274604,2010,Vandalism,87
+Mount Scott,274604,2010,Weapons,1
+Mount Scott,274604,2011,Aggravated Assault,8
+Mount Scott,274604,2011,Arson,1
+Mount Scott,274604,2011,"Assault, Simple",23
+Mount Scott,274604,2011,Burglary,85
+Mount Scott,274604,2011,Curfew,
+Mount Scott,274604,2011,Disorderly Conduct,17
+Mount Scott,274604,2011,Drugs,15
+Mount Scott,274604,2011,DUII,18
+Mount Scott,274604,2011,Embezzlement,3
+Mount Scott,274604,2011,Forgery,4
+Mount Scott,274604,2011,Fraud,15
+Mount Scott,274604,2011,Gambling,
+Mount Scott,274604,2011,Homicide,
+Mount Scott,274604,2011,Kidnap,
+Mount Scott,274604,2011,Larceny,219
+Mount Scott,274604,2011,Liquor Laws,8
+Mount Scott,274604,2011,Motor Vehicle Theft,70
+Mount Scott,274604,2011,Offenses Against Family,
+Mount Scott,274604,2011,Prostitution,4
+Mount Scott,274604,2011,Rape,
+Mount Scott,274604,2011,Robbery,11
+Mount Scott,274604,2011,Runaway,
+Mount Scott,274604,2011,Sex Offenses,3
+Mount Scott,274604,2011,Stolen Property,1
+Mount Scott,274604,2011,Trespass,21
+Mount Scott,274604,2011,Vandalism,63
+Mount Scott,274604,2011,Weapons,3
+Mount Scott,274604,2012,Aggravated Assault,19
+Mount Scott,274604,2012,Arson,
+Mount Scott,274604,2012,"Assault, Simple",27
+Mount Scott,274604,2012,Burglary,80
+Mount Scott,274604,2012,Curfew,
+Mount Scott,274604,2012,Disorderly Conduct,29
+Mount Scott,274604,2012,Drugs,27
+Mount Scott,274604,2012,DUII,19
+Mount Scott,274604,2012,Embezzlement,
+Mount Scott,274604,2012,Forgery,6
+Mount Scott,274604,2012,Fraud,14
+Mount Scott,274604,2012,Gambling,
+Mount Scott,274604,2012,Homicide,1
+Mount Scott,274604,2012,Kidnap,
+Mount Scott,274604,2012,Larceny,271
+Mount Scott,274604,2012,Liquor Laws,7
+Mount Scott,274604,2012,Motor Vehicle Theft,65
+Mount Scott,274604,2012,Offenses Against Family,
+Mount Scott,274604,2012,Prostitution,1
+Mount Scott,274604,2012,Rape,
+Mount Scott,274604,2012,Robbery,12
+Mount Scott,274604,2012,Runaway,1
+Mount Scott,274604,2012,Sex Offenses,3
+Mount Scott,274604,2012,Stolen Property,1
+Mount Scott,274604,2012,Trespass,26
+Mount Scott,274604,2012,Vandalism,56
+Mount Scott,274604,2012,Weapons,3
+Mount Scott,274604,2013,Aggravated Assault,11
+Mount Scott,274604,2013,Arson,
+Mount Scott,274604,2013,"Assault, Simple",28
+Mount Scott,274604,2013,Burglary,60
+Mount Scott,274604,2013,Curfew,
+Mount Scott,274604,2013,Disorderly Conduct,34
+Mount Scott,274604,2013,Drugs,28
+Mount Scott,274604,2013,DUII,15
+Mount Scott,274604,2013,Embezzlement,1
+Mount Scott,274604,2013,Forgery,11
+Mount Scott,274604,2013,Fraud,17
+Mount Scott,274604,2013,Gambling,
+Mount Scott,274604,2013,Homicide,
+Mount Scott,274604,2013,Kidnap,
+Mount Scott,274604,2013,Larceny,253
+Mount Scott,274604,2013,Liquor Laws,8
+Mount Scott,274604,2013,Motor Vehicle Theft,53
+Mount Scott,274604,2013,Offenses Against Family,
+Mount Scott,274604,2013,Prostitution,1
+Mount Scott,274604,2013,Rape,2
+Mount Scott,274604,2013,Robbery,8
+Mount Scott,274604,2013,Runaway,
+Mount Scott,274604,2013,Sex Offenses,1
+Mount Scott,274604,2013,Stolen Property,1
+Mount Scott,274604,2013,Trespass,22
+Mount Scott,274604,2013,Vandalism,66
+Mount Scott,274604,2013,Weapons,5
+Mount Scott,274604,2014,Aggravated Assault,12
+Mount Scott,274604,2014,Arson,2
+Mount Scott,274604,2014,"Assault, Simple",24
+Mount Scott,274604,2014,Burglary,80
+Mount Scott,274604,2014,Curfew,
+Mount Scott,274604,2014,Disorderly Conduct,21
+Mount Scott,274604,2014,Drugs,14
+Mount Scott,274604,2014,DUII,12
+Mount Scott,274604,2014,Embezzlement,1
+Mount Scott,274604,2014,Forgery,5
+Mount Scott,274604,2014,Fraud,15
+Mount Scott,274604,2014,Gambling,
+Mount Scott,274604,2014,Homicide,
+Mount Scott,274604,2014,Kidnap,
+Mount Scott,274604,2014,Larceny,268
+Mount Scott,274604,2014,Liquor Laws,1
+Mount Scott,274604,2014,Motor Vehicle Theft,64
+Mount Scott,274604,2014,Offenses Against Family,
+Mount Scott,274604,2014,Prostitution,
+Mount Scott,274604,2014,Rape,
+Mount Scott,274604,2014,Robbery,9
+Mount Scott,274604,2014,Runaway,
+Mount Scott,274604,2014,Sex Offenses,
+Mount Scott,274604,2014,Stolen Property,1
+Mount Scott,274604,2014,Trespass,22
+Mount Scott,274604,2014,Vandalism,38
+Mount Scott,274604,2014,Weapons,5
+Mount Tabor,274605,2004,Aggravated Assault,3
+Mount Tabor,274605,2004,Arson,
+Mount Tabor,274605,2004,"Assault, Simple",5
+Mount Tabor,274605,2004,Burglary,26
+Mount Tabor,274605,2004,Curfew,
+Mount Tabor,274605,2004,Disorderly Conduct,3
+Mount Tabor,274605,2004,Drugs,5
+Mount Tabor,274605,2004,DUII,6
+Mount Tabor,274605,2004,Embezzlement,
+Mount Tabor,274605,2004,Forgery,2
+Mount Tabor,274605,2004,Fraud,5
+Mount Tabor,274605,2004,Gambling,
+Mount Tabor,274605,2004,Homicide,
+Mount Tabor,274605,2004,Kidnap,
+Mount Tabor,274605,2004,Larceny,87
+Mount Tabor,274605,2004,Liquor Laws,5
+Mount Tabor,274605,2004,Motor Vehicle Theft,15
+Mount Tabor,274605,2004,Offenses Against Family,
+Mount Tabor,274605,2004,Prostitution,
+Mount Tabor,274605,2004,Rape,
+Mount Tabor,274605,2004,Robbery,2
+Mount Tabor,274605,2004,Runaway,
+Mount Tabor,274605,2004,Sex Offenses,
+Mount Tabor,274605,2004,Stolen Property,
+Mount Tabor,274605,2004,Trespass,4
+Mount Tabor,274605,2004,Vandalism,18
+Mount Tabor,274605,2004,Weapons,1
+Mount Tabor,274605,2005,Aggravated Assault,9
+Mount Tabor,274605,2005,Arson,1
+Mount Tabor,274605,2005,"Assault, Simple",15
+Mount Tabor,274605,2005,Burglary,92
+Mount Tabor,274605,2005,Curfew,2
+Mount Tabor,274605,2005,Disorderly Conduct,13
+Mount Tabor,274605,2005,Drugs,28
+Mount Tabor,274605,2005,DUII,16
+Mount Tabor,274605,2005,Embezzlement,1
+Mount Tabor,274605,2005,Forgery,12
+Mount Tabor,274605,2005,Fraud,28
+Mount Tabor,274605,2005,Gambling,
+Mount Tabor,274605,2005,Homicide,
+Mount Tabor,274605,2005,Kidnap,
+Mount Tabor,274605,2005,Larceny,232
+Mount Tabor,274605,2005,Liquor Laws,10
+Mount Tabor,274605,2005,Motor Vehicle Theft,67
+Mount Tabor,274605,2005,Offenses Against Family,1
+Mount Tabor,274605,2005,Prostitution,2
+Mount Tabor,274605,2005,Rape,1
+Mount Tabor,274605,2005,Robbery,1
+Mount Tabor,274605,2005,Runaway,1
+Mount Tabor,274605,2005,Sex Offenses,5
+Mount Tabor,274605,2005,Stolen Property,1
+Mount Tabor,274605,2005,Trespass,8
+Mount Tabor,274605,2005,Vandalism,60
+Mount Tabor,274605,2005,Weapons,3
+Mount Tabor,274605,2006,Aggravated Assault,8
+Mount Tabor,274605,2006,Arson,
+Mount Tabor,274605,2006,"Assault, Simple",14
+Mount Tabor,274605,2006,Burglary,67
+Mount Tabor,274605,2006,Curfew,
+Mount Tabor,274605,2006,Disorderly Conduct,14
+Mount Tabor,274605,2006,Drugs,23
+Mount Tabor,274605,2006,DUII,18
+Mount Tabor,274605,2006,Embezzlement,1
+Mount Tabor,274605,2006,Forgery,6
+Mount Tabor,274605,2006,Fraud,21
+Mount Tabor,274605,2006,Gambling,
+Mount Tabor,274605,2006,Homicide,
+Mount Tabor,274605,2006,Kidnap,
+Mount Tabor,274605,2006,Larceny,260
+Mount Tabor,274605,2006,Liquor Laws,7
+Mount Tabor,274605,2006,Motor Vehicle Theft,54
+Mount Tabor,274605,2006,Offenses Against Family,
+Mount Tabor,274605,2006,Prostitution,
+Mount Tabor,274605,2006,Rape,2
+Mount Tabor,274605,2006,Robbery,8
+Mount Tabor,274605,2006,Runaway,
+Mount Tabor,274605,2006,Sex Offenses,1
+Mount Tabor,274605,2006,Stolen Property,
+Mount Tabor,274605,2006,Trespass,12
+Mount Tabor,274605,2006,Vandalism,63
+Mount Tabor,274605,2006,Weapons,
+Mount Tabor,274605,2007,Aggravated Assault,10
+Mount Tabor,274605,2007,Arson,4
+Mount Tabor,274605,2007,"Assault, Simple",15
+Mount Tabor,274605,2007,Burglary,47
+Mount Tabor,274605,2007,Curfew,
+Mount Tabor,274605,2007,Disorderly Conduct,20
+Mount Tabor,274605,2007,Drugs,14
+Mount Tabor,274605,2007,DUII,29
+Mount Tabor,274605,2007,Embezzlement,
+Mount Tabor,274605,2007,Forgery,5
+Mount Tabor,274605,2007,Fraud,18
+Mount Tabor,274605,2007,Gambling,
+Mount Tabor,274605,2007,Homicide,
+Mount Tabor,274605,2007,Kidnap,
+Mount Tabor,274605,2007,Larceny,257
+Mount Tabor,274605,2007,Liquor Laws,12
+Mount Tabor,274605,2007,Motor Vehicle Theft,64
+Mount Tabor,274605,2007,Offenses Against Family,
+Mount Tabor,274605,2007,Prostitution,
+Mount Tabor,274605,2007,Rape,
+Mount Tabor,274605,2007,Robbery,9
+Mount Tabor,274605,2007,Runaway,
+Mount Tabor,274605,2007,Sex Offenses,
+Mount Tabor,274605,2007,Stolen Property,
+Mount Tabor,274605,2007,Trespass,4
+Mount Tabor,274605,2007,Vandalism,77
+Mount Tabor,274605,2007,Weapons,1
+Mount Tabor,274605,2008,Aggravated Assault,4
+Mount Tabor,274605,2008,Arson,
+Mount Tabor,274605,2008,"Assault, Simple",14
+Mount Tabor,274605,2008,Burglary,47
+Mount Tabor,274605,2008,Curfew,
+Mount Tabor,274605,2008,Disorderly Conduct,12
+Mount Tabor,274605,2008,Drugs,10
+Mount Tabor,274605,2008,DUII,14
+Mount Tabor,274605,2008,Embezzlement,2
+Mount Tabor,274605,2008,Forgery,8
+Mount Tabor,274605,2008,Fraud,11
+Mount Tabor,274605,2008,Gambling,
+Mount Tabor,274605,2008,Homicide,
+Mount Tabor,274605,2008,Kidnap,
+Mount Tabor,274605,2008,Larceny,201
+Mount Tabor,274605,2008,Liquor Laws,4
+Mount Tabor,274605,2008,Motor Vehicle Theft,37
+Mount Tabor,274605,2008,Offenses Against Family,
+Mount Tabor,274605,2008,Prostitution,2
+Mount Tabor,274605,2008,Rape,
+Mount Tabor,274605,2008,Robbery,10
+Mount Tabor,274605,2008,Runaway,
+Mount Tabor,274605,2008,Sex Offenses,1
+Mount Tabor,274605,2008,Stolen Property,
+Mount Tabor,274605,2008,Trespass,12
+Mount Tabor,274605,2008,Vandalism,50
+Mount Tabor,274605,2008,Weapons,
+Mount Tabor,274605,2009,Aggravated Assault,3
+Mount Tabor,274605,2009,Arson,
+Mount Tabor,274605,2009,"Assault, Simple",9
+Mount Tabor,274605,2009,Burglary,55
+Mount Tabor,274605,2009,Curfew,
+Mount Tabor,274605,2009,Disorderly Conduct,13
+Mount Tabor,274605,2009,Drugs,13
+Mount Tabor,274605,2009,DUII,23
+Mount Tabor,274605,2009,Embezzlement,3
+Mount Tabor,274605,2009,Forgery,6
+Mount Tabor,274605,2009,Fraud,18
+Mount Tabor,274605,2009,Gambling,
+Mount Tabor,274605,2009,Homicide,
+Mount Tabor,274605,2009,Kidnap,
+Mount Tabor,274605,2009,Larceny,182
+Mount Tabor,274605,2009,Liquor Laws,4
+Mount Tabor,274605,2009,Motor Vehicle Theft,36
+Mount Tabor,274605,2009,Offenses Against Family,
+Mount Tabor,274605,2009,Prostitution,2
+Mount Tabor,274605,2009,Rape,
+Mount Tabor,274605,2009,Robbery,1
+Mount Tabor,274605,2009,Runaway,
+Mount Tabor,274605,2009,Sex Offenses,1
+Mount Tabor,274605,2009,Stolen Property,
+Mount Tabor,274605,2009,Trespass,13
+Mount Tabor,274605,2009,Vandalism,49
+Mount Tabor,274605,2009,Weapons,
+Mount Tabor,274605,2010,Aggravated Assault,11
+Mount Tabor,274605,2010,Arson,
+Mount Tabor,274605,2010,"Assault, Simple",10
+Mount Tabor,274605,2010,Burglary,54
+Mount Tabor,274605,2010,Curfew,
+Mount Tabor,274605,2010,Disorderly Conduct,13
+Mount Tabor,274605,2010,Drugs,8
+Mount Tabor,274605,2010,DUII,18
+Mount Tabor,274605,2010,Embezzlement,2
+Mount Tabor,274605,2010,Forgery,7
+Mount Tabor,274605,2010,Fraud,9
+Mount Tabor,274605,2010,Gambling,
+Mount Tabor,274605,2010,Homicide,
+Mount Tabor,274605,2010,Kidnap,
+Mount Tabor,274605,2010,Larceny,252
+Mount Tabor,274605,2010,Liquor Laws,1
+Mount Tabor,274605,2010,Motor Vehicle Theft,39
+Mount Tabor,274605,2010,Offenses Against Family,
+Mount Tabor,274605,2010,Prostitution,
+Mount Tabor,274605,2010,Rape,1
+Mount Tabor,274605,2010,Robbery,6
+Mount Tabor,274605,2010,Runaway,
+Mount Tabor,274605,2010,Sex Offenses,2
+Mount Tabor,274605,2010,Stolen Property,1
+Mount Tabor,274605,2010,Trespass,14
+Mount Tabor,274605,2010,Vandalism,53
+Mount Tabor,274605,2010,Weapons,
+Mount Tabor,274605,2011,Aggravated Assault,1
+Mount Tabor,274605,2011,Arson,
+Mount Tabor,274605,2011,"Assault, Simple",12
+Mount Tabor,274605,2011,Burglary,63
+Mount Tabor,274605,2011,Curfew,
+Mount Tabor,274605,2011,Disorderly Conduct,10
+Mount Tabor,274605,2011,Drugs,7
+Mount Tabor,274605,2011,DUII,16
+Mount Tabor,274605,2011,Embezzlement,2
+Mount Tabor,274605,2011,Forgery,13
+Mount Tabor,274605,2011,Fraud,12
+Mount Tabor,274605,2011,Gambling,
+Mount Tabor,274605,2011,Homicide,
+Mount Tabor,274605,2011,Kidnap,
+Mount Tabor,274605,2011,Larceny,246
+Mount Tabor,274605,2011,Liquor Laws,
+Mount Tabor,274605,2011,Motor Vehicle Theft,29
+Mount Tabor,274605,2011,Offenses Against Family,
+Mount Tabor,274605,2011,Prostitution,3
+Mount Tabor,274605,2011,Rape,
+Mount Tabor,274605,2011,Robbery,6
+Mount Tabor,274605,2011,Runaway,1
+Mount Tabor,274605,2011,Sex Offenses,3
+Mount Tabor,274605,2011,Stolen Property,
+Mount Tabor,274605,2011,Trespass,6
+Mount Tabor,274605,2011,Vandalism,52
+Mount Tabor,274605,2011,Weapons,1
+Mount Tabor,274605,2012,Aggravated Assault,1
+Mount Tabor,274605,2012,Arson,
+Mount Tabor,274605,2012,"Assault, Simple",8
+Mount Tabor,274605,2012,Burglary,76
+Mount Tabor,274605,2012,Curfew,4
+Mount Tabor,274605,2012,Disorderly Conduct,16
+Mount Tabor,274605,2012,Drugs,7
+Mount Tabor,274605,2012,DUII,16
+Mount Tabor,274605,2012,Embezzlement,1
+Mount Tabor,274605,2012,Forgery,3
+Mount Tabor,274605,2012,Fraud,14
+Mount Tabor,274605,2012,Gambling,
+Mount Tabor,274605,2012,Homicide,
+Mount Tabor,274605,2012,Kidnap,
+Mount Tabor,274605,2012,Larceny,290
+Mount Tabor,274605,2012,Liquor Laws,4
+Mount Tabor,274605,2012,Motor Vehicle Theft,36
+Mount Tabor,274605,2012,Offenses Against Family,
+Mount Tabor,274605,2012,Prostitution,1
+Mount Tabor,274605,2012,Rape,
+Mount Tabor,274605,2012,Robbery,5
+Mount Tabor,274605,2012,Runaway,
+Mount Tabor,274605,2012,Sex Offenses,1
+Mount Tabor,274605,2012,Stolen Property,
+Mount Tabor,274605,2012,Trespass,5
+Mount Tabor,274605,2012,Vandalism,54
+Mount Tabor,274605,2012,Weapons,1
+Mount Tabor,274605,2013,Aggravated Assault,8
+Mount Tabor,274605,2013,Arson,
+Mount Tabor,274605,2013,"Assault, Simple",4
+Mount Tabor,274605,2013,Burglary,67
+Mount Tabor,274605,2013,Curfew,
+Mount Tabor,274605,2013,Disorderly Conduct,15
+Mount Tabor,274605,2013,Drugs,7
+Mount Tabor,274605,2013,DUII,20
+Mount Tabor,274605,2013,Embezzlement,
+Mount Tabor,274605,2013,Forgery,2
+Mount Tabor,274605,2013,Fraud,10
+Mount Tabor,274605,2013,Gambling,
+Mount Tabor,274605,2013,Homicide,
+Mount Tabor,274605,2013,Kidnap,
+Mount Tabor,274605,2013,Larceny,216
+Mount Tabor,274605,2013,Liquor Laws,6
+Mount Tabor,274605,2013,Motor Vehicle Theft,29
+Mount Tabor,274605,2013,Offenses Against Family,
+Mount Tabor,274605,2013,Prostitution,
+Mount Tabor,274605,2013,Rape,1
+Mount Tabor,274605,2013,Robbery,3
+Mount Tabor,274605,2013,Runaway,
+Mount Tabor,274605,2013,Sex Offenses,
+Mount Tabor,274605,2013,Stolen Property,1
+Mount Tabor,274605,2013,Trespass,13
+Mount Tabor,274605,2013,Vandalism,64
+Mount Tabor,274605,2013,Weapons,1
+Mount Tabor,274605,2014,Aggravated Assault,1
+Mount Tabor,274605,2014,Arson,
+Mount Tabor,274605,2014,"Assault, Simple",8
+Mount Tabor,274605,2014,Burglary,58
+Mount Tabor,274605,2014,Curfew,
+Mount Tabor,274605,2014,Disorderly Conduct,6
+Mount Tabor,274605,2014,Drugs,4
+Mount Tabor,274605,2014,DUII,17
+Mount Tabor,274605,2014,Embezzlement,1
+Mount Tabor,274605,2014,Forgery,1
+Mount Tabor,274605,2014,Fraud,10
+Mount Tabor,274605,2014,Gambling,
+Mount Tabor,274605,2014,Homicide,
+Mount Tabor,274605,2014,Kidnap,
+Mount Tabor,274605,2014,Larceny,201
+Mount Tabor,274605,2014,Liquor Laws,
+Mount Tabor,274605,2014,Motor Vehicle Theft,30
+Mount Tabor,274605,2014,Offenses Against Family,
+Mount Tabor,274605,2014,Prostitution,
+Mount Tabor,274605,2014,Rape,
+Mount Tabor,274605,2014,Robbery,2
+Mount Tabor,274605,2014,Runaway,
+Mount Tabor,274605,2014,Sex Offenses,
+Mount Tabor,274605,2014,Stolen Property,
+Mount Tabor,274605,2014,Trespass,8
+Mount Tabor,274605,2014,Vandalism,30
+Mount Tabor,274605,2014,Weapons,1
+Neighbors Southwest,274653,2004,Aggravated Assault,
+Neighbors Southwest,274653,2004,Arson,
+Neighbors Southwest,274653,2004,"Assault, Simple",
+Neighbors Southwest,274653,2004,Burglary,
+Neighbors Southwest,274653,2004,Curfew,
+Neighbors Southwest,274653,2004,Disorderly Conduct,
+Neighbors Southwest,274653,2004,Drugs,
+Neighbors Southwest,274653,2004,DUII,
+Neighbors Southwest,274653,2004,Embezzlement,
+Neighbors Southwest,274653,2004,Forgery,
+Neighbors Southwest,274653,2004,Fraud,
+Neighbors Southwest,274653,2004,Gambling,
+Neighbors Southwest,274653,2004,Homicide,
+Neighbors Southwest,274653,2004,Kidnap,
+Neighbors Southwest,274653,2004,Larceny,
+Neighbors Southwest,274653,2004,Liquor Laws,
+Neighbors Southwest,274653,2004,Motor Vehicle Theft,
+Neighbors Southwest,274653,2004,Offenses Against Family,
+Neighbors Southwest,274653,2004,Prostitution,
+Neighbors Southwest,274653,2004,Rape,
+Neighbors Southwest,274653,2004,Robbery,
+Neighbors Southwest,274653,2004,Runaway,
+Neighbors Southwest,274653,2004,Sex Offenses,
+Neighbors Southwest,274653,2004,Stolen Property,
+Neighbors Southwest,274653,2004,Trespass,
+Neighbors Southwest,274653,2004,Vandalism,
+Neighbors Southwest,274653,2004,Weapons,
+Neighbors Southwest,274653,2005,Aggravated Assault,
+Neighbors Southwest,274653,2005,Arson,
+Neighbors Southwest,274653,2005,"Assault, Simple",
+Neighbors Southwest,274653,2005,Burglary,
+Neighbors Southwest,274653,2005,Curfew,
+Neighbors Southwest,274653,2005,Disorderly Conduct,
+Neighbors Southwest,274653,2005,Drugs,
+Neighbors Southwest,274653,2005,DUII,
+Neighbors Southwest,274653,2005,Embezzlement,
+Neighbors Southwest,274653,2005,Forgery,
+Neighbors Southwest,274653,2005,Fraud,
+Neighbors Southwest,274653,2005,Gambling,
+Neighbors Southwest,274653,2005,Homicide,
+Neighbors Southwest,274653,2005,Kidnap,
+Neighbors Southwest,274653,2005,Larceny,
+Neighbors Southwest,274653,2005,Liquor Laws,
+Neighbors Southwest,274653,2005,Motor Vehicle Theft,
+Neighbors Southwest,274653,2005,Offenses Against Family,
+Neighbors Southwest,274653,2005,Prostitution,
+Neighbors Southwest,274653,2005,Rape,
+Neighbors Southwest,274653,2005,Robbery,
+Neighbors Southwest,274653,2005,Runaway,
+Neighbors Southwest,274653,2005,Sex Offenses,
+Neighbors Southwest,274653,2005,Stolen Property,
+Neighbors Southwest,274653,2005,Trespass,
+Neighbors Southwest,274653,2005,Vandalism,
+Neighbors Southwest,274653,2005,Weapons,
+Neighbors Southwest,274653,2006,Aggravated Assault,
+Neighbors Southwest,274653,2006,Arson,
+Neighbors Southwest,274653,2006,"Assault, Simple",
+Neighbors Southwest,274653,2006,Burglary,
+Neighbors Southwest,274653,2006,Curfew,
+Neighbors Southwest,274653,2006,Disorderly Conduct,
+Neighbors Southwest,274653,2006,Drugs,
+Neighbors Southwest,274653,2006,DUII,
+Neighbors Southwest,274653,2006,Embezzlement,
+Neighbors Southwest,274653,2006,Forgery,
+Neighbors Southwest,274653,2006,Fraud,
+Neighbors Southwest,274653,2006,Gambling,
+Neighbors Southwest,274653,2006,Homicide,
+Neighbors Southwest,274653,2006,Kidnap,
+Neighbors Southwest,274653,2006,Larceny,
+Neighbors Southwest,274653,2006,Liquor Laws,
+Neighbors Southwest,274653,2006,Motor Vehicle Theft,
+Neighbors Southwest,274653,2006,Offenses Against Family,
+Neighbors Southwest,274653,2006,Prostitution,
+Neighbors Southwest,274653,2006,Rape,
+Neighbors Southwest,274653,2006,Robbery,
+Neighbors Southwest,274653,2006,Runaway,
+Neighbors Southwest,274653,2006,Sex Offenses,
+Neighbors Southwest,274653,2006,Stolen Property,
+Neighbors Southwest,274653,2006,Trespass,
+Neighbors Southwest,274653,2006,Vandalism,
+Neighbors Southwest,274653,2006,Weapons,
+Neighbors Southwest,274653,2007,Aggravated Assault,
+Neighbors Southwest,274653,2007,Arson,
+Neighbors Southwest,274653,2007,"Assault, Simple",
+Neighbors Southwest,274653,2007,Burglary,
+Neighbors Southwest,274653,2007,Curfew,
+Neighbors Southwest,274653,2007,Disorderly Conduct,
+Neighbors Southwest,274653,2007,Drugs,
+Neighbors Southwest,274653,2007,DUII,
+Neighbors Southwest,274653,2007,Embezzlement,
+Neighbors Southwest,274653,2007,Forgery,
+Neighbors Southwest,274653,2007,Fraud,
+Neighbors Southwest,274653,2007,Gambling,
+Neighbors Southwest,274653,2007,Homicide,
+Neighbors Southwest,274653,2007,Kidnap,
+Neighbors Southwest,274653,2007,Larceny,
+Neighbors Southwest,274653,2007,Liquor Laws,
+Neighbors Southwest,274653,2007,Motor Vehicle Theft,
+Neighbors Southwest,274653,2007,Offenses Against Family,
+Neighbors Southwest,274653,2007,Prostitution,
+Neighbors Southwest,274653,2007,Rape,
+Neighbors Southwest,274653,2007,Robbery,
+Neighbors Southwest,274653,2007,Runaway,
+Neighbors Southwest,274653,2007,Sex Offenses,
+Neighbors Southwest,274653,2007,Stolen Property,
+Neighbors Southwest,274653,2007,Trespass,
+Neighbors Southwest,274653,2007,Vandalism,
+Neighbors Southwest,274653,2007,Weapons,
+Neighbors Southwest,274653,2008,Aggravated Assault,
+Neighbors Southwest,274653,2008,Arson,
+Neighbors Southwest,274653,2008,"Assault, Simple",
+Neighbors Southwest,274653,2008,Burglary,
+Neighbors Southwest,274653,2008,Curfew,
+Neighbors Southwest,274653,2008,Disorderly Conduct,
+Neighbors Southwest,274653,2008,Drugs,
+Neighbors Southwest,274653,2008,DUII,
+Neighbors Southwest,274653,2008,Embezzlement,
+Neighbors Southwest,274653,2008,Forgery,
+Neighbors Southwest,274653,2008,Fraud,
+Neighbors Southwest,274653,2008,Gambling,
+Neighbors Southwest,274653,2008,Homicide,
+Neighbors Southwest,274653,2008,Kidnap,
+Neighbors Southwest,274653,2008,Larceny,
+Neighbors Southwest,274653,2008,Liquor Laws,
+Neighbors Southwest,274653,2008,Motor Vehicle Theft,
+Neighbors Southwest,274653,2008,Offenses Against Family,
+Neighbors Southwest,274653,2008,Prostitution,
+Neighbors Southwest,274653,2008,Rape,
+Neighbors Southwest,274653,2008,Robbery,
+Neighbors Southwest,274653,2008,Runaway,
+Neighbors Southwest,274653,2008,Sex Offenses,
+Neighbors Southwest,274653,2008,Stolen Property,
+Neighbors Southwest,274653,2008,Trespass,
+Neighbors Southwest,274653,2008,Vandalism,
+Neighbors Southwest,274653,2008,Weapons,
+Neighbors Southwest,274653,2009,Aggravated Assault,
+Neighbors Southwest,274653,2009,Arson,
+Neighbors Southwest,274653,2009,"Assault, Simple",
+Neighbors Southwest,274653,2009,Burglary,
+Neighbors Southwest,274653,2009,Curfew,
+Neighbors Southwest,274653,2009,Disorderly Conduct,
+Neighbors Southwest,274653,2009,Drugs,
+Neighbors Southwest,274653,2009,DUII,
+Neighbors Southwest,274653,2009,Embezzlement,
+Neighbors Southwest,274653,2009,Forgery,
+Neighbors Southwest,274653,2009,Fraud,
+Neighbors Southwest,274653,2009,Gambling,
+Neighbors Southwest,274653,2009,Homicide,
+Neighbors Southwest,274653,2009,Kidnap,
+Neighbors Southwest,274653,2009,Larceny,
+Neighbors Southwest,274653,2009,Liquor Laws,
+Neighbors Southwest,274653,2009,Motor Vehicle Theft,
+Neighbors Southwest,274653,2009,Offenses Against Family,
+Neighbors Southwest,274653,2009,Prostitution,
+Neighbors Southwest,274653,2009,Rape,
+Neighbors Southwest,274653,2009,Robbery,
+Neighbors Southwest,274653,2009,Runaway,
+Neighbors Southwest,274653,2009,Sex Offenses,
+Neighbors Southwest,274653,2009,Stolen Property,
+Neighbors Southwest,274653,2009,Trespass,
+Neighbors Southwest,274653,2009,Vandalism,
+Neighbors Southwest,274653,2009,Weapons,
+Neighbors Southwest,274653,2010,Aggravated Assault,
+Neighbors Southwest,274653,2010,Arson,
+Neighbors Southwest,274653,2010,"Assault, Simple",
+Neighbors Southwest,274653,2010,Burglary,
+Neighbors Southwest,274653,2010,Curfew,
+Neighbors Southwest,274653,2010,Disorderly Conduct,
+Neighbors Southwest,274653,2010,Drugs,
+Neighbors Southwest,274653,2010,DUII,
+Neighbors Southwest,274653,2010,Embezzlement,
+Neighbors Southwest,274653,2010,Forgery,
+Neighbors Southwest,274653,2010,Fraud,
+Neighbors Southwest,274653,2010,Gambling,
+Neighbors Southwest,274653,2010,Homicide,
+Neighbors Southwest,274653,2010,Kidnap,
+Neighbors Southwest,274653,2010,Larceny,
+Neighbors Southwest,274653,2010,Liquor Laws,
+Neighbors Southwest,274653,2010,Motor Vehicle Theft,
+Neighbors Southwest,274653,2010,Offenses Against Family,
+Neighbors Southwest,274653,2010,Prostitution,
+Neighbors Southwest,274653,2010,Rape,
+Neighbors Southwest,274653,2010,Robbery,
+Neighbors Southwest,274653,2010,Runaway,
+Neighbors Southwest,274653,2010,Sex Offenses,
+Neighbors Southwest,274653,2010,Stolen Property,
+Neighbors Southwest,274653,2010,Trespass,
+Neighbors Southwest,274653,2010,Vandalism,
+Neighbors Southwest,274653,2010,Weapons,
+Neighbors Southwest,274653,2011,Aggravated Assault,
+Neighbors Southwest,274653,2011,Arson,
+Neighbors Southwest,274653,2011,"Assault, Simple",
+Neighbors Southwest,274653,2011,Burglary,
+Neighbors Southwest,274653,2011,Curfew,
+Neighbors Southwest,274653,2011,Disorderly Conduct,
+Neighbors Southwest,274653,2011,Drugs,
+Neighbors Southwest,274653,2011,DUII,
+Neighbors Southwest,274653,2011,Embezzlement,
+Neighbors Southwest,274653,2011,Forgery,
+Neighbors Southwest,274653,2011,Fraud,
+Neighbors Southwest,274653,2011,Gambling,
+Neighbors Southwest,274653,2011,Homicide,
+Neighbors Southwest,274653,2011,Kidnap,
+Neighbors Southwest,274653,2011,Larceny,
+Neighbors Southwest,274653,2011,Liquor Laws,
+Neighbors Southwest,274653,2011,Motor Vehicle Theft,
+Neighbors Southwest,274653,2011,Offenses Against Family,
+Neighbors Southwest,274653,2011,Prostitution,
+Neighbors Southwest,274653,2011,Rape,
+Neighbors Southwest,274653,2011,Robbery,
+Neighbors Southwest,274653,2011,Runaway,
+Neighbors Southwest,274653,2011,Sex Offenses,
+Neighbors Southwest,274653,2011,Stolen Property,
+Neighbors Southwest,274653,2011,Trespass,
+Neighbors Southwest,274653,2011,Vandalism,
+Neighbors Southwest,274653,2011,Weapons,
+Neighbors Southwest,274653,2012,Aggravated Assault,
+Neighbors Southwest,274653,2012,Arson,
+Neighbors Southwest,274653,2012,"Assault, Simple",
+Neighbors Southwest,274653,2012,Burglary,
+Neighbors Southwest,274653,2012,Curfew,
+Neighbors Southwest,274653,2012,Disorderly Conduct,
+Neighbors Southwest,274653,2012,Drugs,
+Neighbors Southwest,274653,2012,DUII,
+Neighbors Southwest,274653,2012,Embezzlement,
+Neighbors Southwest,274653,2012,Forgery,
+Neighbors Southwest,274653,2012,Fraud,
+Neighbors Southwest,274653,2012,Gambling,
+Neighbors Southwest,274653,2012,Homicide,
+Neighbors Southwest,274653,2012,Kidnap,
+Neighbors Southwest,274653,2012,Larceny,
+Neighbors Southwest,274653,2012,Liquor Laws,
+Neighbors Southwest,274653,2012,Motor Vehicle Theft,
+Neighbors Southwest,274653,2012,Offenses Against Family,
+Neighbors Southwest,274653,2012,Prostitution,
+Neighbors Southwest,274653,2012,Rape,
+Neighbors Southwest,274653,2012,Robbery,
+Neighbors Southwest,274653,2012,Runaway,
+Neighbors Southwest,274653,2012,Sex Offenses,
+Neighbors Southwest,274653,2012,Stolen Property,
+Neighbors Southwest,274653,2012,Trespass,
+Neighbors Southwest,274653,2012,Vandalism,
+Neighbors Southwest,274653,2012,Weapons,
+Neighbors Southwest,274653,2013,Aggravated Assault,
+Neighbors Southwest,274653,2013,Arson,
+Neighbors Southwest,274653,2013,"Assault, Simple",
+Neighbors Southwest,274653,2013,Burglary,
+Neighbors Southwest,274653,2013,Curfew,
+Neighbors Southwest,274653,2013,Disorderly Conduct,
+Neighbors Southwest,274653,2013,Drugs,
+Neighbors Southwest,274653,2013,DUII,
+Neighbors Southwest,274653,2013,Embezzlement,
+Neighbors Southwest,274653,2013,Forgery,
+Neighbors Southwest,274653,2013,Fraud,
+Neighbors Southwest,274653,2013,Gambling,
+Neighbors Southwest,274653,2013,Homicide,
+Neighbors Southwest,274653,2013,Kidnap,
+Neighbors Southwest,274653,2013,Larceny,
+Neighbors Southwest,274653,2013,Liquor Laws,
+Neighbors Southwest,274653,2013,Motor Vehicle Theft,
+Neighbors Southwest,274653,2013,Offenses Against Family,
+Neighbors Southwest,274653,2013,Prostitution,
+Neighbors Southwest,274653,2013,Rape,
+Neighbors Southwest,274653,2013,Robbery,
+Neighbors Southwest,274653,2013,Runaway,
+Neighbors Southwest,274653,2013,Sex Offenses,
+Neighbors Southwest,274653,2013,Stolen Property,
+Neighbors Southwest,274653,2013,Trespass,
+Neighbors Southwest,274653,2013,Vandalism,
+Neighbors Southwest,274653,2013,Weapons,
+Neighbors Southwest,274653,2014,Aggravated Assault,
+Neighbors Southwest,274653,2014,Arson,
+Neighbors Southwest,274653,2014,"Assault, Simple",
+Neighbors Southwest,274653,2014,Burglary,
+Neighbors Southwest,274653,2014,Curfew,
+Neighbors Southwest,274653,2014,Disorderly Conduct,
+Neighbors Southwest,274653,2014,Drugs,
+Neighbors Southwest,274653,2014,DUII,
+Neighbors Southwest,274653,2014,Embezzlement,
+Neighbors Southwest,274653,2014,Forgery,
+Neighbors Southwest,274653,2014,Fraud,
+Neighbors Southwest,274653,2014,Gambling,
+Neighbors Southwest,274653,2014,Homicide,
+Neighbors Southwest,274653,2014,Kidnap,
+Neighbors Southwest,274653,2014,Larceny,
+Neighbors Southwest,274653,2014,Liquor Laws,
+Neighbors Southwest,274653,2014,Motor Vehicle Theft,
+Neighbors Southwest,274653,2014,Offenses Against Family,
+Neighbors Southwest,274653,2014,Prostitution,
+Neighbors Southwest,274653,2014,Rape,
+Neighbors Southwest,274653,2014,Robbery,
+Neighbors Southwest,274653,2014,Runaway,
+Neighbors Southwest,274653,2014,Sex Offenses,
+Neighbors Southwest,274653,2014,Stolen Property,
+Neighbors Southwest,274653,2014,Trespass,
+Neighbors Southwest,274653,2014,Vandalism,
+Neighbors Southwest,274653,2014,Weapons,
+Northwest,274797,2004,Aggravated Assault,14
+Northwest,274797,2004,Arson,1
+Northwest,274797,2004,"Assault, Simple",23
+Northwest,274797,2004,Burglary,79
+Northwest,274797,2004,Curfew,2
+Northwest,274797,2004,Disorderly Conduct,25
+Northwest,274797,2004,Drugs,27
+Northwest,274797,2004,DUII,15
+Northwest,274797,2004,Embezzlement,4
+Northwest,274797,2004,Forgery,21
+Northwest,274797,2004,Fraud,27
+Northwest,274797,2004,Gambling,
+Northwest,274797,2004,Homicide,
+Northwest,274797,2004,Kidnap,
+Northwest,274797,2004,Larceny,485
+Northwest,274797,2004,Liquor Laws,40
+Northwest,274797,2004,Motor Vehicle Theft,91
+Northwest,274797,2004,Offenses Against Family,
+Northwest,274797,2004,Prostitution,12
+Northwest,274797,2004,Rape,
+Northwest,274797,2004,Robbery,19
+Northwest,274797,2004,Runaway,
+Northwest,274797,2004,Sex Offenses,3
+Northwest,274797,2004,Stolen Property,1
+Northwest,274797,2004,Trespass,49
+Northwest,274797,2004,Vandalism,97
+Northwest,274797,2004,Weapons,5
+Northwest,274797,2005,Aggravated Assault,42
+Northwest,274797,2005,Arson,4
+Northwest,274797,2005,"Assault, Simple",79
+Northwest,274797,2005,Burglary,203
+Northwest,274797,2005,Curfew,1
+Northwest,274797,2005,Disorderly Conduct,80
+Northwest,274797,2005,Drugs,129
+Northwest,274797,2005,DUII,83
+Northwest,274797,2005,Embezzlement,12
+Northwest,274797,2005,Forgery,60
+Northwest,274797,2005,Fraud,73
+Northwest,274797,2005,Gambling,
+Northwest,274797,2005,Homicide,
+Northwest,274797,2005,Kidnap,4
+Northwest,274797,2005,Larceny,1331
+Northwest,274797,2005,Liquor Laws,111
+Northwest,274797,2005,Motor Vehicle Theft,273
+Northwest,274797,2005,Offenses Against Family,
+Northwest,274797,2005,Prostitution,82
+Northwest,274797,2005,Rape,1
+Northwest,274797,2005,Robbery,38
+Northwest,274797,2005,Runaway,
+Northwest,274797,2005,Sex Offenses,6
+Northwest,274797,2005,Stolen Property,2
+Northwest,274797,2005,Trespass,188
+Northwest,274797,2005,Vandalism,225
+Northwest,274797,2005,Weapons,11
+Northwest,274797,2006,Aggravated Assault,28
+Northwest,274797,2006,Arson,6
+Northwest,274797,2006,"Assault, Simple",86
+Northwest,274797,2006,Burglary,171
+Northwest,274797,2006,Curfew,1
+Northwest,274797,2006,Disorderly Conduct,87
+Northwest,274797,2006,Drugs,80
+Northwest,274797,2006,DUII,76
+Northwest,274797,2006,Embezzlement,19
+Northwest,274797,2006,Forgery,83
+Northwest,274797,2006,Fraud,89
+Northwest,274797,2006,Gambling,
+Northwest,274797,2006,Homicide,
+Northwest,274797,2006,Kidnap,
+Northwest,274797,2006,Larceny,1027
+Northwest,274797,2006,Liquor Laws,126
+Northwest,274797,2006,Motor Vehicle Theft,171
+Northwest,274797,2006,Offenses Against Family,
+Northwest,274797,2006,Prostitution,42
+Northwest,274797,2006,Rape,2
+Northwest,274797,2006,Robbery,37
+Northwest,274797,2006,Runaway,
+Northwest,274797,2006,Sex Offenses,6
+Northwest,274797,2006,Stolen Property,
+Northwest,274797,2006,Trespass,122
+Northwest,274797,2006,Vandalism,223
+Northwest,274797,2006,Weapons,9
+Northwest,274797,2007,Aggravated Assault,30
+Northwest,274797,2007,Arson,2
+Northwest,274797,2007,"Assault, Simple",80
+Northwest,274797,2007,Burglary,172
+Northwest,274797,2007,Curfew,
+Northwest,274797,2007,Disorderly Conduct,80
+Northwest,274797,2007,Drugs,64
+Northwest,274797,2007,DUII,69
+Northwest,274797,2007,Embezzlement,11
+Northwest,274797,2007,Forgery,36
+Northwest,274797,2007,Fraud,96
+Northwest,274797,2007,Gambling,1
+Northwest,274797,2007,Homicide,
+Northwest,274797,2007,Kidnap,1
+Northwest,274797,2007,Larceny,1156
+Northwest,274797,2007,Liquor Laws,169
+Northwest,274797,2007,Motor Vehicle Theft,208
+Northwest,274797,2007,Offenses Against Family,
+Northwest,274797,2007,Prostitution,11
+Northwest,274797,2007,Rape,3
+Northwest,274797,2007,Robbery,45
+Northwest,274797,2007,Runaway,
+Northwest,274797,2007,Sex Offenses,6
+Northwest,274797,2007,Stolen Property,
+Northwest,274797,2007,Trespass,105
+Northwest,274797,2007,Vandalism,247
+Northwest,274797,2007,Weapons,5
+Northwest,274797,2008,Aggravated Assault,46
+Northwest,274797,2008,Arson,7
+Northwest,274797,2008,"Assault, Simple",102
+Northwest,274797,2008,Burglary,163
+Northwest,274797,2008,Curfew,
+Northwest,274797,2008,Disorderly Conduct,110
+Northwest,274797,2008,Drugs,50
+Northwest,274797,2008,DUII,71
+Northwest,274797,2008,Embezzlement,9
+Northwest,274797,2008,Forgery,34
+Northwest,274797,2008,Fraud,86
+Northwest,274797,2008,Gambling,
+Northwest,274797,2008,Homicide,
+Northwest,274797,2008,Kidnap,
+Northwest,274797,2008,Larceny,1068
+Northwest,274797,2008,Liquor Laws,316
+Northwest,274797,2008,Motor Vehicle Theft,157
+Northwest,274797,2008,Offenses Against Family,1
+Northwest,274797,2008,Prostitution,15
+Northwest,274797,2008,Rape,
+Northwest,274797,2008,Robbery,49
+Northwest,274797,2008,Runaway,1
+Northwest,274797,2008,Sex Offenses,1
+Northwest,274797,2008,Stolen Property,3
+Northwest,274797,2008,Trespass,97
+Northwest,274797,2008,Vandalism,212
+Northwest,274797,2008,Weapons,4
+Northwest,274797,2009,Aggravated Assault,36
+Northwest,274797,2009,Arson,5
+Northwest,274797,2009,"Assault, Simple",91
+Northwest,274797,2009,Burglary,105
+Northwest,274797,2009,Curfew,
+Northwest,274797,2009,Disorderly Conduct,138
+Northwest,274797,2009,Drugs,70
+Northwest,274797,2009,DUII,64
+Northwest,274797,2009,Embezzlement,10
+Northwest,274797,2009,Forgery,18
+Northwest,274797,2009,Fraud,73
+Northwest,274797,2009,Gambling,
+Northwest,274797,2009,Homicide,
+Northwest,274797,2009,Kidnap,
+Northwest,274797,2009,Larceny,999
+Northwest,274797,2009,Liquor Laws,343
+Northwest,274797,2009,Motor Vehicle Theft,153
+Northwest,274797,2009,Offenses Against Family,
+Northwest,274797,2009,Prostitution,9
+Northwest,274797,2009,Rape,2
+Northwest,274797,2009,Robbery,37
+Northwest,274797,2009,Runaway,1
+Northwest,274797,2009,Sex Offenses,10
+Northwest,274797,2009,Stolen Property,
+Northwest,274797,2009,Trespass,92
+Northwest,274797,2009,Vandalism,202
+Northwest,274797,2009,Weapons,4
+Northwest,274797,2010,Aggravated Assault,40
+Northwest,274797,2010,Arson,1
+Northwest,274797,2010,"Assault, Simple",66
+Northwest,274797,2010,Burglary,129
+Northwest,274797,2010,Curfew,
+Northwest,274797,2010,Disorderly Conduct,150
+Northwest,274797,2010,Drugs,85
+Northwest,274797,2010,DUII,50
+Northwest,274797,2010,Embezzlement,5
+Northwest,274797,2010,Forgery,23
+Northwest,274797,2010,Fraud,60
+Northwest,274797,2010,Gambling,
+Northwest,274797,2010,Homicide,1
+Northwest,274797,2010,Kidnap,
+Northwest,274797,2010,Larceny,1158
+Northwest,274797,2010,Liquor Laws,455
+Northwest,274797,2010,Motor Vehicle Theft,154
+Northwest,274797,2010,Offenses Against Family,2
+Northwest,274797,2010,Prostitution,18
+Northwest,274797,2010,Rape,3
+Northwest,274797,2010,Robbery,40
+Northwest,274797,2010,Runaway,
+Northwest,274797,2010,Sex Offenses,3
+Northwest,274797,2010,Stolen Property,4
+Northwest,274797,2010,Trespass,116
+Northwest,274797,2010,Vandalism,219
+Northwest,274797,2010,Weapons,2
+Northwest,274797,2011,Aggravated Assault,29
+Northwest,274797,2011,Arson,3
+Northwest,274797,2011,"Assault, Simple",79
+Northwest,274797,2011,Burglary,103
+Northwest,274797,2011,Curfew,
+Northwest,274797,2011,Disorderly Conduct,137
+Northwest,274797,2011,Drugs,122
+Northwest,274797,2011,DUII,52
+Northwest,274797,2011,Embezzlement,10
+Northwest,274797,2011,Forgery,24
+Northwest,274797,2011,Fraud,57
+Northwest,274797,2011,Gambling,
+Northwest,274797,2011,Homicide,1
+Northwest,274797,2011,Kidnap,1
+Northwest,274797,2011,Larceny,1259
+Northwest,274797,2011,Liquor Laws,281
+Northwest,274797,2011,Motor Vehicle Theft,145
+Northwest,274797,2011,Offenses Against Family,
+Northwest,274797,2011,Prostitution,12
+Northwest,274797,2011,Rape,3
+Northwest,274797,2011,Robbery,23
+Northwest,274797,2011,Runaway,
+Northwest,274797,2011,Sex Offenses,5
+Northwest,274797,2011,Stolen Property,4
+Northwest,274797,2011,Trespass,77
+Northwest,274797,2011,Vandalism,228
+Northwest,274797,2011,Weapons,14
+Northwest,274797,2012,Aggravated Assault,39
+Northwest,274797,2012,Arson,2
+Northwest,274797,2012,"Assault, Simple",66
+Northwest,274797,2012,Burglary,145
+Northwest,274797,2012,Curfew,
+Northwest,274797,2012,Disorderly Conduct,106
+Northwest,274797,2012,Drugs,113
+Northwest,274797,2012,DUII,67
+Northwest,274797,2012,Embezzlement,14
+Northwest,274797,2012,Forgery,16
+Northwest,274797,2012,Fraud,49
+Northwest,274797,2012,Gambling,
+Northwest,274797,2012,Homicide,1
+Northwest,274797,2012,Kidnap,
+Northwest,274797,2012,Larceny,1199
+Northwest,274797,2012,Liquor Laws,259
+Northwest,274797,2012,Motor Vehicle Theft,136
+Northwest,274797,2012,Offenses Against Family,
+Northwest,274797,2012,Prostitution,2
+Northwest,274797,2012,Rape,2
+Northwest,274797,2012,Robbery,23
+Northwest,274797,2012,Runaway,
+Northwest,274797,2012,Sex Offenses,6
+Northwest,274797,2012,Stolen Property,2
+Northwest,274797,2012,Trespass,121
+Northwest,274797,2012,Vandalism,206
+Northwest,274797,2012,Weapons,5
+Northwest,274797,2013,Aggravated Assault,27
+Northwest,274797,2013,Arson,
+Northwest,274797,2013,"Assault, Simple",66
+Northwest,274797,2013,Burglary,136
+Northwest,274797,2013,Curfew,
+Northwest,274797,2013,Disorderly Conduct,121
+Northwest,274797,2013,Drugs,92
+Northwest,274797,2013,DUII,58
+Northwest,274797,2013,Embezzlement,4
+Northwest,274797,2013,Forgery,18
+Northwest,274797,2013,Fraud,60
+Northwest,274797,2013,Gambling,
+Northwest,274797,2013,Homicide,
+Northwest,274797,2013,Kidnap,
+Northwest,274797,2013,Larceny,1049
+Northwest,274797,2013,Liquor Laws,293
+Northwest,274797,2013,Motor Vehicle Theft,138
+Northwest,274797,2013,Offenses Against Family,
+Northwest,274797,2013,Prostitution,2
+Northwest,274797,2013,Rape,2
+Northwest,274797,2013,Robbery,22
+Northwest,274797,2013,Runaway,2
+Northwest,274797,2013,Sex Offenses,4
+Northwest,274797,2013,Stolen Property,2
+Northwest,274797,2013,Trespass,79
+Northwest,274797,2013,Vandalism,175
+Northwest,274797,2013,Weapons,5
+Northwest,274797,2014,Aggravated Assault,34
+Northwest,274797,2014,Arson,
+Northwest,274797,2014,"Assault, Simple",80
+Northwest,274797,2014,Burglary,170
+Northwest,274797,2014,Curfew,
+Northwest,274797,2014,Disorderly Conduct,108
+Northwest,274797,2014,Drugs,79
+Northwest,274797,2014,DUII,63
+Northwest,274797,2014,Embezzlement,3
+Northwest,274797,2014,Forgery,8
+Northwest,274797,2014,Fraud,62
+Northwest,274797,2014,Gambling,
+Northwest,274797,2014,Homicide,
+Northwest,274797,2014,Kidnap,
+Northwest,274797,2014,Larceny,1465
+Northwest,274797,2014,Liquor Laws,192
+Northwest,274797,2014,Motor Vehicle Theft,157
+Northwest,274797,2014,Offenses Against Family,
+Northwest,274797,2014,Prostitution,
+Northwest,274797,2014,Rape,
+Northwest,274797,2014,Robbery,29
+Northwest,274797,2014,Runaway,
+Northwest,274797,2014,Sex Offenses,5
+Northwest,274797,2014,Stolen Property,3
+Northwest,274797,2014,Trespass,118
+Northwest,274797,2014,Vandalism,191
+Northwest,274797,2014,Weapons,7
+Old Town-Chinatown,274898,2004,Aggravated Assault,26
+Old Town-Chinatown,274898,2004,Arson,
+Old Town-Chinatown,274898,2004,"Assault, Simple",55
+Old Town-Chinatown,274898,2004,Burglary,8
+Old Town-Chinatown,274898,2004,Curfew,1
+Old Town-Chinatown,274898,2004,Disorderly Conduct,66
+Old Town-Chinatown,274898,2004,Drugs,261
+Old Town-Chinatown,274898,2004,DUII,19
+Old Town-Chinatown,274898,2004,Embezzlement,2
+Old Town-Chinatown,274898,2004,Forgery,8
+Old Town-Chinatown,274898,2004,Fraud,16
+Old Town-Chinatown,274898,2004,Gambling,
+Old Town-Chinatown,274898,2004,Homicide,1
+Old Town-Chinatown,274898,2004,Kidnap,1
+Old Town-Chinatown,274898,2004,Larceny,101
+Old Town-Chinatown,274898,2004,Liquor Laws,73
+Old Town-Chinatown,274898,2004,Motor Vehicle Theft,26
+Old Town-Chinatown,274898,2004,Offenses Against Family,
+Old Town-Chinatown,274898,2004,Prostitution,2
+Old Town-Chinatown,274898,2004,Rape,1
+Old Town-Chinatown,274898,2004,Robbery,26
+Old Town-Chinatown,274898,2004,Runaway,
+Old Town-Chinatown,274898,2004,Sex Offenses,1
+Old Town-Chinatown,274898,2004,Stolen Property,3
+Old Town-Chinatown,274898,2004,Trespass,547
+Old Town-Chinatown,274898,2004,Vandalism,18
+Old Town-Chinatown,274898,2004,Weapons,8
+Old Town-Chinatown,274898,2005,Aggravated Assault,69
+Old Town-Chinatown,274898,2005,Arson,
+Old Town-Chinatown,274898,2005,"Assault, Simple",166
+Old Town-Chinatown,274898,2005,Burglary,30
+Old Town-Chinatown,274898,2005,Curfew,1
+Old Town-Chinatown,274898,2005,Disorderly Conduct,207
+Old Town-Chinatown,274898,2005,Drugs,598
+Old Town-Chinatown,274898,2005,DUII,64
+Old Town-Chinatown,274898,2005,Embezzlement,4
+Old Town-Chinatown,274898,2005,Forgery,34
+Old Town-Chinatown,274898,2005,Fraud,32
+Old Town-Chinatown,274898,2005,Gambling,
+Old Town-Chinatown,274898,2005,Homicide,1
+Old Town-Chinatown,274898,2005,Kidnap,
+Old Town-Chinatown,274898,2005,Larceny,316
+Old Town-Chinatown,274898,2005,Liquor Laws,315
+Old Town-Chinatown,274898,2005,Motor Vehicle Theft,53
+Old Town-Chinatown,274898,2005,Offenses Against Family,
+Old Town-Chinatown,274898,2005,Prostitution,4
+Old Town-Chinatown,274898,2005,Rape,5
+Old Town-Chinatown,274898,2005,Robbery,39
+Old Town-Chinatown,274898,2005,Runaway,
+Old Town-Chinatown,274898,2005,Sex Offenses,14
+Old Town-Chinatown,274898,2005,Stolen Property,3
+Old Town-Chinatown,274898,2005,Trespass,725
+Old Town-Chinatown,274898,2005,Vandalism,87
+Old Town-Chinatown,274898,2005,Weapons,18
+Old Town-Chinatown,274898,2006,Aggravated Assault,103
+Old Town-Chinatown,274898,2006,Arson,
+Old Town-Chinatown,274898,2006,"Assault, Simple",217
+Old Town-Chinatown,274898,2006,Burglary,35
+Old Town-Chinatown,274898,2006,Curfew,2
+Old Town-Chinatown,274898,2006,Disorderly Conduct,238
+Old Town-Chinatown,274898,2006,Drugs,653
+Old Town-Chinatown,274898,2006,DUII,99
+Old Town-Chinatown,274898,2006,Embezzlement,2
+Old Town-Chinatown,274898,2006,Forgery,30
+Old Town-Chinatown,274898,2006,Fraud,22
+Old Town-Chinatown,274898,2006,Gambling,
+Old Town-Chinatown,274898,2006,Homicide,
+Old Town-Chinatown,274898,2006,Kidnap,1
+Old Town-Chinatown,274898,2006,Larceny,314
+Old Town-Chinatown,274898,2006,Liquor Laws,472
+Old Town-Chinatown,274898,2006,Motor Vehicle Theft,52
+Old Town-Chinatown,274898,2006,Offenses Against Family,
+Old Town-Chinatown,274898,2006,Prostitution,16
+Old Town-Chinatown,274898,2006,Rape,9
+Old Town-Chinatown,274898,2006,Robbery,49
+Old Town-Chinatown,274898,2006,Runaway,1
+Old Town-Chinatown,274898,2006,Sex Offenses,5
+Old Town-Chinatown,274898,2006,Stolen Property,6
+Old Town-Chinatown,274898,2006,Trespass,371
+Old Town-Chinatown,274898,2006,Vandalism,110
+Old Town-Chinatown,274898,2006,Weapons,18
+Old Town-Chinatown,274898,2007,Aggravated Assault,85
+Old Town-Chinatown,274898,2007,Arson,1
+Old Town-Chinatown,274898,2007,"Assault, Simple",197
+Old Town-Chinatown,274898,2007,Burglary,32
+Old Town-Chinatown,274898,2007,Curfew,1
+Old Town-Chinatown,274898,2007,Disorderly Conduct,226
+Old Town-Chinatown,274898,2007,Drugs,694
+Old Town-Chinatown,274898,2007,DUII,88
+Old Town-Chinatown,274898,2007,Embezzlement,2
+Old Town-Chinatown,274898,2007,Forgery,13
+Old Town-Chinatown,274898,2007,Fraud,25
+Old Town-Chinatown,274898,2007,Gambling,
+Old Town-Chinatown,274898,2007,Homicide,
+Old Town-Chinatown,274898,2007,Kidnap,1
+Old Town-Chinatown,274898,2007,Larceny,316
+Old Town-Chinatown,274898,2007,Liquor Laws,832
+Old Town-Chinatown,274898,2007,Motor Vehicle Theft,39
+Old Town-Chinatown,274898,2007,Offenses Against Family,1
+Old Town-Chinatown,274898,2007,Prostitution,11
+Old Town-Chinatown,274898,2007,Rape,5
+Old Town-Chinatown,274898,2007,Robbery,84
+Old Town-Chinatown,274898,2007,Runaway,
+Old Town-Chinatown,274898,2007,Sex Offenses,4
+Old Town-Chinatown,274898,2007,Stolen Property,1
+Old Town-Chinatown,274898,2007,Trespass,305
+Old Town-Chinatown,274898,2007,Vandalism,96
+Old Town-Chinatown,274898,2007,Weapons,25
+Old Town-Chinatown,274898,2008,Aggravated Assault,115
+Old Town-Chinatown,274898,2008,Arson,1
+Old Town-Chinatown,274898,2008,"Assault, Simple",196
+Old Town-Chinatown,274898,2008,Burglary,14
+Old Town-Chinatown,274898,2008,Curfew,
+Old Town-Chinatown,274898,2008,Disorderly Conduct,237
+Old Town-Chinatown,274898,2008,Drugs,636
+Old Town-Chinatown,274898,2008,DUII,84
+Old Town-Chinatown,274898,2008,Embezzlement,3
+Old Town-Chinatown,274898,2008,Forgery,6
+Old Town-Chinatown,274898,2008,Fraud,27
+Old Town-Chinatown,274898,2008,Gambling,
+Old Town-Chinatown,274898,2008,Homicide,
+Old Town-Chinatown,274898,2008,Kidnap,
+Old Town-Chinatown,274898,2008,Larceny,359
+Old Town-Chinatown,274898,2008,Liquor Laws,962
+Old Town-Chinatown,274898,2008,Motor Vehicle Theft,45
+Old Town-Chinatown,274898,2008,Offenses Against Family,
+Old Town-Chinatown,274898,2008,Prostitution,5
+Old Town-Chinatown,274898,2008,Rape,3
+Old Town-Chinatown,274898,2008,Robbery,54
+Old Town-Chinatown,274898,2008,Runaway,
+Old Town-Chinatown,274898,2008,Sex Offenses,6
+Old Town-Chinatown,274898,2008,Stolen Property,1
+Old Town-Chinatown,274898,2008,Trespass,180
+Old Town-Chinatown,274898,2008,Vandalism,99
+Old Town-Chinatown,274898,2008,Weapons,15
+Old Town-Chinatown,274898,2009,Aggravated Assault,130
+Old Town-Chinatown,274898,2009,Arson,
+Old Town-Chinatown,274898,2009,"Assault, Simple",258
+Old Town-Chinatown,274898,2009,Burglary,20
+Old Town-Chinatown,274898,2009,Curfew,1
+Old Town-Chinatown,274898,2009,Disorderly Conduct,316
+Old Town-Chinatown,274898,2009,Drugs,398
+Old Town-Chinatown,274898,2009,DUII,78
+Old Town-Chinatown,274898,2009,Embezzlement,1
+Old Town-Chinatown,274898,2009,Forgery,7
+Old Town-Chinatown,274898,2009,Fraud,25
+Old Town-Chinatown,274898,2009,Gambling,
+Old Town-Chinatown,274898,2009,Homicide,3
+Old Town-Chinatown,274898,2009,Kidnap,1
+Old Town-Chinatown,274898,2009,Larceny,313
+Old Town-Chinatown,274898,2009,Liquor Laws,989
+Old Town-Chinatown,274898,2009,Motor Vehicle Theft,21
+Old Town-Chinatown,274898,2009,Offenses Against Family,
+Old Town-Chinatown,274898,2009,Prostitution,
+Old Town-Chinatown,274898,2009,Rape,1
+Old Town-Chinatown,274898,2009,Robbery,53
+Old Town-Chinatown,274898,2009,Runaway,
+Old Town-Chinatown,274898,2009,Sex Offenses,6
+Old Town-Chinatown,274898,2009,Stolen Property,1
+Old Town-Chinatown,274898,2009,Trespass,150
+Old Town-Chinatown,274898,2009,Vandalism,84
+Old Town-Chinatown,274898,2009,Weapons,11
+Old Town-Chinatown,274898,2010,Aggravated Assault,125
+Old Town-Chinatown,274898,2010,Arson,1
+Old Town-Chinatown,274898,2010,"Assault, Simple",231
+Old Town-Chinatown,274898,2010,Burglary,26
+Old Town-Chinatown,274898,2010,Curfew,1
+Old Town-Chinatown,274898,2010,Disorderly Conduct,278
+Old Town-Chinatown,274898,2010,Drugs,462
+Old Town-Chinatown,274898,2010,DUII,56
+Old Town-Chinatown,274898,2010,Embezzlement,2
+Old Town-Chinatown,274898,2010,Forgery,8
+Old Town-Chinatown,274898,2010,Fraud,22
+Old Town-Chinatown,274898,2010,Gambling,1
+Old Town-Chinatown,274898,2010,Homicide,3
+Old Town-Chinatown,274898,2010,Kidnap,
+Old Town-Chinatown,274898,2010,Larceny,463
+Old Town-Chinatown,274898,2010,Liquor Laws,653
+Old Town-Chinatown,274898,2010,Motor Vehicle Theft,32
+Old Town-Chinatown,274898,2010,Offenses Against Family,
+Old Town-Chinatown,274898,2010,Prostitution,5
+Old Town-Chinatown,274898,2010,Rape,2
+Old Town-Chinatown,274898,2010,Robbery,61
+Old Town-Chinatown,274898,2010,Runaway,
+Old Town-Chinatown,274898,2010,Sex Offenses,13
+Old Town-Chinatown,274898,2010,Stolen Property,4
+Old Town-Chinatown,274898,2010,Trespass,135
+Old Town-Chinatown,274898,2010,Vandalism,118
+Old Town-Chinatown,274898,2010,Weapons,22
+Old Town-Chinatown,274898,2011,Aggravated Assault,116
+Old Town-Chinatown,274898,2011,Arson,2
+Old Town-Chinatown,274898,2011,"Assault, Simple",270
+Old Town-Chinatown,274898,2011,Burglary,18
+Old Town-Chinatown,274898,2011,Curfew,
+Old Town-Chinatown,274898,2011,Disorderly Conduct,363
+Old Town-Chinatown,274898,2011,Drugs,651
+Old Town-Chinatown,274898,2011,DUII,71
+Old Town-Chinatown,274898,2011,Embezzlement,1
+Old Town-Chinatown,274898,2011,Forgery,14
+Old Town-Chinatown,274898,2011,Fraud,30
+Old Town-Chinatown,274898,2011,Gambling,
+Old Town-Chinatown,274898,2011,Homicide,1
+Old Town-Chinatown,274898,2011,Kidnap,1
+Old Town-Chinatown,274898,2011,Larceny,486
+Old Town-Chinatown,274898,2011,Liquor Laws,767
+Old Town-Chinatown,274898,2011,Motor Vehicle Theft,46
+Old Town-Chinatown,274898,2011,Offenses Against Family,
+Old Town-Chinatown,274898,2011,Prostitution,3
+Old Town-Chinatown,274898,2011,Rape,2
+Old Town-Chinatown,274898,2011,Robbery,37
+Old Town-Chinatown,274898,2011,Runaway,
+Old Town-Chinatown,274898,2011,Sex Offenses,5
+Old Town-Chinatown,274898,2011,Stolen Property,2
+Old Town-Chinatown,274898,2011,Trespass,245
+Old Town-Chinatown,274898,2011,Vandalism,114
+Old Town-Chinatown,274898,2011,Weapons,24
+Old Town-Chinatown,274898,2012,Aggravated Assault,88
+Old Town-Chinatown,274898,2012,Arson,5
+Old Town-Chinatown,274898,2012,"Assault, Simple",270
+Old Town-Chinatown,274898,2012,Burglary,23
+Old Town-Chinatown,274898,2012,Curfew,
+Old Town-Chinatown,274898,2012,Disorderly Conduct,308
+Old Town-Chinatown,274898,2012,Drugs,579
+Old Town-Chinatown,274898,2012,DUII,73
+Old Town-Chinatown,274898,2012,Embezzlement,1
+Old Town-Chinatown,274898,2012,Forgery,8
+Old Town-Chinatown,274898,2012,Fraud,39
+Old Town-Chinatown,274898,2012,Gambling,
+Old Town-Chinatown,274898,2012,Homicide,
+Old Town-Chinatown,274898,2012,Kidnap,1
+Old Town-Chinatown,274898,2012,Larceny,511
+Old Town-Chinatown,274898,2012,Liquor Laws,796
+Old Town-Chinatown,274898,2012,Motor Vehicle Theft,38
+Old Town-Chinatown,274898,2012,Offenses Against Family,
+Old Town-Chinatown,274898,2012,Prostitution,2
+Old Town-Chinatown,274898,2012,Rape,2
+Old Town-Chinatown,274898,2012,Robbery,36
+Old Town-Chinatown,274898,2012,Runaway,
+Old Town-Chinatown,274898,2012,Sex Offenses,2
+Old Town-Chinatown,274898,2012,Stolen Property,3
+Old Town-Chinatown,274898,2012,Trespass,232
+Old Town-Chinatown,274898,2012,Vandalism,106
+Old Town-Chinatown,274898,2012,Weapons,28
+Old Town-Chinatown,274898,2013,Aggravated Assault,99
+Old Town-Chinatown,274898,2013,Arson,3
+Old Town-Chinatown,274898,2013,"Assault, Simple",224
+Old Town-Chinatown,274898,2013,Burglary,29
+Old Town-Chinatown,274898,2013,Curfew,1
+Old Town-Chinatown,274898,2013,Disorderly Conduct,516
+Old Town-Chinatown,274898,2013,Drugs,699
+Old Town-Chinatown,274898,2013,DUII,70
+Old Town-Chinatown,274898,2013,Embezzlement,1
+Old Town-Chinatown,274898,2013,Forgery,12
+Old Town-Chinatown,274898,2013,Fraud,43
+Old Town-Chinatown,274898,2013,Gambling,
+Old Town-Chinatown,274898,2013,Homicide,
+Old Town-Chinatown,274898,2013,Kidnap,
+Old Town-Chinatown,274898,2013,Larceny,506
+Old Town-Chinatown,274898,2013,Liquor Laws,776
+Old Town-Chinatown,274898,2013,Motor Vehicle Theft,51
+Old Town-Chinatown,274898,2013,Offenses Against Family,
+Old Town-Chinatown,274898,2013,Prostitution,2
+Old Town-Chinatown,274898,2013,Rape,1
+Old Town-Chinatown,274898,2013,Robbery,63
+Old Town-Chinatown,274898,2013,Runaway,
+Old Town-Chinatown,274898,2013,Sex Offenses,9
+Old Town-Chinatown,274898,2013,Stolen Property,4
+Old Town-Chinatown,274898,2013,Trespass,307
+Old Town-Chinatown,274898,2013,Vandalism,109
+Old Town-Chinatown,274898,2013,Weapons,45
+Old Town-Chinatown,274898,2014,Aggravated Assault,111
+Old Town-Chinatown,274898,2014,Arson,
+Old Town-Chinatown,274898,2014,"Assault, Simple",210
+Old Town-Chinatown,274898,2014,Burglary,27
+Old Town-Chinatown,274898,2014,Curfew,2
+Old Town-Chinatown,274898,2014,Disorderly Conduct,486
+Old Town-Chinatown,274898,2014,Drugs,614
+Old Town-Chinatown,274898,2014,DUII,45
+Old Town-Chinatown,274898,2014,Embezzlement,4
+Old Town-Chinatown,274898,2014,Forgery,17
+Old Town-Chinatown,274898,2014,Fraud,59
+Old Town-Chinatown,274898,2014,Gambling,
+Old Town-Chinatown,274898,2014,Homicide,1
+Old Town-Chinatown,274898,2014,Kidnap,
+Old Town-Chinatown,274898,2014,Larceny,604
+Old Town-Chinatown,274898,2014,Liquor Laws,635
+Old Town-Chinatown,274898,2014,Motor Vehicle Theft,31
+Old Town-Chinatown,274898,2014,Offenses Against Family,1
+Old Town-Chinatown,274898,2014,Prostitution,
+Old Town-Chinatown,274898,2014,Rape,4
+Old Town-Chinatown,274898,2014,Robbery,53
+Old Town-Chinatown,274898,2014,Runaway,1
+Old Town-Chinatown,274898,2014,Sex Offenses,14
+Old Town-Chinatown,274898,2014,Stolen Property,6
+Old Town-Chinatown,274898,2014,Trespass,264
+Old Town-Chinatown,274898,2014,Vandalism,104
+Old Town-Chinatown,274898,2014,Weapons,30
+Overlook,271119,2004,Aggravated Assault,10
+Overlook,271119,2004,Arson,
+Overlook,271119,2004,"Assault, Simple",11
+Overlook,271119,2004,Burglary,32
+Overlook,271119,2004,Curfew,
+Overlook,271119,2004,Disorderly Conduct,9
+Overlook,271119,2004,Drugs,7
+Overlook,271119,2004,DUII,10
+Overlook,271119,2004,Embezzlement,
+Overlook,271119,2004,Forgery,3
+Overlook,271119,2004,Fraud,14
+Overlook,271119,2004,Gambling,
+Overlook,271119,2004,Homicide,
+Overlook,271119,2004,Kidnap,
+Overlook,271119,2004,Larceny,85
+Overlook,271119,2004,Liquor Laws,7
+Overlook,271119,2004,Motor Vehicle Theft,11
+Overlook,271119,2004,Offenses Against Family,
+Overlook,271119,2004,Prostitution,2
+Overlook,271119,2004,Rape,
+Overlook,271119,2004,Robbery,3
+Overlook,271119,2004,Runaway,
+Overlook,271119,2004,Sex Offenses,
+Overlook,271119,2004,Stolen Property,
+Overlook,271119,2004,Trespass,7
+Overlook,271119,2004,Vandalism,15
+Overlook,271119,2004,Weapons,2
+Overlook,271119,2005,Aggravated Assault,18
+Overlook,271119,2005,Arson,
+Overlook,271119,2005,"Assault, Simple",36
+Overlook,271119,2005,Burglary,64
+Overlook,271119,2005,Curfew,2
+Overlook,271119,2005,Disorderly Conduct,38
+Overlook,271119,2005,Drugs,59
+Overlook,271119,2005,DUII,50
+Overlook,271119,2005,Embezzlement,3
+Overlook,271119,2005,Forgery,29
+Overlook,271119,2005,Fraud,32
+Overlook,271119,2005,Gambling,1
+Overlook,271119,2005,Homicide,
+Overlook,271119,2005,Kidnap,2
+Overlook,271119,2005,Larceny,287
+Overlook,271119,2005,Liquor Laws,16
+Overlook,271119,2005,Motor Vehicle Theft,56
+Overlook,271119,2005,Offenses Against Family,
+Overlook,271119,2005,Prostitution,1
+Overlook,271119,2005,Rape,
+Overlook,271119,2005,Robbery,11
+Overlook,271119,2005,Runaway,1
+Overlook,271119,2005,Sex Offenses,
+Overlook,271119,2005,Stolen Property,3
+Overlook,271119,2005,Trespass,56
+Overlook,271119,2005,Vandalism,63
+Overlook,271119,2005,Weapons,8
+Overlook,271119,2006,Aggravated Assault,22
+Overlook,271119,2006,Arson,3
+Overlook,271119,2006,"Assault, Simple",28
+Overlook,271119,2006,Burglary,62
+Overlook,271119,2006,Curfew,2
+Overlook,271119,2006,Disorderly Conduct,39
+Overlook,271119,2006,Drugs,65
+Overlook,271119,2006,DUII,19
+Overlook,271119,2006,Embezzlement,4
+Overlook,271119,2006,Forgery,26
+Overlook,271119,2006,Fraud,24
+Overlook,271119,2006,Gambling,
+Overlook,271119,2006,Homicide,
+Overlook,271119,2006,Kidnap,1
+Overlook,271119,2006,Larceny,257
+Overlook,271119,2006,Liquor Laws,29
+Overlook,271119,2006,Motor Vehicle Theft,47
+Overlook,271119,2006,Offenses Against Family,
+Overlook,271119,2006,Prostitution,
+Overlook,271119,2006,Rape,1
+Overlook,271119,2006,Robbery,24
+Overlook,271119,2006,Runaway,
+Overlook,271119,2006,Sex Offenses,
+Overlook,271119,2006,Stolen Property,1
+Overlook,271119,2006,Trespass,39
+Overlook,271119,2006,Vandalism,67
+Overlook,271119,2006,Weapons,2
+Overlook,271119,2007,Aggravated Assault,27
+Overlook,271119,2007,Arson,
+Overlook,271119,2007,"Assault, Simple",39
+Overlook,271119,2007,Burglary,62
+Overlook,271119,2007,Curfew,2
+Overlook,271119,2007,Disorderly Conduct,31
+Overlook,271119,2007,Drugs,128
+Overlook,271119,2007,DUII,35
+Overlook,271119,2007,Embezzlement,9
+Overlook,271119,2007,Forgery,27
+Overlook,271119,2007,Fraud,35
+Overlook,271119,2007,Gambling,
+Overlook,271119,2007,Homicide,2
+Overlook,271119,2007,Kidnap,1
+Overlook,271119,2007,Larceny,210
+Overlook,271119,2007,Liquor Laws,16
+Overlook,271119,2007,Motor Vehicle Theft,39
+Overlook,271119,2007,Offenses Against Family,
+Overlook,271119,2007,Prostitution,2
+Overlook,271119,2007,Rape,1
+Overlook,271119,2007,Robbery,26
+Overlook,271119,2007,Runaway,
+Overlook,271119,2007,Sex Offenses,3
+Overlook,271119,2007,Stolen Property,
+Overlook,271119,2007,Trespass,32
+Overlook,271119,2007,Vandalism,65
+Overlook,271119,2007,Weapons,1
+Overlook,271119,2008,Aggravated Assault,18
+Overlook,271119,2008,Arson,
+Overlook,271119,2008,"Assault, Simple",15
+Overlook,271119,2008,Burglary,67
+Overlook,271119,2008,Curfew,
+Overlook,271119,2008,Disorderly Conduct,35
+Overlook,271119,2008,Drugs,49
+Overlook,271119,2008,DUII,16
+Overlook,271119,2008,Embezzlement,3
+Overlook,271119,2008,Forgery,8
+Overlook,271119,2008,Fraud,22
+Overlook,271119,2008,Gambling,
+Overlook,271119,2008,Homicide,
+Overlook,271119,2008,Kidnap,1
+Overlook,271119,2008,Larceny,251
+Overlook,271119,2008,Liquor Laws,24
+Overlook,271119,2008,Motor Vehicle Theft,45
+Overlook,271119,2008,Offenses Against Family,
+Overlook,271119,2008,Prostitution,1
+Overlook,271119,2008,Rape,
+Overlook,271119,2008,Robbery,12
+Overlook,271119,2008,Runaway,
+Overlook,271119,2008,Sex Offenses,
+Overlook,271119,2008,Stolen Property,
+Overlook,271119,2008,Trespass,28
+Overlook,271119,2008,Vandalism,63
+Overlook,271119,2008,Weapons,1
+Overlook,271119,2009,Aggravated Assault,11
+Overlook,271119,2009,Arson,3
+Overlook,271119,2009,"Assault, Simple",16
+Overlook,271119,2009,Burglary,50
+Overlook,271119,2009,Curfew,2
+Overlook,271119,2009,Disorderly Conduct,39
+Overlook,271119,2009,Drugs,27
+Overlook,271119,2009,DUII,20
+Overlook,271119,2009,Embezzlement,1
+Overlook,271119,2009,Forgery,14
+Overlook,271119,2009,Fraud,22
+Overlook,271119,2009,Gambling,
+Overlook,271119,2009,Homicide,
+Overlook,271119,2009,Kidnap,
+Overlook,271119,2009,Larceny,239
+Overlook,271119,2009,Liquor Laws,11
+Overlook,271119,2009,Motor Vehicle Theft,44
+Overlook,271119,2009,Offenses Against Family,
+Overlook,271119,2009,Prostitution,1
+Overlook,271119,2009,Rape,1
+Overlook,271119,2009,Robbery,14
+Overlook,271119,2009,Runaway,
+Overlook,271119,2009,Sex Offenses,
+Overlook,271119,2009,Stolen Property,1
+Overlook,271119,2009,Trespass,19
+Overlook,271119,2009,Vandalism,77
+Overlook,271119,2009,Weapons,1
+Overlook,271119,2010,Aggravated Assault,6
+Overlook,271119,2010,Arson,2
+Overlook,271119,2010,"Assault, Simple",19
+Overlook,271119,2010,Burglary,41
+Overlook,271119,2010,Curfew,1
+Overlook,271119,2010,Disorderly Conduct,37
+Overlook,271119,2010,Drugs,23
+Overlook,271119,2010,DUII,19
+Overlook,271119,2010,Embezzlement,5
+Overlook,271119,2010,Forgery,11
+Overlook,271119,2010,Fraud,14
+Overlook,271119,2010,Gambling,
+Overlook,271119,2010,Homicide,
+Overlook,271119,2010,Kidnap,
+Overlook,271119,2010,Larceny,214
+Overlook,271119,2010,Liquor Laws,8
+Overlook,271119,2010,Motor Vehicle Theft,47
+Overlook,271119,2010,Offenses Against Family,
+Overlook,271119,2010,Prostitution,
+Overlook,271119,2010,Rape,2
+Overlook,271119,2010,Robbery,15
+Overlook,271119,2010,Runaway,
+Overlook,271119,2010,Sex Offenses,1
+Overlook,271119,2010,Stolen Property,
+Overlook,271119,2010,Trespass,25
+Overlook,271119,2010,Vandalism,76
+Overlook,271119,2010,Weapons,3
+Overlook,271119,2011,Aggravated Assault,10
+Overlook,271119,2011,Arson,
+Overlook,271119,2011,"Assault, Simple",33
+Overlook,271119,2011,Burglary,51
+Overlook,271119,2011,Curfew,
+Overlook,271119,2011,Disorderly Conduct,26
+Overlook,271119,2011,Drugs,26
+Overlook,271119,2011,DUII,17
+Overlook,271119,2011,Embezzlement,6
+Overlook,271119,2011,Forgery,6
+Overlook,271119,2011,Fraud,23
+Overlook,271119,2011,Gambling,
+Overlook,271119,2011,Homicide,
+Overlook,271119,2011,Kidnap,
+Overlook,271119,2011,Larceny,269
+Overlook,271119,2011,Liquor Laws,14
+Overlook,271119,2011,Motor Vehicle Theft,39
+Overlook,271119,2011,Offenses Against Family,
+Overlook,271119,2011,Prostitution,1
+Overlook,271119,2011,Rape,
+Overlook,271119,2011,Robbery,13
+Overlook,271119,2011,Runaway,
+Overlook,271119,2011,Sex Offenses,
+Overlook,271119,2011,Stolen Property,1
+Overlook,271119,2011,Trespass,20
+Overlook,271119,2011,Vandalism,71
+Overlook,271119,2011,Weapons,3
+Overlook,271119,2012,Aggravated Assault,17
+Overlook,271119,2012,Arson,
+Overlook,271119,2012,"Assault, Simple",21
+Overlook,271119,2012,Burglary,76
+Overlook,271119,2012,Curfew,2
+Overlook,271119,2012,Disorderly Conduct,46
+Overlook,271119,2012,Drugs,25
+Overlook,271119,2012,DUII,17
+Overlook,271119,2012,Embezzlement,4
+Overlook,271119,2012,Forgery,5
+Overlook,271119,2012,Fraud,19
+Overlook,271119,2012,Gambling,
+Overlook,271119,2012,Homicide,
+Overlook,271119,2012,Kidnap,
+Overlook,271119,2012,Larceny,269
+Overlook,271119,2012,Liquor Laws,14
+Overlook,271119,2012,Motor Vehicle Theft,48
+Overlook,271119,2012,Offenses Against Family,
+Overlook,271119,2012,Prostitution,
+Overlook,271119,2012,Rape,
+Overlook,271119,2012,Robbery,9
+Overlook,271119,2012,Runaway,
+Overlook,271119,2012,Sex Offenses,2
+Overlook,271119,2012,Stolen Property,1
+Overlook,271119,2012,Trespass,72
+Overlook,271119,2012,Vandalism,61
+Overlook,271119,2012,Weapons,7
+Overlook,271119,2013,Aggravated Assault,11
+Overlook,271119,2013,Arson,
+Overlook,271119,2013,"Assault, Simple",20
+Overlook,271119,2013,Burglary,46
+Overlook,271119,2013,Curfew,
+Overlook,271119,2013,Disorderly Conduct,34
+Overlook,271119,2013,Drugs,42
+Overlook,271119,2013,DUII,31
+Overlook,271119,2013,Embezzlement,2
+Overlook,271119,2013,Forgery,9
+Overlook,271119,2013,Fraud,22
+Overlook,271119,2013,Gambling,
+Overlook,271119,2013,Homicide,1
+Overlook,271119,2013,Kidnap,
+Overlook,271119,2013,Larceny,198
+Overlook,271119,2013,Liquor Laws,22
+Overlook,271119,2013,Motor Vehicle Theft,39
+Overlook,271119,2013,Offenses Against Family,
+Overlook,271119,2013,Prostitution,
+Overlook,271119,2013,Rape,
+Overlook,271119,2013,Robbery,7
+Overlook,271119,2013,Runaway,
+Overlook,271119,2013,Sex Offenses,
+Overlook,271119,2013,Stolen Property,5
+Overlook,271119,2013,Trespass,28
+Overlook,271119,2013,Vandalism,46
+Overlook,271119,2013,Weapons,3
+Overlook,271119,2014,Aggravated Assault,9
+Overlook,271119,2014,Arson,
+Overlook,271119,2014,"Assault, Simple",23
+Overlook,271119,2014,Burglary,66
+Overlook,271119,2014,Curfew,
+Overlook,271119,2014,Disorderly Conduct,29
+Overlook,271119,2014,Drugs,50
+Overlook,271119,2014,DUII,25
+Overlook,271119,2014,Embezzlement,1
+Overlook,271119,2014,Forgery,8
+Overlook,271119,2014,Fraud,15
+Overlook,271119,2014,Gambling,
+Overlook,271119,2014,Homicide,
+Overlook,271119,2014,Kidnap,
+Overlook,271119,2014,Larceny,258
+Overlook,271119,2014,Liquor Laws,24
+Overlook,271119,2014,Motor Vehicle Theft,31
+Overlook,271119,2014,Offenses Against Family,
+Overlook,271119,2014,Prostitution,
+Overlook,271119,2014,Rape,1
+Overlook,271119,2014,Robbery,12
+Overlook,271119,2014,Runaway,
+Overlook,271119,2014,Sex Offenses,4
+Overlook,271119,2014,Stolen Property,2
+Overlook,271119,2014,Trespass,27
+Overlook,271119,2014,Vandalism,44
+Overlook,271119,2014,Weapons,7
+Parkrose,207340,2004,Aggravated Assault,7
+Parkrose,207340,2004,Arson,
+Parkrose,207340,2004,"Assault, Simple",11
+Parkrose,207340,2004,Burglary,30
+Parkrose,207340,2004,Curfew,2
+Parkrose,207340,2004,Disorderly Conduct,8
+Parkrose,207340,2004,Drugs,13
+Parkrose,207340,2004,DUII,10
+Parkrose,207340,2004,Embezzlement,2
+Parkrose,207340,2004,Forgery,27
+Parkrose,207340,2004,Fraud,24
+Parkrose,207340,2004,Gambling,
+Parkrose,207340,2004,Homicide,
+Parkrose,207340,2004,Kidnap,1
+Parkrose,207340,2004,Larceny,151
+Parkrose,207340,2004,Liquor Laws,6
+Parkrose,207340,2004,Motor Vehicle Theft,54
+Parkrose,207340,2004,Offenses Against Family,
+Parkrose,207340,2004,Prostitution,2
+Parkrose,207340,2004,Rape,1
+Parkrose,207340,2004,Robbery,4
+Parkrose,207340,2004,Runaway,
+Parkrose,207340,2004,Sex Offenses,
+Parkrose,207340,2004,Stolen Property,1
+Parkrose,207340,2004,Trespass,9
+Parkrose,207340,2004,Vandalism,37
+Parkrose,207340,2004,Weapons,1
+Parkrose,207340,2005,Aggravated Assault,32
+Parkrose,207340,2005,Arson,1
+Parkrose,207340,2005,"Assault, Simple",54
+Parkrose,207340,2005,Burglary,124
+Parkrose,207340,2005,Curfew,3
+Parkrose,207340,2005,Disorderly Conduct,40
+Parkrose,207340,2005,Drugs,50
+Parkrose,207340,2005,DUII,39
+Parkrose,207340,2005,Embezzlement,8
+Parkrose,207340,2005,Forgery,76
+Parkrose,207340,2005,Fraud,95
+Parkrose,207340,2005,Gambling,
+Parkrose,207340,2005,Homicide,
+Parkrose,207340,2005,Kidnap,
+Parkrose,207340,2005,Larceny,595
+Parkrose,207340,2005,Liquor Laws,11
+Parkrose,207340,2005,Motor Vehicle Theft,193
+Parkrose,207340,2005,Offenses Against Family,
+Parkrose,207340,2005,Prostitution,5
+Parkrose,207340,2005,Rape,
+Parkrose,207340,2005,Robbery,18
+Parkrose,207340,2005,Runaway,
+Parkrose,207340,2005,Sex Offenses,1
+Parkrose,207340,2005,Stolen Property,
+Parkrose,207340,2005,Trespass,49
+Parkrose,207340,2005,Vandalism,113
+Parkrose,207340,2005,Weapons,5
+Parkrose,207340,2006,Aggravated Assault,17
+Parkrose,207340,2006,Arson,
+Parkrose,207340,2006,"Assault, Simple",45
+Parkrose,207340,2006,Burglary,103
+Parkrose,207340,2006,Curfew,3
+Parkrose,207340,2006,Disorderly Conduct,30
+Parkrose,207340,2006,Drugs,59
+Parkrose,207340,2006,DUII,64
+Parkrose,207340,2006,Embezzlement,8
+Parkrose,207340,2006,Forgery,68
+Parkrose,207340,2006,Fraud,96
+Parkrose,207340,2006,Gambling,
+Parkrose,207340,2006,Homicide,
+Parkrose,207340,2006,Kidnap,
+Parkrose,207340,2006,Larceny,577
+Parkrose,207340,2006,Liquor Laws,10
+Parkrose,207340,2006,Motor Vehicle Theft,189
+Parkrose,207340,2006,Offenses Against Family,
+Parkrose,207340,2006,Prostitution,20
+Parkrose,207340,2006,Rape,
+Parkrose,207340,2006,Robbery,18
+Parkrose,207340,2006,Runaway,
+Parkrose,207340,2006,Sex Offenses,1
+Parkrose,207340,2006,Stolen Property,1
+Parkrose,207340,2006,Trespass,61
+Parkrose,207340,2006,Vandalism,137
+Parkrose,207340,2006,Weapons,9
+Parkrose,207340,2007,Aggravated Assault,30
+Parkrose,207340,2007,Arson,
+Parkrose,207340,2007,"Assault, Simple",50
+Parkrose,207340,2007,Burglary,120
+Parkrose,207340,2007,Curfew,
+Parkrose,207340,2007,Disorderly Conduct,46
+Parkrose,207340,2007,Drugs,86
+Parkrose,207340,2007,DUII,61
+Parkrose,207340,2007,Embezzlement,10
+Parkrose,207340,2007,Forgery,41
+Parkrose,207340,2007,Fraud,84
+Parkrose,207340,2007,Gambling,
+Parkrose,207340,2007,Homicide,
+Parkrose,207340,2007,Kidnap,
+Parkrose,207340,2007,Larceny,545
+Parkrose,207340,2007,Liquor Laws,14
+Parkrose,207340,2007,Motor Vehicle Theft,188
+Parkrose,207340,2007,Offenses Against Family,
+Parkrose,207340,2007,Prostitution,17
+Parkrose,207340,2007,Rape,4
+Parkrose,207340,2007,Robbery,24
+Parkrose,207340,2007,Runaway,
+Parkrose,207340,2007,Sex Offenses,1
+Parkrose,207340,2007,Stolen Property,4
+Parkrose,207340,2007,Trespass,66
+Parkrose,207340,2007,Vandalism,125
+Parkrose,207340,2007,Weapons,14
+Parkrose,207340,2008,Aggravated Assault,20
+Parkrose,207340,2008,Arson,
+Parkrose,207340,2008,"Assault, Simple",42
+Parkrose,207340,2008,Burglary,101
+Parkrose,207340,2008,Curfew,2
+Parkrose,207340,2008,Disorderly Conduct,47
+Parkrose,207340,2008,Drugs,68
+Parkrose,207340,2008,DUII,62
+Parkrose,207340,2008,Embezzlement,10
+Parkrose,207340,2008,Forgery,66
+Parkrose,207340,2008,Fraud,93
+Parkrose,207340,2008,Gambling,
+Parkrose,207340,2008,Homicide,
+Parkrose,207340,2008,Kidnap,
+Parkrose,207340,2008,Larceny,567
+Parkrose,207340,2008,Liquor Laws,11
+Parkrose,207340,2008,Motor Vehicle Theft,132
+Parkrose,207340,2008,Offenses Against Family,
+Parkrose,207340,2008,Prostitution,15
+Parkrose,207340,2008,Rape,
+Parkrose,207340,2008,Robbery,26
+Parkrose,207340,2008,Runaway,1
+Parkrose,207340,2008,Sex Offenses,
+Parkrose,207340,2008,Stolen Property,2
+Parkrose,207340,2008,Trespass,55
+Parkrose,207340,2008,Vandalism,124
+Parkrose,207340,2008,Weapons,11
+Parkrose,207340,2009,Aggravated Assault,32
+Parkrose,207340,2009,Arson,1
+Parkrose,207340,2009,"Assault, Simple",41
+Parkrose,207340,2009,Burglary,87
+Parkrose,207340,2009,Curfew,4
+Parkrose,207340,2009,Disorderly Conduct,35
+Parkrose,207340,2009,Drugs,19
+Parkrose,207340,2009,DUII,55
+Parkrose,207340,2009,Embezzlement,7
+Parkrose,207340,2009,Forgery,38
+Parkrose,207340,2009,Fraud,56
+Parkrose,207340,2009,Gambling,
+Parkrose,207340,2009,Homicide,
+Parkrose,207340,2009,Kidnap,
+Parkrose,207340,2009,Larceny,411
+Parkrose,207340,2009,Liquor Laws,6
+Parkrose,207340,2009,Motor Vehicle Theft,117
+Parkrose,207340,2009,Offenses Against Family,
+Parkrose,207340,2009,Prostitution,15
+Parkrose,207340,2009,Rape,
+Parkrose,207340,2009,Robbery,7
+Parkrose,207340,2009,Runaway,1
+Parkrose,207340,2009,Sex Offenses,1
+Parkrose,207340,2009,Stolen Property,1
+Parkrose,207340,2009,Trespass,75
+Parkrose,207340,2009,Vandalism,100
+Parkrose,207340,2009,Weapons,2
+Parkrose,207340,2010,Aggravated Assault,33
+Parkrose,207340,2010,Arson,1
+Parkrose,207340,2010,"Assault, Simple",50
+Parkrose,207340,2010,Burglary,99
+Parkrose,207340,2010,Curfew,1
+Parkrose,207340,2010,Disorderly Conduct,23
+Parkrose,207340,2010,Drugs,21
+Parkrose,207340,2010,DUII,57
+Parkrose,207340,2010,Embezzlement,4
+Parkrose,207340,2010,Forgery,23
+Parkrose,207340,2010,Fraud,53
+Parkrose,207340,2010,Gambling,
+Parkrose,207340,2010,Homicide,1
+Parkrose,207340,2010,Kidnap,
+Parkrose,207340,2010,Larceny,515
+Parkrose,207340,2010,Liquor Laws,3
+Parkrose,207340,2010,Motor Vehicle Theft,155
+Parkrose,207340,2010,Offenses Against Family,
+Parkrose,207340,2010,Prostitution,5
+Parkrose,207340,2010,Rape,
+Parkrose,207340,2010,Robbery,23
+Parkrose,207340,2010,Runaway,1
+Parkrose,207340,2010,Sex Offenses,
+Parkrose,207340,2010,Stolen Property,1
+Parkrose,207340,2010,Trespass,65
+Parkrose,207340,2010,Vandalism,122
+Parkrose,207340,2010,Weapons,4
+Parkrose,207340,2011,Aggravated Assault,40
+Parkrose,207340,2011,Arson,
+Parkrose,207340,2011,"Assault, Simple",41
+Parkrose,207340,2011,Burglary,114
+Parkrose,207340,2011,Curfew,
+Parkrose,207340,2011,Disorderly Conduct,33
+Parkrose,207340,2011,Drugs,28
+Parkrose,207340,2011,DUII,40
+Parkrose,207340,2011,Embezzlement,5
+Parkrose,207340,2011,Forgery,51
+Parkrose,207340,2011,Fraud,49
+Parkrose,207340,2011,Gambling,
+Parkrose,207340,2011,Homicide,1
+Parkrose,207340,2011,Kidnap,1
+Parkrose,207340,2011,Larceny,555
+Parkrose,207340,2011,Liquor Laws,
+Parkrose,207340,2011,Motor Vehicle Theft,136
+Parkrose,207340,2011,Offenses Against Family,
+Parkrose,207340,2011,Prostitution,4
+Parkrose,207340,2011,Rape,
+Parkrose,207340,2011,Robbery,18
+Parkrose,207340,2011,Runaway,
+Parkrose,207340,2011,Sex Offenses,1
+Parkrose,207340,2011,Stolen Property,1
+Parkrose,207340,2011,Trespass,46
+Parkrose,207340,2011,Vandalism,90
+Parkrose,207340,2011,Weapons,2
+Parkrose,207340,2012,Aggravated Assault,30
+Parkrose,207340,2012,Arson,
+Parkrose,207340,2012,"Assault, Simple",40
+Parkrose,207340,2012,Burglary,112
+Parkrose,207340,2012,Curfew,1
+Parkrose,207340,2012,Disorderly Conduct,23
+Parkrose,207340,2012,Drugs,29
+Parkrose,207340,2012,DUII,40
+Parkrose,207340,2012,Embezzlement,3
+Parkrose,207340,2012,Forgery,26
+Parkrose,207340,2012,Fraud,25
+Parkrose,207340,2012,Gambling,
+Parkrose,207340,2012,Homicide,1
+Parkrose,207340,2012,Kidnap,
+Parkrose,207340,2012,Larceny,462
+Parkrose,207340,2012,Liquor Laws,8
+Parkrose,207340,2012,Motor Vehicle Theft,148
+Parkrose,207340,2012,Offenses Against Family,
+Parkrose,207340,2012,Prostitution,30
+Parkrose,207340,2012,Rape,
+Parkrose,207340,2012,Robbery,17
+Parkrose,207340,2012,Runaway,
+Parkrose,207340,2012,Sex Offenses,1
+Parkrose,207340,2012,Stolen Property,2
+Parkrose,207340,2012,Trespass,62
+Parkrose,207340,2012,Vandalism,84
+Parkrose,207340,2012,Weapons,5
+Parkrose,207340,2013,Aggravated Assault,35
+Parkrose,207340,2013,Arson,
+Parkrose,207340,2013,"Assault, Simple",56
+Parkrose,207340,2013,Burglary,65
+Parkrose,207340,2013,Curfew,
+Parkrose,207340,2013,Disorderly Conduct,46
+Parkrose,207340,2013,Drugs,77
+Parkrose,207340,2013,DUII,49
+Parkrose,207340,2013,Embezzlement,4
+Parkrose,207340,2013,Forgery,33
+Parkrose,207340,2013,Fraud,54
+Parkrose,207340,2013,Gambling,
+Parkrose,207340,2013,Homicide,
+Parkrose,207340,2013,Kidnap,
+Parkrose,207340,2013,Larceny,477
+Parkrose,207340,2013,Liquor Laws,20
+Parkrose,207340,2013,Motor Vehicle Theft,135
+Parkrose,207340,2013,Offenses Against Family,
+Parkrose,207340,2013,Prostitution,44
+Parkrose,207340,2013,Rape,
+Parkrose,207340,2013,Robbery,14
+Parkrose,207340,2013,Runaway,
+Parkrose,207340,2013,Sex Offenses,1
+Parkrose,207340,2013,Stolen Property,4
+Parkrose,207340,2013,Trespass,68
+Parkrose,207340,2013,Vandalism,73
+Parkrose,207340,2013,Weapons,11
+Parkrose,207340,2014,Aggravated Assault,46
+Parkrose,207340,2014,Arson,
+Parkrose,207340,2014,"Assault, Simple",48
+Parkrose,207340,2014,Burglary,90
+Parkrose,207340,2014,Curfew,1
+Parkrose,207340,2014,Disorderly Conduct,49
+Parkrose,207340,2014,Drugs,86
+Parkrose,207340,2014,DUII,52
+Parkrose,207340,2014,Embezzlement,3
+Parkrose,207340,2014,Forgery,20
+Parkrose,207340,2014,Fraud,43
+Parkrose,207340,2014,Gambling,
+Parkrose,207340,2014,Homicide,1
+Parkrose,207340,2014,Kidnap,1
+Parkrose,207340,2014,Larceny,519
+Parkrose,207340,2014,Liquor Laws,5
+Parkrose,207340,2014,Motor Vehicle Theft,107
+Parkrose,207340,2014,Offenses Against Family,
+Parkrose,207340,2014,Prostitution,37
+Parkrose,207340,2014,Rape,1
+Parkrose,207340,2014,Robbery,17
+Parkrose,207340,2014,Runaway,
+Parkrose,207340,2014,Sex Offenses,3
+Parkrose,207340,2014,Stolen Property,2
+Parkrose,207340,2014,Trespass,81
+Parkrose,207340,2014,Vandalism,68
+Parkrose,207340,2014,Weapons,11
+Pearl District,271122,2004,Aggravated Assault,7
+Pearl District,271122,2004,Arson,
+Pearl District,271122,2004,"Assault, Simple",7
+Pearl District,271122,2004,Burglary,17
+Pearl District,271122,2004,Curfew,
+Pearl District,271122,2004,Disorderly Conduct,9
+Pearl District,271122,2004,Drugs,9
+Pearl District,271122,2004,DUII,6
+Pearl District,271122,2004,Embezzlement,
+Pearl District,271122,2004,Forgery,4
+Pearl District,271122,2004,Fraud,6
+Pearl District,271122,2004,Gambling,
+Pearl District,271122,2004,Homicide,
+Pearl District,271122,2004,Kidnap,
+Pearl District,271122,2004,Larceny,158
+Pearl District,271122,2004,Liquor Laws,5
+Pearl District,271122,2004,Motor Vehicle Theft,23
+Pearl District,271122,2004,Offenses Against Family,1
+Pearl District,271122,2004,Prostitution,5
+Pearl District,271122,2004,Rape,
+Pearl District,271122,2004,Robbery,8
+Pearl District,271122,2004,Runaway,
+Pearl District,271122,2004,Sex Offenses,
+Pearl District,271122,2004,Stolen Property,
+Pearl District,271122,2004,Trespass,15
+Pearl District,271122,2004,Vandalism,28
+Pearl District,271122,2004,Weapons,1
+Pearl District,271122,2005,Aggravated Assault,14
+Pearl District,271122,2005,Arson,
+Pearl District,271122,2005,"Assault, Simple",44
+Pearl District,271122,2005,Burglary,53
+Pearl District,271122,2005,Curfew,
+Pearl District,271122,2005,Disorderly Conduct,30
+Pearl District,271122,2005,Drugs,44
+Pearl District,271122,2005,DUII,33
+Pearl District,271122,2005,Embezzlement,1
+Pearl District,271122,2005,Forgery,13
+Pearl District,271122,2005,Fraud,32
+Pearl District,271122,2005,Gambling,
+Pearl District,271122,2005,Homicide,
+Pearl District,271122,2005,Kidnap,
+Pearl District,271122,2005,Larceny,403
+Pearl District,271122,2005,Liquor Laws,88
+Pearl District,271122,2005,Motor Vehicle Theft,39
+Pearl District,271122,2005,Offenses Against Family,
+Pearl District,271122,2005,Prostitution,1
+Pearl District,271122,2005,Rape,2
+Pearl District,271122,2005,Robbery,8
+Pearl District,271122,2005,Runaway,
+Pearl District,271122,2005,Sex Offenses,4
+Pearl District,271122,2005,Stolen Property,
+Pearl District,271122,2005,Trespass,52
+Pearl District,271122,2005,Vandalism,68
+Pearl District,271122,2005,Weapons,6
+Pearl District,271122,2006,Aggravated Assault,16
+Pearl District,271122,2006,Arson,2
+Pearl District,271122,2006,"Assault, Simple",50
+Pearl District,271122,2006,Burglary,29
+Pearl District,271122,2006,Curfew,2
+Pearl District,271122,2006,Disorderly Conduct,43
+Pearl District,271122,2006,Drugs,45
+Pearl District,271122,2006,DUII,32
+Pearl District,271122,2006,Embezzlement,3
+Pearl District,271122,2006,Forgery,13
+Pearl District,271122,2006,Fraud,21
+Pearl District,271122,2006,Gambling,
+Pearl District,271122,2006,Homicide,
+Pearl District,271122,2006,Kidnap,
+Pearl District,271122,2006,Larceny,401
+Pearl District,271122,2006,Liquor Laws,106
+Pearl District,271122,2006,Motor Vehicle Theft,48
+Pearl District,271122,2006,Offenses Against Family,
+Pearl District,271122,2006,Prostitution,2
+Pearl District,271122,2006,Rape,
+Pearl District,271122,2006,Robbery,14
+Pearl District,271122,2006,Runaway,
+Pearl District,271122,2006,Sex Offenses,
+Pearl District,271122,2006,Stolen Property,1
+Pearl District,271122,2006,Trespass,37
+Pearl District,271122,2006,Vandalism,66
+Pearl District,271122,2006,Weapons,3
+Pearl District,271122,2007,Aggravated Assault,19
+Pearl District,271122,2007,Arson,
+Pearl District,271122,2007,"Assault, Simple",52
+Pearl District,271122,2007,Burglary,36
+Pearl District,271122,2007,Curfew,
+Pearl District,271122,2007,Disorderly Conduct,39
+Pearl District,271122,2007,Drugs,32
+Pearl District,271122,2007,DUII,41
+Pearl District,271122,2007,Embezzlement,5
+Pearl District,271122,2007,Forgery,8
+Pearl District,271122,2007,Fraud,33
+Pearl District,271122,2007,Gambling,
+Pearl District,271122,2007,Homicide,
+Pearl District,271122,2007,Kidnap,
+Pearl District,271122,2007,Larceny,453
+Pearl District,271122,2007,Liquor Laws,108
+Pearl District,271122,2007,Motor Vehicle Theft,44
+Pearl District,271122,2007,Offenses Against Family,
+Pearl District,271122,2007,Prostitution,1
+Pearl District,271122,2007,Rape,
+Pearl District,271122,2007,Robbery,23
+Pearl District,271122,2007,Runaway,1
+Pearl District,271122,2007,Sex Offenses,1
+Pearl District,271122,2007,Stolen Property,
+Pearl District,271122,2007,Trespass,39
+Pearl District,271122,2007,Vandalism,60
+Pearl District,271122,2007,Weapons,2
+Pearl District,271122,2008,Aggravated Assault,24
+Pearl District,271122,2008,Arson,
+Pearl District,271122,2008,"Assault, Simple",58
+Pearl District,271122,2008,Burglary,32
+Pearl District,271122,2008,Curfew,
+Pearl District,271122,2008,Disorderly Conduct,43
+Pearl District,271122,2008,Drugs,50
+Pearl District,271122,2008,DUII,32
+Pearl District,271122,2008,Embezzlement,3
+Pearl District,271122,2008,Forgery,5
+Pearl District,271122,2008,Fraud,13
+Pearl District,271122,2008,Gambling,
+Pearl District,271122,2008,Homicide,
+Pearl District,271122,2008,Kidnap,
+Pearl District,271122,2008,Larceny,413
+Pearl District,271122,2008,Liquor Laws,174
+Pearl District,271122,2008,Motor Vehicle Theft,44
+Pearl District,271122,2008,Offenses Against Family,
+Pearl District,271122,2008,Prostitution,1
+Pearl District,271122,2008,Rape,2
+Pearl District,271122,2008,Robbery,18
+Pearl District,271122,2008,Runaway,
+Pearl District,271122,2008,Sex Offenses,
+Pearl District,271122,2008,Stolen Property,2
+Pearl District,271122,2008,Trespass,34
+Pearl District,271122,2008,Vandalism,69
+Pearl District,271122,2008,Weapons,4
+Pearl District,271122,2009,Aggravated Assault,14
+Pearl District,271122,2009,Arson,
+Pearl District,271122,2009,"Assault, Simple",41
+Pearl District,271122,2009,Burglary,41
+Pearl District,271122,2009,Curfew,
+Pearl District,271122,2009,Disorderly Conduct,47
+Pearl District,271122,2009,Drugs,67
+Pearl District,271122,2009,DUII,26
+Pearl District,271122,2009,Embezzlement,4
+Pearl District,271122,2009,Forgery,9
+Pearl District,271122,2009,Fraud,19
+Pearl District,271122,2009,Gambling,
+Pearl District,271122,2009,Homicide,
+Pearl District,271122,2009,Kidnap,
+Pearl District,271122,2009,Larceny,482
+Pearl District,271122,2009,Liquor Laws,197
+Pearl District,271122,2009,Motor Vehicle Theft,32
+Pearl District,271122,2009,Offenses Against Family,
+Pearl District,271122,2009,Prostitution,1
+Pearl District,271122,2009,Rape,
+Pearl District,271122,2009,Robbery,11
+Pearl District,271122,2009,Runaway,
+Pearl District,271122,2009,Sex Offenses,2
+Pearl District,271122,2009,Stolen Property,
+Pearl District,271122,2009,Trespass,58
+Pearl District,271122,2009,Vandalism,59
+Pearl District,271122,2009,Weapons,3
+Pearl District,271122,2010,Aggravated Assault,20
+Pearl District,271122,2010,Arson,
+Pearl District,271122,2010,"Assault, Simple",28
+Pearl District,271122,2010,Burglary,29
+Pearl District,271122,2010,Curfew,
+Pearl District,271122,2010,Disorderly Conduct,58
+Pearl District,271122,2010,Drugs,77
+Pearl District,271122,2010,DUII,19
+Pearl District,271122,2010,Embezzlement,
+Pearl District,271122,2010,Forgery,9
+Pearl District,271122,2010,Fraud,17
+Pearl District,271122,2010,Gambling,
+Pearl District,271122,2010,Homicide,
+Pearl District,271122,2010,Kidnap,
+Pearl District,271122,2010,Larceny,628
+Pearl District,271122,2010,Liquor Laws,118
+Pearl District,271122,2010,Motor Vehicle Theft,35
+Pearl District,271122,2010,Offenses Against Family,1
+Pearl District,271122,2010,Prostitution,
+Pearl District,271122,2010,Rape,
+Pearl District,271122,2010,Robbery,15
+Pearl District,271122,2010,Runaway,
+Pearl District,271122,2010,Sex Offenses,1
+Pearl District,271122,2010,Stolen Property,
+Pearl District,271122,2010,Trespass,42
+Pearl District,271122,2010,Vandalism,70
+Pearl District,271122,2010,Weapons,5
+Pearl District,271122,2011,Aggravated Assault,18
+Pearl District,271122,2011,Arson,5
+Pearl District,271122,2011,"Assault, Simple",36
+Pearl District,271122,2011,Burglary,39
+Pearl District,271122,2011,Curfew,
+Pearl District,271122,2011,Disorderly Conduct,90
+Pearl District,271122,2011,Drugs,110
+Pearl District,271122,2011,DUII,27
+Pearl District,271122,2011,Embezzlement,1
+Pearl District,271122,2011,Forgery,8
+Pearl District,271122,2011,Fraud,29
+Pearl District,271122,2011,Gambling,
+Pearl District,271122,2011,Homicide,
+Pearl District,271122,2011,Kidnap,
+Pearl District,271122,2011,Larceny,736
+Pearl District,271122,2011,Liquor Laws,134
+Pearl District,271122,2011,Motor Vehicle Theft,33
+Pearl District,271122,2011,Offenses Against Family,
+Pearl District,271122,2011,Prostitution,1
+Pearl District,271122,2011,Rape,1
+Pearl District,271122,2011,Robbery,16
+Pearl District,271122,2011,Runaway,
+Pearl District,271122,2011,Sex Offenses,
+Pearl District,271122,2011,Stolen Property,3
+Pearl District,271122,2011,Trespass,40
+Pearl District,271122,2011,Vandalism,72
+Pearl District,271122,2011,Weapons,3
+Pearl District,271122,2012,Aggravated Assault,21
+Pearl District,271122,2012,Arson,
+Pearl District,271122,2012,"Assault, Simple",48
+Pearl District,271122,2012,Burglary,42
+Pearl District,271122,2012,Curfew,
+Pearl District,271122,2012,Disorderly Conduct,62
+Pearl District,271122,2012,Drugs,75
+Pearl District,271122,2012,DUII,31
+Pearl District,271122,2012,Embezzlement,3
+Pearl District,271122,2012,Forgery,11
+Pearl District,271122,2012,Fraud,36
+Pearl District,271122,2012,Gambling,
+Pearl District,271122,2012,Homicide,1
+Pearl District,271122,2012,Kidnap,
+Pearl District,271122,2012,Larceny,688
+Pearl District,271122,2012,Liquor Laws,135
+Pearl District,271122,2012,Motor Vehicle Theft,42
+Pearl District,271122,2012,Offenses Against Family,
+Pearl District,271122,2012,Prostitution,1
+Pearl District,271122,2012,Rape,1
+Pearl District,271122,2012,Robbery,17
+Pearl District,271122,2012,Runaway,
+Pearl District,271122,2012,Sex Offenses,2
+Pearl District,271122,2012,Stolen Property,3
+Pearl District,271122,2012,Trespass,50
+Pearl District,271122,2012,Vandalism,94
+Pearl District,271122,2012,Weapons,7
+Pearl District,271122,2013,Aggravated Assault,17
+Pearl District,271122,2013,Arson,
+Pearl District,271122,2013,"Assault, Simple",47
+Pearl District,271122,2013,Burglary,42
+Pearl District,271122,2013,Curfew,
+Pearl District,271122,2013,Disorderly Conduct,54
+Pearl District,271122,2013,Drugs,105
+Pearl District,271122,2013,DUII,29
+Pearl District,271122,2013,Embezzlement,4
+Pearl District,271122,2013,Forgery,8
+Pearl District,271122,2013,Fraud,24
+Pearl District,271122,2013,Gambling,
+Pearl District,271122,2013,Homicide,
+Pearl District,271122,2013,Kidnap,
+Pearl District,271122,2013,Larceny,815
+Pearl District,271122,2013,Liquor Laws,132
+Pearl District,271122,2013,Motor Vehicle Theft,42
+Pearl District,271122,2013,Offenses Against Family,
+Pearl District,271122,2013,Prostitution,
+Pearl District,271122,2013,Rape,1
+Pearl District,271122,2013,Robbery,20
+Pearl District,271122,2013,Runaway,1
+Pearl District,271122,2013,Sex Offenses,2
+Pearl District,271122,2013,Stolen Property,2
+Pearl District,271122,2013,Trespass,41
+Pearl District,271122,2013,Vandalism,56
+Pearl District,271122,2013,Weapons,7
+Pearl District,271122,2014,Aggravated Assault,17
+Pearl District,271122,2014,Arson,
+Pearl District,271122,2014,"Assault, Simple",45
+Pearl District,271122,2014,Burglary,55
+Pearl District,271122,2014,Curfew,1
+Pearl District,271122,2014,Disorderly Conduct,54
+Pearl District,271122,2014,Drugs,79
+Pearl District,271122,2014,DUII,19
+Pearl District,271122,2014,Embezzlement,1
+Pearl District,271122,2014,Forgery,10
+Pearl District,271122,2014,Fraud,30
+Pearl District,271122,2014,Gambling,
+Pearl District,271122,2014,Homicide,
+Pearl District,271122,2014,Kidnap,
+Pearl District,271122,2014,Larceny,1010
+Pearl District,271122,2014,Liquor Laws,83
+Pearl District,271122,2014,Motor Vehicle Theft,46
+Pearl District,271122,2014,Offenses Against Family,
+Pearl District,271122,2014,Prostitution,
+Pearl District,271122,2014,Rape,2
+Pearl District,271122,2014,Robbery,21
+Pearl District,271122,2014,Runaway,
+Pearl District,271122,2014,Sex Offenses,2
+Pearl District,271122,2014,Stolen Property,4
+Pearl District,271122,2014,Trespass,50
+Pearl District,271122,2014,Vandalism,85
+Pearl District,271122,2014,Weapons,4
+Pleasant Valley,275055,2004,Aggravated Assault,
+Pleasant Valley,275055,2004,Arson,
+Pleasant Valley,275055,2004,"Assault, Simple",2
+Pleasant Valley,275055,2004,Burglary,16
+Pleasant Valley,275055,2004,Curfew,1
+Pleasant Valley,275055,2004,Disorderly Conduct,4
+Pleasant Valley,275055,2004,Drugs,1
+Pleasant Valley,275055,2004,DUII,2
+Pleasant Valley,275055,2004,Embezzlement,
+Pleasant Valley,275055,2004,Forgery,3
+Pleasant Valley,275055,2004,Fraud,5
+Pleasant Valley,275055,2004,Gambling,
+Pleasant Valley,275055,2004,Homicide,
+Pleasant Valley,275055,2004,Kidnap,
+Pleasant Valley,275055,2004,Larceny,30
+Pleasant Valley,275055,2004,Liquor Laws,
+Pleasant Valley,275055,2004,Motor Vehicle Theft,7
+Pleasant Valley,275055,2004,Offenses Against Family,
+Pleasant Valley,275055,2004,Prostitution,
+Pleasant Valley,275055,2004,Rape,
+Pleasant Valley,275055,2004,Robbery,1
+Pleasant Valley,275055,2004,Runaway,
+Pleasant Valley,275055,2004,Sex Offenses,
+Pleasant Valley,275055,2004,Stolen Property,
+Pleasant Valley,275055,2004,Trespass,2
+Pleasant Valley,275055,2004,Vandalism,5
+Pleasant Valley,275055,2004,Weapons,
+Pleasant Valley,275055,2005,Aggravated Assault,13
+Pleasant Valley,275055,2005,Arson,1
+Pleasant Valley,275055,2005,"Assault, Simple",16
+Pleasant Valley,275055,2005,Burglary,83
+Pleasant Valley,275055,2005,Curfew,1
+Pleasant Valley,275055,2005,Disorderly Conduct,5
+Pleasant Valley,275055,2005,Drugs,14
+Pleasant Valley,275055,2005,DUII,17
+Pleasant Valley,275055,2005,Embezzlement,
+Pleasant Valley,275055,2005,Forgery,9
+Pleasant Valley,275055,2005,Fraud,28
+Pleasant Valley,275055,2005,Gambling,
+Pleasant Valley,275055,2005,Homicide,
+Pleasant Valley,275055,2005,Kidnap,2
+Pleasant Valley,275055,2005,Larceny,202
+Pleasant Valley,275055,2005,Liquor Laws,1
+Pleasant Valley,275055,2005,Motor Vehicle Theft,51
+Pleasant Valley,275055,2005,Offenses Against Family,
+Pleasant Valley,275055,2005,Prostitution,
+Pleasant Valley,275055,2005,Rape,
+Pleasant Valley,275055,2005,Robbery,4
+Pleasant Valley,275055,2005,Runaway,
+Pleasant Valley,275055,2005,Sex Offenses,
+Pleasant Valley,275055,2005,Stolen Property,
+Pleasant Valley,275055,2005,Trespass,13
+Pleasant Valley,275055,2005,Vandalism,58
+Pleasant Valley,275055,2005,Weapons,2
+Pleasant Valley,275055,2006,Aggravated Assault,11
+Pleasant Valley,275055,2006,Arson,
+Pleasant Valley,275055,2006,"Assault, Simple",18
+Pleasant Valley,275055,2006,Burglary,65
+Pleasant Valley,275055,2006,Curfew,
+Pleasant Valley,275055,2006,Disorderly Conduct,13
+Pleasant Valley,275055,2006,Drugs,14
+Pleasant Valley,275055,2006,DUII,18
+Pleasant Valley,275055,2006,Embezzlement,
+Pleasant Valley,275055,2006,Forgery,8
+Pleasant Valley,275055,2006,Fraud,32
+Pleasant Valley,275055,2006,Gambling,
+Pleasant Valley,275055,2006,Homicide,
+Pleasant Valley,275055,2006,Kidnap,2
+Pleasant Valley,275055,2006,Larceny,183
+Pleasant Valley,275055,2006,Liquor Laws,1
+Pleasant Valley,275055,2006,Motor Vehicle Theft,61
+Pleasant Valley,275055,2006,Offenses Against Family,
+Pleasant Valley,275055,2006,Prostitution,
+Pleasant Valley,275055,2006,Rape,
+Pleasant Valley,275055,2006,Robbery,5
+Pleasant Valley,275055,2006,Runaway,
+Pleasant Valley,275055,2006,Sex Offenses,
+Pleasant Valley,275055,2006,Stolen Property,1
+Pleasant Valley,275055,2006,Trespass,16
+Pleasant Valley,275055,2006,Vandalism,64
+Pleasant Valley,275055,2006,Weapons,1
+Pleasant Valley,275055,2007,Aggravated Assault,11
+Pleasant Valley,275055,2007,Arson,
+Pleasant Valley,275055,2007,"Assault, Simple",24
+Pleasant Valley,275055,2007,Burglary,79
+Pleasant Valley,275055,2007,Curfew,1
+Pleasant Valley,275055,2007,Disorderly Conduct,19
+Pleasant Valley,275055,2007,Drugs,7
+Pleasant Valley,275055,2007,DUII,16
+Pleasant Valley,275055,2007,Embezzlement,1
+Pleasant Valley,275055,2007,Forgery,4
+Pleasant Valley,275055,2007,Fraud,24
+Pleasant Valley,275055,2007,Gambling,
+Pleasant Valley,275055,2007,Homicide,
+Pleasant Valley,275055,2007,Kidnap,
+Pleasant Valley,275055,2007,Larceny,208
+Pleasant Valley,275055,2007,Liquor Laws,4
+Pleasant Valley,275055,2007,Motor Vehicle Theft,45
+Pleasant Valley,275055,2007,Offenses Against Family,
+Pleasant Valley,275055,2007,Prostitution,
+Pleasant Valley,275055,2007,Rape,1
+Pleasant Valley,275055,2007,Robbery,5
+Pleasant Valley,275055,2007,Runaway,
+Pleasant Valley,275055,2007,Sex Offenses,1
+Pleasant Valley,275055,2007,Stolen Property,1
+Pleasant Valley,275055,2007,Trespass,17
+Pleasant Valley,275055,2007,Vandalism,58
+Pleasant Valley,275055,2007,Weapons,5
+Pleasant Valley,275055,2008,Aggravated Assault,15
+Pleasant Valley,275055,2008,Arson,
+Pleasant Valley,275055,2008,"Assault, Simple",18
+Pleasant Valley,275055,2008,Burglary,68
+Pleasant Valley,275055,2008,Curfew,
+Pleasant Valley,275055,2008,Disorderly Conduct,18
+Pleasant Valley,275055,2008,Drugs,6
+Pleasant Valley,275055,2008,DUII,14
+Pleasant Valley,275055,2008,Embezzlement,1
+Pleasant Valley,275055,2008,Forgery,5
+Pleasant Valley,275055,2008,Fraud,24
+Pleasant Valley,275055,2008,Gambling,
+Pleasant Valley,275055,2008,Homicide,
+Pleasant Valley,275055,2008,Kidnap,
+Pleasant Valley,275055,2008,Larceny,163
+Pleasant Valley,275055,2008,Liquor Laws,6
+Pleasant Valley,275055,2008,Motor Vehicle Theft,39
+Pleasant Valley,275055,2008,Offenses Against Family,
+Pleasant Valley,275055,2008,Prostitution,
+Pleasant Valley,275055,2008,Rape,
+Pleasant Valley,275055,2008,Robbery,
+Pleasant Valley,275055,2008,Runaway,
+Pleasant Valley,275055,2008,Sex Offenses,
+Pleasant Valley,275055,2008,Stolen Property,
+Pleasant Valley,275055,2008,Trespass,22
+Pleasant Valley,275055,2008,Vandalism,55
+Pleasant Valley,275055,2008,Weapons,3
+Pleasant Valley,275055,2009,Aggravated Assault,15
+Pleasant Valley,275055,2009,Arson,1
+Pleasant Valley,275055,2009,"Assault, Simple",18
+Pleasant Valley,275055,2009,Burglary,69
+Pleasant Valley,275055,2009,Curfew,
+Pleasant Valley,275055,2009,Disorderly Conduct,14
+Pleasant Valley,275055,2009,Drugs,9
+Pleasant Valley,275055,2009,DUII,21
+Pleasant Valley,275055,2009,Embezzlement,
+Pleasant Valley,275055,2009,Forgery,2
+Pleasant Valley,275055,2009,Fraud,16
+Pleasant Valley,275055,2009,Gambling,
+Pleasant Valley,275055,2009,Homicide,
+Pleasant Valley,275055,2009,Kidnap,
+Pleasant Valley,275055,2009,Larceny,193
+Pleasant Valley,275055,2009,Liquor Laws,3
+Pleasant Valley,275055,2009,Motor Vehicle Theft,49
+Pleasant Valley,275055,2009,Offenses Against Family,
+Pleasant Valley,275055,2009,Prostitution,
+Pleasant Valley,275055,2009,Rape,
+Pleasant Valley,275055,2009,Robbery,6
+Pleasant Valley,275055,2009,Runaway,
+Pleasant Valley,275055,2009,Sex Offenses,
+Pleasant Valley,275055,2009,Stolen Property,
+Pleasant Valley,275055,2009,Trespass,16
+Pleasant Valley,275055,2009,Vandalism,50
+Pleasant Valley,275055,2009,Weapons,5
+Pleasant Valley,275055,2010,Aggravated Assault,12
+Pleasant Valley,275055,2010,Arson,
+Pleasant Valley,275055,2010,"Assault, Simple",21
+Pleasant Valley,275055,2010,Burglary,104
+Pleasant Valley,275055,2010,Curfew,
+Pleasant Valley,275055,2010,Disorderly Conduct,16
+Pleasant Valley,275055,2010,Drugs,12
+Pleasant Valley,275055,2010,DUII,18
+Pleasant Valley,275055,2010,Embezzlement,
+Pleasant Valley,275055,2010,Forgery,6
+Pleasant Valley,275055,2010,Fraud,22
+Pleasant Valley,275055,2010,Gambling,
+Pleasant Valley,275055,2010,Homicide,1
+Pleasant Valley,275055,2010,Kidnap,
+Pleasant Valley,275055,2010,Larceny,188
+Pleasant Valley,275055,2010,Liquor Laws,1
+Pleasant Valley,275055,2010,Motor Vehicle Theft,40
+Pleasant Valley,275055,2010,Offenses Against Family,
+Pleasant Valley,275055,2010,Prostitution,
+Pleasant Valley,275055,2010,Rape,
+Pleasant Valley,275055,2010,Robbery,8
+Pleasant Valley,275055,2010,Runaway,
+Pleasant Valley,275055,2010,Sex Offenses,
+Pleasant Valley,275055,2010,Stolen Property,
+Pleasant Valley,275055,2010,Trespass,16
+Pleasant Valley,275055,2010,Vandalism,55
+Pleasant Valley,275055,2010,Weapons,1
+Pleasant Valley,275055,2011,Aggravated Assault,7
+Pleasant Valley,275055,2011,Arson,
+Pleasant Valley,275055,2011,"Assault, Simple",10
+Pleasant Valley,275055,2011,Burglary,82
+Pleasant Valley,275055,2011,Curfew,
+Pleasant Valley,275055,2011,Disorderly Conduct,13
+Pleasant Valley,275055,2011,Drugs,19
+Pleasant Valley,275055,2011,DUII,7
+Pleasant Valley,275055,2011,Embezzlement,
+Pleasant Valley,275055,2011,Forgery,3
+Pleasant Valley,275055,2011,Fraud,20
+Pleasant Valley,275055,2011,Gambling,
+Pleasant Valley,275055,2011,Homicide,
+Pleasant Valley,275055,2011,Kidnap,1
+Pleasant Valley,275055,2011,Larceny,167
+Pleasant Valley,275055,2011,Liquor Laws,2
+Pleasant Valley,275055,2011,Motor Vehicle Theft,40
+Pleasant Valley,275055,2011,Offenses Against Family,
+Pleasant Valley,275055,2011,Prostitution,
+Pleasant Valley,275055,2011,Rape,
+Pleasant Valley,275055,2011,Robbery,3
+Pleasant Valley,275055,2011,Runaway,
+Pleasant Valley,275055,2011,Sex Offenses,
+Pleasant Valley,275055,2011,Stolen Property,
+Pleasant Valley,275055,2011,Trespass,13
+Pleasant Valley,275055,2011,Vandalism,40
+Pleasant Valley,275055,2011,Weapons,2
+Pleasant Valley,275055,2012,Aggravated Assault,21
+Pleasant Valley,275055,2012,Arson,2
+Pleasant Valley,275055,2012,"Assault, Simple",13
+Pleasant Valley,275055,2012,Burglary,79
+Pleasant Valley,275055,2012,Curfew,
+Pleasant Valley,275055,2012,Disorderly Conduct,15
+Pleasant Valley,275055,2012,Drugs,8
+Pleasant Valley,275055,2012,DUII,17
+Pleasant Valley,275055,2012,Embezzlement,
+Pleasant Valley,275055,2012,Forgery,2
+Pleasant Valley,275055,2012,Fraud,14
+Pleasant Valley,275055,2012,Gambling,
+Pleasant Valley,275055,2012,Homicide,
+Pleasant Valley,275055,2012,Kidnap,
+Pleasant Valley,275055,2012,Larceny,178
+Pleasant Valley,275055,2012,Liquor Laws,2
+Pleasant Valley,275055,2012,Motor Vehicle Theft,38
+Pleasant Valley,275055,2012,Offenses Against Family,
+Pleasant Valley,275055,2012,Prostitution,
+Pleasant Valley,275055,2012,Rape,
+Pleasant Valley,275055,2012,Robbery,5
+Pleasant Valley,275055,2012,Runaway,
+Pleasant Valley,275055,2012,Sex Offenses,1
+Pleasant Valley,275055,2012,Stolen Property,
+Pleasant Valley,275055,2012,Trespass,12
+Pleasant Valley,275055,2012,Vandalism,46
+Pleasant Valley,275055,2012,Weapons,1
+Pleasant Valley,275055,2013,Aggravated Assault,6
+Pleasant Valley,275055,2013,Arson,
+Pleasant Valley,275055,2013,"Assault, Simple",19
+Pleasant Valley,275055,2013,Burglary,64
+Pleasant Valley,275055,2013,Curfew,
+Pleasant Valley,275055,2013,Disorderly Conduct,18
+Pleasant Valley,275055,2013,Drugs,7
+Pleasant Valley,275055,2013,DUII,14
+Pleasant Valley,275055,2013,Embezzlement,1
+Pleasant Valley,275055,2013,Forgery,5
+Pleasant Valley,275055,2013,Fraud,18
+Pleasant Valley,275055,2013,Gambling,
+Pleasant Valley,275055,2013,Homicide,
+Pleasant Valley,275055,2013,Kidnap,
+Pleasant Valley,275055,2013,Larceny,119
+Pleasant Valley,275055,2013,Liquor Laws,
+Pleasant Valley,275055,2013,Motor Vehicle Theft,25
+Pleasant Valley,275055,2013,Offenses Against Family,
+Pleasant Valley,275055,2013,Prostitution,
+Pleasant Valley,275055,2013,Rape,
+Pleasant Valley,275055,2013,Robbery,5
+Pleasant Valley,275055,2013,Runaway,
+Pleasant Valley,275055,2013,Sex Offenses,
+Pleasant Valley,275055,2013,Stolen Property,
+Pleasant Valley,275055,2013,Trespass,11
+Pleasant Valley,275055,2013,Vandalism,35
+Pleasant Valley,275055,2013,Weapons,1
+Pleasant Valley,275055,2014,Aggravated Assault,7
+Pleasant Valley,275055,2014,Arson,
+Pleasant Valley,275055,2014,"Assault, Simple",12
+Pleasant Valley,275055,2014,Burglary,57
+Pleasant Valley,275055,2014,Curfew,
+Pleasant Valley,275055,2014,Disorderly Conduct,13
+Pleasant Valley,275055,2014,Drugs,6
+Pleasant Valley,275055,2014,DUII,12
+Pleasant Valley,275055,2014,Embezzlement,1
+Pleasant Valley,275055,2014,Forgery,4
+Pleasant Valley,275055,2014,Fraud,23
+Pleasant Valley,275055,2014,Gambling,
+Pleasant Valley,275055,2014,Homicide,
+Pleasant Valley,275055,2014,Kidnap,1
+Pleasant Valley,275055,2014,Larceny,125
+Pleasant Valley,275055,2014,Liquor Laws,
+Pleasant Valley,275055,2014,Motor Vehicle Theft,37
+Pleasant Valley,275055,2014,Offenses Against Family,
+Pleasant Valley,275055,2014,Prostitution,
+Pleasant Valley,275055,2014,Rape,
+Pleasant Valley,275055,2014,Robbery,
+Pleasant Valley,275055,2014,Runaway,
+Pleasant Valley,275055,2014,Sex Offenses,1
+Pleasant Valley,275055,2014,Stolen Property,
+Pleasant Valley,275055,2014,Trespass,11
+Pleasant Valley,275055,2014,Vandalism,34
+Pleasant Valley,275055,2014,Weapons,3
+Portsmith,275080,2004,Aggravated Assault,2
+Portsmith,275080,2004,Arson,
+Portsmith,275080,2004,"Assault, Simple",11
+Portsmith,275080,2004,Burglary,21
+Portsmith,275080,2004,Curfew,1
+Portsmith,275080,2004,Disorderly Conduct,6
+Portsmith,275080,2004,Drugs,4
+Portsmith,275080,2004,DUII,8
+Portsmith,275080,2004,Embezzlement,
+Portsmith,275080,2004,Forgery,1
+Portsmith,275080,2004,Fraud,5
+Portsmith,275080,2004,Gambling,
+Portsmith,275080,2004,Homicide,
+Portsmith,275080,2004,Kidnap,
+Portsmith,275080,2004,Larceny,51
+Portsmith,275080,2004,Liquor Laws,1
+Portsmith,275080,2004,Motor Vehicle Theft,24
+Portsmith,275080,2004,Offenses Against Family,
+Portsmith,275080,2004,Prostitution,
+Portsmith,275080,2004,Rape,
+Portsmith,275080,2004,Robbery,1
+Portsmith,275080,2004,Runaway,
+Portsmith,275080,2004,Sex Offenses,
+Portsmith,275080,2004,Stolen Property,
+Portsmith,275080,2004,Trespass,3
+Portsmith,275080,2004,Vandalism,21
+Portsmith,275080,2004,Weapons,3
+Portsmith,275080,2005,Aggravated Assault,28
+Portsmith,275080,2005,Arson,1
+Portsmith,275080,2005,"Assault, Simple",24
+Portsmith,275080,2005,Burglary,57
+Portsmith,275080,2005,Curfew,5
+Portsmith,275080,2005,Disorderly Conduct,32
+Portsmith,275080,2005,Drugs,20
+Portsmith,275080,2005,DUII,26
+Portsmith,275080,2005,Embezzlement,
+Portsmith,275080,2005,Forgery,12
+Portsmith,275080,2005,Fraud,13
+Portsmith,275080,2005,Gambling,
+Portsmith,275080,2005,Homicide,
+Portsmith,275080,2005,Kidnap,
+Portsmith,275080,2005,Larceny,173
+Portsmith,275080,2005,Liquor Laws,8
+Portsmith,275080,2005,Motor Vehicle Theft,68
+Portsmith,275080,2005,Offenses Against Family,
+Portsmith,275080,2005,Prostitution,
+Portsmith,275080,2005,Rape,
+Portsmith,275080,2005,Robbery,4
+Portsmith,275080,2005,Runaway,1
+Portsmith,275080,2005,Sex Offenses,
+Portsmith,275080,2005,Stolen Property,1
+Portsmith,275080,2005,Trespass,23
+Portsmith,275080,2005,Vandalism,95
+Portsmith,275080,2005,Weapons,2
+Portsmith,275080,2006,Aggravated Assault,25
+Portsmith,275080,2006,Arson,2
+Portsmith,275080,2006,"Assault, Simple",49
+Portsmith,275080,2006,Burglary,66
+Portsmith,275080,2006,Curfew,
+Portsmith,275080,2006,Disorderly Conduct,37
+Portsmith,275080,2006,Drugs,25
+Portsmith,275080,2006,DUII,28
+Portsmith,275080,2006,Embezzlement,
+Portsmith,275080,2006,Forgery,11
+Portsmith,275080,2006,Fraud,34
+Portsmith,275080,2006,Gambling,
+Portsmith,275080,2006,Homicide,
+Portsmith,275080,2006,Kidnap,1
+Portsmith,275080,2006,Larceny,188
+Portsmith,275080,2006,Liquor Laws,9
+Portsmith,275080,2006,Motor Vehicle Theft,73
+Portsmith,275080,2006,Offenses Against Family,
+Portsmith,275080,2006,Prostitution,
+Portsmith,275080,2006,Rape,
+Portsmith,275080,2006,Robbery,9
+Portsmith,275080,2006,Runaway,1
+Portsmith,275080,2006,Sex Offenses,
+Portsmith,275080,2006,Stolen Property,
+Portsmith,275080,2006,Trespass,43
+Portsmith,275080,2006,Vandalism,104
+Portsmith,275080,2006,Weapons,4
+Portsmith,275080,2007,Aggravated Assault,27
+Portsmith,275080,2007,Arson,
+Portsmith,275080,2007,"Assault, Simple",48
+Portsmith,275080,2007,Burglary,61
+Portsmith,275080,2007,Curfew,20
+Portsmith,275080,2007,Disorderly Conduct,40
+Portsmith,275080,2007,Drugs,29
+Portsmith,275080,2007,DUII,21
+Portsmith,275080,2007,Embezzlement,
+Portsmith,275080,2007,Forgery,12
+Portsmith,275080,2007,Fraud,20
+Portsmith,275080,2007,Gambling,
+Portsmith,275080,2007,Homicide,
+Portsmith,275080,2007,Kidnap,2
+Portsmith,275080,2007,Larceny,196
+Portsmith,275080,2007,Liquor Laws,19
+Portsmith,275080,2007,Motor Vehicle Theft,58
+Portsmith,275080,2007,Offenses Against Family,1
+Portsmith,275080,2007,Prostitution,
+Portsmith,275080,2007,Rape,1
+Portsmith,275080,2007,Robbery,29
+Portsmith,275080,2007,Runaway,
+Portsmith,275080,2007,Sex Offenses,1
+Portsmith,275080,2007,Stolen Property,4
+Portsmith,275080,2007,Trespass,55
+Portsmith,275080,2007,Vandalism,107
+Portsmith,275080,2007,Weapons,8
+Portsmith,275080,2008,Aggravated Assault,33
+Portsmith,275080,2008,Arson,2
+Portsmith,275080,2008,"Assault, Simple",45
+Portsmith,275080,2008,Burglary,62
+Portsmith,275080,2008,Curfew,3
+Portsmith,275080,2008,Disorderly Conduct,39
+Portsmith,275080,2008,Drugs,31
+Portsmith,275080,2008,DUII,22
+Portsmith,275080,2008,Embezzlement,2
+Portsmith,275080,2008,Forgery,3
+Portsmith,275080,2008,Fraud,11
+Portsmith,275080,2008,Gambling,
+Portsmith,275080,2008,Homicide,
+Portsmith,275080,2008,Kidnap,1
+Portsmith,275080,2008,Larceny,200
+Portsmith,275080,2008,Liquor Laws,9
+Portsmith,275080,2008,Motor Vehicle Theft,63
+Portsmith,275080,2008,Offenses Against Family,
+Portsmith,275080,2008,Prostitution,
+Portsmith,275080,2008,Rape,
+Portsmith,275080,2008,Robbery,9
+Portsmith,275080,2008,Runaway,
+Portsmith,275080,2008,Sex Offenses,2
+Portsmith,275080,2008,Stolen Property,1
+Portsmith,275080,2008,Trespass,46
+Portsmith,275080,2008,Vandalism,128
+Portsmith,275080,2008,Weapons,9
+Portsmith,275080,2009,Aggravated Assault,27
+Portsmith,275080,2009,Arson,2
+Portsmith,275080,2009,"Assault, Simple",34
+Portsmith,275080,2009,Burglary,56
+Portsmith,275080,2009,Curfew,1
+Portsmith,275080,2009,Disorderly Conduct,39
+Portsmith,275080,2009,Drugs,14
+Portsmith,275080,2009,DUII,24
+Portsmith,275080,2009,Embezzlement,2
+Portsmith,275080,2009,Forgery,
+Portsmith,275080,2009,Fraud,8
+Portsmith,275080,2009,Gambling,
+Portsmith,275080,2009,Homicide,1
+Portsmith,275080,2009,Kidnap,
+Portsmith,275080,2009,Larceny,186
+Portsmith,275080,2009,Liquor Laws,6
+Portsmith,275080,2009,Motor Vehicle Theft,62
+Portsmith,275080,2009,Offenses Against Family,
+Portsmith,275080,2009,Prostitution,
+Portsmith,275080,2009,Rape,
+Portsmith,275080,2009,Robbery,8
+Portsmith,275080,2009,Runaway,2
+Portsmith,275080,2009,Sex Offenses,
+Portsmith,275080,2009,Stolen Property,
+Portsmith,275080,2009,Trespass,35
+Portsmith,275080,2009,Vandalism,87
+Portsmith,275080,2009,Weapons,4
+Portsmith,275080,2010,Aggravated Assault,27
+Portsmith,275080,2010,Arson,
+Portsmith,275080,2010,"Assault, Simple",30
+Portsmith,275080,2010,Burglary,95
+Portsmith,275080,2010,Curfew,6
+Portsmith,275080,2010,Disorderly Conduct,35
+Portsmith,275080,2010,Drugs,27
+Portsmith,275080,2010,DUII,21
+Portsmith,275080,2010,Embezzlement,
+Portsmith,275080,2010,Forgery,3
+Portsmith,275080,2010,Fraud,11
+Portsmith,275080,2010,Gambling,
+Portsmith,275080,2010,Homicide,1
+Portsmith,275080,2010,Kidnap,
+Portsmith,275080,2010,Larceny,162
+Portsmith,275080,2010,Liquor Laws,5
+Portsmith,275080,2010,Motor Vehicle Theft,37
+Portsmith,275080,2010,Offenses Against Family,
+Portsmith,275080,2010,Prostitution,
+Portsmith,275080,2010,Rape,
+Portsmith,275080,2010,Robbery,14
+Portsmith,275080,2010,Runaway,
+Portsmith,275080,2010,Sex Offenses,1
+Portsmith,275080,2010,Stolen Property,
+Portsmith,275080,2010,Trespass,43
+Portsmith,275080,2010,Vandalism,122
+Portsmith,275080,2010,Weapons,5
+Portsmith,275080,2011,Aggravated Assault,25
+Portsmith,275080,2011,Arson,1
+Portsmith,275080,2011,"Assault, Simple",50
+Portsmith,275080,2011,Burglary,57
+Portsmith,275080,2011,Curfew,
+Portsmith,275080,2011,Disorderly Conduct,33
+Portsmith,275080,2011,Drugs,16
+Portsmith,275080,2011,DUII,15
+Portsmith,275080,2011,Embezzlement,
+Portsmith,275080,2011,Forgery,6
+Portsmith,275080,2011,Fraud,12
+Portsmith,275080,2011,Gambling,
+Portsmith,275080,2011,Homicide,1
+Portsmith,275080,2011,Kidnap,1
+Portsmith,275080,2011,Larceny,167
+Portsmith,275080,2011,Liquor Laws,5
+Portsmith,275080,2011,Motor Vehicle Theft,75
+Portsmith,275080,2011,Offenses Against Family,
+Portsmith,275080,2011,Prostitution,
+Portsmith,275080,2011,Rape,
+Portsmith,275080,2011,Robbery,12
+Portsmith,275080,2011,Runaway,
+Portsmith,275080,2011,Sex Offenses,
+Portsmith,275080,2011,Stolen Property,1
+Portsmith,275080,2011,Trespass,44
+Portsmith,275080,2011,Vandalism,76
+Portsmith,275080,2011,Weapons,4
+Portsmith,275080,2012,Aggravated Assault,30
+Portsmith,275080,2012,Arson,
+Portsmith,275080,2012,"Assault, Simple",35
+Portsmith,275080,2012,Burglary,59
+Portsmith,275080,2012,Curfew,
+Portsmith,275080,2012,Disorderly Conduct,32
+Portsmith,275080,2012,Drugs,12
+Portsmith,275080,2012,DUII,13
+Portsmith,275080,2012,Embezzlement,1
+Portsmith,275080,2012,Forgery,8
+Portsmith,275080,2012,Fraud,3
+Portsmith,275080,2012,Gambling,
+Portsmith,275080,2012,Homicide,1
+Portsmith,275080,2012,Kidnap,
+Portsmith,275080,2012,Larceny,161
+Portsmith,275080,2012,Liquor Laws,13
+Portsmith,275080,2012,Motor Vehicle Theft,70
+Portsmith,275080,2012,Offenses Against Family,
+Portsmith,275080,2012,Prostitution,
+Portsmith,275080,2012,Rape,
+Portsmith,275080,2012,Robbery,8
+Portsmith,275080,2012,Runaway,
+Portsmith,275080,2012,Sex Offenses,1
+Portsmith,275080,2012,Stolen Property,1
+Portsmith,275080,2012,Trespass,35
+Portsmith,275080,2012,Vandalism,73
+Portsmith,275080,2012,Weapons,5
+Portsmith,275080,2013,Aggravated Assault,18
+Portsmith,275080,2013,Arson,1
+Portsmith,275080,2013,"Assault, Simple",49
+Portsmith,275080,2013,Burglary,79
+Portsmith,275080,2013,Curfew,1
+Portsmith,275080,2013,Disorderly Conduct,54
+Portsmith,275080,2013,Drugs,16
+Portsmith,275080,2013,DUII,17
+Portsmith,275080,2013,Embezzlement,
+Portsmith,275080,2013,Forgery,13
+Portsmith,275080,2013,Fraud,13
+Portsmith,275080,2013,Gambling,
+Portsmith,275080,2013,Homicide,
+Portsmith,275080,2013,Kidnap,
+Portsmith,275080,2013,Larceny,203
+Portsmith,275080,2013,Liquor Laws,6
+Portsmith,275080,2013,Motor Vehicle Theft,79
+Portsmith,275080,2013,Offenses Against Family,
+Portsmith,275080,2013,Prostitution,
+Portsmith,275080,2013,Rape,
+Portsmith,275080,2013,Robbery,13
+Portsmith,275080,2013,Runaway,
+Portsmith,275080,2013,Sex Offenses,
+Portsmith,275080,2013,Stolen Property,1
+Portsmith,275080,2013,Trespass,31
+Portsmith,275080,2013,Vandalism,64
+Portsmith,275080,2013,Weapons,6
+Portsmith,275080,2014,Aggravated Assault,24
+Portsmith,275080,2014,Arson,1
+Portsmith,275080,2014,"Assault, Simple",32
+Portsmith,275080,2014,Burglary,54
+Portsmith,275080,2014,Curfew,
+Portsmith,275080,2014,Disorderly Conduct,38
+Portsmith,275080,2014,Drugs,10
+Portsmith,275080,2014,DUII,18
+Portsmith,275080,2014,Embezzlement,
+Portsmith,275080,2014,Forgery,3
+Portsmith,275080,2014,Fraud,14
+Portsmith,275080,2014,Gambling,
+Portsmith,275080,2014,Homicide,2
+Portsmith,275080,2014,Kidnap,
+Portsmith,275080,2014,Larceny,164
+Portsmith,275080,2014,Liquor Laws,6
+Portsmith,275080,2014,Motor Vehicle Theft,43
+Portsmith,275080,2014,Offenses Against Family,
+Portsmith,275080,2014,Prostitution,
+Portsmith,275080,2014,Rape,
+Portsmith,275080,2014,Robbery,12
+Portsmith,275080,2014,Runaway,
+Portsmith,275080,2014,Sex Offenses,
+Portsmith,275080,2014,Stolen Property,1
+Portsmith,275080,2014,Trespass,30
+Portsmith,275080,2014,Vandalism,60
+Portsmith,275080,2014,Weapons,5
+Powellhurst,207384,2004,Aggravated Assault,15
+Powellhurst,207384,2004,Arson,
+Powellhurst,207384,2004,"Assault, Simple",13
+Powellhurst,207384,2004,Burglary,56
+Powellhurst,207384,2004,Curfew,2
+Powellhurst,207384,2004,Disorderly Conduct,11
+Powellhurst,207384,2004,Drugs,21
+Powellhurst,207384,2004,DUII,19
+Powellhurst,207384,2004,Embezzlement,2
+Powellhurst,207384,2004,Forgery,15
+Powellhurst,207384,2004,Fraud,17
+Powellhurst,207384,2004,Gambling,
+Powellhurst,207384,2004,Homicide,
+Powellhurst,207384,2004,Kidnap,
+Powellhurst,207384,2004,Larceny,138
+Powellhurst,207384,2004,Liquor Laws,2
+Powellhurst,207384,2004,Motor Vehicle Theft,42
+Powellhurst,207384,2004,Offenses Against Family,
+Powellhurst,207384,2004,Prostitution,3
+Powellhurst,207384,2004,Rape,2
+Powellhurst,207384,2004,Robbery,8
+Powellhurst,207384,2004,Runaway,1
+Powellhurst,207384,2004,Sex Offenses,
+Powellhurst,207384,2004,Stolen Property,
+Powellhurst,207384,2004,Trespass,17
+Powellhurst,207384,2004,Vandalism,28
+Powellhurst,207384,2004,Weapons,4
+Powellhurst,207384,2005,Aggravated Assault,83
+Powellhurst,207384,2005,Arson,1
+Powellhurst,207384,2005,"Assault, Simple",108
+Powellhurst,207384,2005,Burglary,329
+Powellhurst,207384,2005,Curfew,9
+Powellhurst,207384,2005,Disorderly Conduct,78
+Powellhurst,207384,2005,Drugs,166
+Powellhurst,207384,2005,DUII,72
+Powellhurst,207384,2005,Embezzlement,15
+Powellhurst,207384,2005,Forgery,116
+Powellhurst,207384,2005,Fraud,91
+Powellhurst,207384,2005,Gambling,
+Powellhurst,207384,2005,Homicide,1
+Powellhurst,207384,2005,Kidnap,1
+Powellhurst,207384,2005,Larceny,771
+Powellhurst,207384,2005,Liquor Laws,11
+Powellhurst,207384,2005,Motor Vehicle Theft,268
+Powellhurst,207384,2005,Offenses Against Family,
+Powellhurst,207384,2005,Prostitution,5
+Powellhurst,207384,2005,Rape,1
+Powellhurst,207384,2005,Robbery,35
+Powellhurst,207384,2005,Runaway,
+Powellhurst,207384,2005,Sex Offenses,2
+Powellhurst,207384,2005,Stolen Property,4
+Powellhurst,207384,2005,Trespass,107
+Powellhurst,207384,2005,Vandalism,216
+Powellhurst,207384,2005,Weapons,39
+Powellhurst,207384,2006,Aggravated Assault,69
+Powellhurst,207384,2006,Arson,2
+Powellhurst,207384,2006,"Assault, Simple",84
+Powellhurst,207384,2006,Burglary,229
+Powellhurst,207384,2006,Curfew,4
+Powellhurst,207384,2006,Disorderly Conduct,90
+Powellhurst,207384,2006,Drugs,101
+Powellhurst,207384,2006,DUII,72
+Powellhurst,207384,2006,Embezzlement,4
+Powellhurst,207384,2006,Forgery,57
+Powellhurst,207384,2006,Fraud,115
+Powellhurst,207384,2006,Gambling,
+Powellhurst,207384,2006,Homicide,1
+Powellhurst,207384,2006,Kidnap,
+Powellhurst,207384,2006,Larceny,608
+Powellhurst,207384,2006,Liquor Laws,17
+Powellhurst,207384,2006,Motor Vehicle Theft,235
+Powellhurst,207384,2006,Offenses Against Family,
+Powellhurst,207384,2006,Prostitution,
+Powellhurst,207384,2006,Rape,1
+Powellhurst,207384,2006,Robbery,66
+Powellhurst,207384,2006,Runaway,2
+Powellhurst,207384,2006,Sex Offenses,1
+Powellhurst,207384,2006,Stolen Property,4
+Powellhurst,207384,2006,Trespass,64
+Powellhurst,207384,2006,Vandalism,272
+Powellhurst,207384,2006,Weapons,22
+Powellhurst,207384,2007,Aggravated Assault,80
+Powellhurst,207384,2007,Arson,4
+Powellhurst,207384,2007,"Assault, Simple",121
+Powellhurst,207384,2007,Burglary,245
+Powellhurst,207384,2007,Curfew,4
+Powellhurst,207384,2007,Disorderly Conduct,84
+Powellhurst,207384,2007,Drugs,99
+Powellhurst,207384,2007,DUII,94
+Powellhurst,207384,2007,Embezzlement,6
+Powellhurst,207384,2007,Forgery,52
+Powellhurst,207384,2007,Fraud,129
+Powellhurst,207384,2007,Gambling,
+Powellhurst,207384,2007,Homicide,1
+Powellhurst,207384,2007,Kidnap,3
+Powellhurst,207384,2007,Larceny,634
+Powellhurst,207384,2007,Liquor Laws,9
+Powellhurst,207384,2007,Motor Vehicle Theft,227
+Powellhurst,207384,2007,Offenses Against Family,
+Powellhurst,207384,2007,Prostitution,
+Powellhurst,207384,2007,Rape,4
+Powellhurst,207384,2007,Robbery,46
+Powellhurst,207384,2007,Runaway,
+Powellhurst,207384,2007,Sex Offenses,3
+Powellhurst,207384,2007,Stolen Property,4
+Powellhurst,207384,2007,Trespass,85
+Powellhurst,207384,2007,Vandalism,253
+Powellhurst,207384,2007,Weapons,16
+Powellhurst,207384,2008,Aggravated Assault,84
+Powellhurst,207384,2008,Arson,2
+Powellhurst,207384,2008,"Assault, Simple",94
+Powellhurst,207384,2008,Burglary,199
+Powellhurst,207384,2008,Curfew,7
+Powellhurst,207384,2008,Disorderly Conduct,82
+Powellhurst,207384,2008,Drugs,98
+Powellhurst,207384,2008,DUII,107
+Powellhurst,207384,2008,Embezzlement,10
+Powellhurst,207384,2008,Forgery,40
+Powellhurst,207384,2008,Fraud,109
+Powellhurst,207384,2008,Gambling,
+Powellhurst,207384,2008,Homicide,
+Powellhurst,207384,2008,Kidnap,2
+Powellhurst,207384,2008,Larceny,657
+Powellhurst,207384,2008,Liquor Laws,25
+Powellhurst,207384,2008,Motor Vehicle Theft,146
+Powellhurst,207384,2008,Offenses Against Family,1
+Powellhurst,207384,2008,Prostitution,9
+Powellhurst,207384,2008,Rape,
+Powellhurst,207384,2008,Robbery,41
+Powellhurst,207384,2008,Runaway,1
+Powellhurst,207384,2008,Sex Offenses,1
+Powellhurst,207384,2008,Stolen Property,6
+Powellhurst,207384,2008,Trespass,70
+Powellhurst,207384,2008,Vandalism,244
+Powellhurst,207384,2008,Weapons,11
+Powellhurst,207384,2009,Aggravated Assault,69
+Powellhurst,207384,2009,Arson,1
+Powellhurst,207384,2009,"Assault, Simple",113
+Powellhurst,207384,2009,Burglary,196
+Powellhurst,207384,2009,Curfew,3
+Powellhurst,207384,2009,Disorderly Conduct,104
+Powellhurst,207384,2009,Drugs,116
+Powellhurst,207384,2009,DUII,70
+Powellhurst,207384,2009,Embezzlement,7
+Powellhurst,207384,2009,Forgery,40
+Powellhurst,207384,2009,Fraud,84
+Powellhurst,207384,2009,Gambling,
+Powellhurst,207384,2009,Homicide,2
+Powellhurst,207384,2009,Kidnap,
+Powellhurst,207384,2009,Larceny,596
+Powellhurst,207384,2009,Liquor Laws,26
+Powellhurst,207384,2009,Motor Vehicle Theft,176
+Powellhurst,207384,2009,Offenses Against Family,
+Powellhurst,207384,2009,Prostitution,3
+Powellhurst,207384,2009,Rape,2
+Powellhurst,207384,2009,Robbery,65
+Powellhurst,207384,2009,Runaway,
+Powellhurst,207384,2009,Sex Offenses,3
+Powellhurst,207384,2009,Stolen Property,5
+Powellhurst,207384,2009,Trespass,54
+Powellhurst,207384,2009,Vandalism,259
+Powellhurst,207384,2009,Weapons,22
+Powellhurst,207384,2010,Aggravated Assault,82
+Powellhurst,207384,2010,Arson,
+Powellhurst,207384,2010,"Assault, Simple",103
+Powellhurst,207384,2010,Burglary,250
+Powellhurst,207384,2010,Curfew,21
+Powellhurst,207384,2010,Disorderly Conduct,118
+Powellhurst,207384,2010,Drugs,102
+Powellhurst,207384,2010,DUII,101
+Powellhurst,207384,2010,Embezzlement,3
+Powellhurst,207384,2010,Forgery,28
+Powellhurst,207384,2010,Fraud,98
+Powellhurst,207384,2010,Gambling,
+Powellhurst,207384,2010,Homicide,1
+Powellhurst,207384,2010,Kidnap,1
+Powellhurst,207384,2010,Larceny,646
+Powellhurst,207384,2010,Liquor Laws,11
+Powellhurst,207384,2010,Motor Vehicle Theft,206
+Powellhurst,207384,2010,Offenses Against Family,
+Powellhurst,207384,2010,Prostitution,8
+Powellhurst,207384,2010,Rape,1
+Powellhurst,207384,2010,Robbery,52
+Powellhurst,207384,2010,Runaway,
+Powellhurst,207384,2010,Sex Offenses,4
+Powellhurst,207384,2010,Stolen Property,4
+Powellhurst,207384,2010,Trespass,81
+Powellhurst,207384,2010,Vandalism,243
+Powellhurst,207384,2010,Weapons,21
+Powellhurst,207384,2011,Aggravated Assault,60
+Powellhurst,207384,2011,Arson,
+Powellhurst,207384,2011,"Assault, Simple",111
+Powellhurst,207384,2011,Burglary,240
+Powellhurst,207384,2011,Curfew,
+Powellhurst,207384,2011,Disorderly Conduct,83
+Powellhurst,207384,2011,Drugs,91
+Powellhurst,207384,2011,DUII,74
+Powellhurst,207384,2011,Embezzlement,3
+Powellhurst,207384,2011,Forgery,57
+Powellhurst,207384,2011,Fraud,69
+Powellhurst,207384,2011,Gambling,
+Powellhurst,207384,2011,Homicide,
+Powellhurst,207384,2011,Kidnap,1
+Powellhurst,207384,2011,Larceny,624
+Powellhurst,207384,2011,Liquor Laws,14
+Powellhurst,207384,2011,Motor Vehicle Theft,162
+Powellhurst,207384,2011,Offenses Against Family,
+Powellhurst,207384,2011,Prostitution,1
+Powellhurst,207384,2011,Rape,1
+Powellhurst,207384,2011,Robbery,34
+Powellhurst,207384,2011,Runaway,
+Powellhurst,207384,2011,Sex Offenses,1
+Powellhurst,207384,2011,Stolen Property,3
+Powellhurst,207384,2011,Trespass,67
+Powellhurst,207384,2011,Vandalism,160
+Powellhurst,207384,2011,Weapons,14
+Powellhurst,207384,2012,Aggravated Assault,70
+Powellhurst,207384,2012,Arson,3
+Powellhurst,207384,2012,"Assault, Simple",103
+Powellhurst,207384,2012,Burglary,237
+Powellhurst,207384,2012,Curfew,
+Powellhurst,207384,2012,Disorderly Conduct,94
+Powellhurst,207384,2012,Drugs,114
+Powellhurst,207384,2012,DUII,53
+Powellhurst,207384,2012,Embezzlement,6
+Powellhurst,207384,2012,Forgery,33
+Powellhurst,207384,2012,Fraud,88
+Powellhurst,207384,2012,Gambling,
+Powellhurst,207384,2012,Homicide,3
+Powellhurst,207384,2012,Kidnap,2
+Powellhurst,207384,2012,Larceny,552
+Powellhurst,207384,2012,Liquor Laws,11
+Powellhurst,207384,2012,Motor Vehicle Theft,166
+Powellhurst,207384,2012,Offenses Against Family,
+Powellhurst,207384,2012,Prostitution,3
+Powellhurst,207384,2012,Rape,2
+Powellhurst,207384,2012,Robbery,48
+Powellhurst,207384,2012,Runaway,
+Powellhurst,207384,2012,Sex Offenses,
+Powellhurst,207384,2012,Stolen Property,9
+Powellhurst,207384,2012,Trespass,89
+Powellhurst,207384,2012,Vandalism,218
+Powellhurst,207384,2012,Weapons,31
+Powellhurst,207384,2013,Aggravated Assault,68
+Powellhurst,207384,2013,Arson,1
+Powellhurst,207384,2013,"Assault, Simple",114
+Powellhurst,207384,2013,Burglary,219
+Powellhurst,207384,2013,Curfew,
+Powellhurst,207384,2013,Disorderly Conduct,106
+Powellhurst,207384,2013,Drugs,124
+Powellhurst,207384,2013,DUII,73
+Powellhurst,207384,2013,Embezzlement,2
+Powellhurst,207384,2013,Forgery,38
+Powellhurst,207384,2013,Fraud,77
+Powellhurst,207384,2013,Gambling,
+Powellhurst,207384,2013,Homicide,
+Powellhurst,207384,2013,Kidnap,
+Powellhurst,207384,2013,Larceny,677
+Powellhurst,207384,2013,Liquor Laws,15
+Powellhurst,207384,2013,Motor Vehicle Theft,175
+Powellhurst,207384,2013,Offenses Against Family,
+Powellhurst,207384,2013,Prostitution,3
+Powellhurst,207384,2013,Rape,1
+Powellhurst,207384,2013,Robbery,47
+Powellhurst,207384,2013,Runaway,
+Powellhurst,207384,2013,Sex Offenses,2
+Powellhurst,207384,2013,Stolen Property,3
+Powellhurst,207384,2013,Trespass,62
+Powellhurst,207384,2013,Vandalism,139
+Powellhurst,207384,2013,Weapons,21
+Powellhurst,207384,2014,Aggravated Assault,71
+Powellhurst,207384,2014,Arson,1
+Powellhurst,207384,2014,"Assault, Simple",107
+Powellhurst,207384,2014,Burglary,152
+Powellhurst,207384,2014,Curfew,
+Powellhurst,207384,2014,Disorderly Conduct,88
+Powellhurst,207384,2014,Drugs,110
+Powellhurst,207384,2014,DUII,70
+Powellhurst,207384,2014,Embezzlement,3
+Powellhurst,207384,2014,Forgery,19
+Powellhurst,207384,2014,Fraud,79
+Powellhurst,207384,2014,Gambling,
+Powellhurst,207384,2014,Homicide,
+Powellhurst,207384,2014,Kidnap,
+Powellhurst,207384,2014,Larceny,627
+Powellhurst,207384,2014,Liquor Laws,7
+Powellhurst,207384,2014,Motor Vehicle Theft,184
+Powellhurst,207384,2014,Offenses Against Family,
+Powellhurst,207384,2014,Prostitution,
+Powellhurst,207384,2014,Rape,1
+Powellhurst,207384,2014,Robbery,40
+Powellhurst,207384,2014,Runaway,
+Powellhurst,207384,2014,Sex Offenses,2
+Powellhurst,207384,2014,Stolen Property,4
+Powellhurst,207384,2014,Trespass,70
+Powellhurst,207384,2014,Vandalism,156
+Powellhurst,207384,2014,Weapons,22
+Raleigh West,275125,2004,Aggravated Assault,
+Raleigh West,275125,2004,Arson,
+Raleigh West,275125,2004,"Assault, Simple",
+Raleigh West,275125,2004,Burglary,
+Raleigh West,275125,2004,Curfew,
+Raleigh West,275125,2004,Disorderly Conduct,
+Raleigh West,275125,2004,Drugs,
+Raleigh West,275125,2004,DUII,
+Raleigh West,275125,2004,Embezzlement,
+Raleigh West,275125,2004,Forgery,
+Raleigh West,275125,2004,Fraud,
+Raleigh West,275125,2004,Gambling,
+Raleigh West,275125,2004,Homicide,
+Raleigh West,275125,2004,Kidnap,
+Raleigh West,275125,2004,Larceny,
+Raleigh West,275125,2004,Liquor Laws,
+Raleigh West,275125,2004,Motor Vehicle Theft,
+Raleigh West,275125,2004,Offenses Against Family,
+Raleigh West,275125,2004,Prostitution,
+Raleigh West,275125,2004,Rape,
+Raleigh West,275125,2004,Robbery,
+Raleigh West,275125,2004,Runaway,
+Raleigh West,275125,2004,Sex Offenses,
+Raleigh West,275125,2004,Stolen Property,
+Raleigh West,275125,2004,Trespass,
+Raleigh West,275125,2004,Vandalism,
+Raleigh West,275125,2004,Weapons,
+Raleigh West,275125,2005,Aggravated Assault,
+Raleigh West,275125,2005,Arson,
+Raleigh West,275125,2005,"Assault, Simple",
+Raleigh West,275125,2005,Burglary,
+Raleigh West,275125,2005,Curfew,
+Raleigh West,275125,2005,Disorderly Conduct,
+Raleigh West,275125,2005,Drugs,
+Raleigh West,275125,2005,DUII,
+Raleigh West,275125,2005,Embezzlement,
+Raleigh West,275125,2005,Forgery,
+Raleigh West,275125,2005,Fraud,
+Raleigh West,275125,2005,Gambling,
+Raleigh West,275125,2005,Homicide,
+Raleigh West,275125,2005,Kidnap,
+Raleigh West,275125,2005,Larceny,
+Raleigh West,275125,2005,Liquor Laws,
+Raleigh West,275125,2005,Motor Vehicle Theft,
+Raleigh West,275125,2005,Offenses Against Family,
+Raleigh West,275125,2005,Prostitution,
+Raleigh West,275125,2005,Rape,
+Raleigh West,275125,2005,Robbery,
+Raleigh West,275125,2005,Runaway,
+Raleigh West,275125,2005,Sex Offenses,
+Raleigh West,275125,2005,Stolen Property,
+Raleigh West,275125,2005,Trespass,
+Raleigh West,275125,2005,Vandalism,
+Raleigh West,275125,2005,Weapons,
+Raleigh West,275125,2006,Aggravated Assault,
+Raleigh West,275125,2006,Arson,
+Raleigh West,275125,2006,"Assault, Simple",
+Raleigh West,275125,2006,Burglary,
+Raleigh West,275125,2006,Curfew,
+Raleigh West,275125,2006,Disorderly Conduct,
+Raleigh West,275125,2006,Drugs,
+Raleigh West,275125,2006,DUII,
+Raleigh West,275125,2006,Embezzlement,
+Raleigh West,275125,2006,Forgery,
+Raleigh West,275125,2006,Fraud,
+Raleigh West,275125,2006,Gambling,
+Raleigh West,275125,2006,Homicide,
+Raleigh West,275125,2006,Kidnap,
+Raleigh West,275125,2006,Larceny,
+Raleigh West,275125,2006,Liquor Laws,
+Raleigh West,275125,2006,Motor Vehicle Theft,
+Raleigh West,275125,2006,Offenses Against Family,
+Raleigh West,275125,2006,Prostitution,
+Raleigh West,275125,2006,Rape,
+Raleigh West,275125,2006,Robbery,
+Raleigh West,275125,2006,Runaway,
+Raleigh West,275125,2006,Sex Offenses,
+Raleigh West,275125,2006,Stolen Property,
+Raleigh West,275125,2006,Trespass,
+Raleigh West,275125,2006,Vandalism,
+Raleigh West,275125,2006,Weapons,
+Raleigh West,275125,2007,Aggravated Assault,
+Raleigh West,275125,2007,Arson,
+Raleigh West,275125,2007,"Assault, Simple",
+Raleigh West,275125,2007,Burglary,
+Raleigh West,275125,2007,Curfew,
+Raleigh West,275125,2007,Disorderly Conduct,
+Raleigh West,275125,2007,Drugs,
+Raleigh West,275125,2007,DUII,
+Raleigh West,275125,2007,Embezzlement,
+Raleigh West,275125,2007,Forgery,
+Raleigh West,275125,2007,Fraud,
+Raleigh West,275125,2007,Gambling,
+Raleigh West,275125,2007,Homicide,
+Raleigh West,275125,2007,Kidnap,
+Raleigh West,275125,2007,Larceny,
+Raleigh West,275125,2007,Liquor Laws,
+Raleigh West,275125,2007,Motor Vehicle Theft,
+Raleigh West,275125,2007,Offenses Against Family,
+Raleigh West,275125,2007,Prostitution,
+Raleigh West,275125,2007,Rape,
+Raleigh West,275125,2007,Robbery,
+Raleigh West,275125,2007,Runaway,
+Raleigh West,275125,2007,Sex Offenses,
+Raleigh West,275125,2007,Stolen Property,
+Raleigh West,275125,2007,Trespass,
+Raleigh West,275125,2007,Vandalism,
+Raleigh West,275125,2007,Weapons,
+Raleigh West,275125,2008,Aggravated Assault,
+Raleigh West,275125,2008,Arson,
+Raleigh West,275125,2008,"Assault, Simple",
+Raleigh West,275125,2008,Burglary,
+Raleigh West,275125,2008,Curfew,
+Raleigh West,275125,2008,Disorderly Conduct,
+Raleigh West,275125,2008,Drugs,
+Raleigh West,275125,2008,DUII,
+Raleigh West,275125,2008,Embezzlement,
+Raleigh West,275125,2008,Forgery,
+Raleigh West,275125,2008,Fraud,
+Raleigh West,275125,2008,Gambling,
+Raleigh West,275125,2008,Homicide,
+Raleigh West,275125,2008,Kidnap,
+Raleigh West,275125,2008,Larceny,
+Raleigh West,275125,2008,Liquor Laws,
+Raleigh West,275125,2008,Motor Vehicle Theft,
+Raleigh West,275125,2008,Offenses Against Family,
+Raleigh West,275125,2008,Prostitution,
+Raleigh West,275125,2008,Rape,
+Raleigh West,275125,2008,Robbery,
+Raleigh West,275125,2008,Runaway,
+Raleigh West,275125,2008,Sex Offenses,
+Raleigh West,275125,2008,Stolen Property,
+Raleigh West,275125,2008,Trespass,
+Raleigh West,275125,2008,Vandalism,
+Raleigh West,275125,2008,Weapons,
+Raleigh West,275125,2009,Aggravated Assault,
+Raleigh West,275125,2009,Arson,
+Raleigh West,275125,2009,"Assault, Simple",
+Raleigh West,275125,2009,Burglary,
+Raleigh West,275125,2009,Curfew,
+Raleigh West,275125,2009,Disorderly Conduct,
+Raleigh West,275125,2009,Drugs,
+Raleigh West,275125,2009,DUII,
+Raleigh West,275125,2009,Embezzlement,
+Raleigh West,275125,2009,Forgery,
+Raleigh West,275125,2009,Fraud,
+Raleigh West,275125,2009,Gambling,
+Raleigh West,275125,2009,Homicide,
+Raleigh West,275125,2009,Kidnap,
+Raleigh West,275125,2009,Larceny,
+Raleigh West,275125,2009,Liquor Laws,
+Raleigh West,275125,2009,Motor Vehicle Theft,
+Raleigh West,275125,2009,Offenses Against Family,
+Raleigh West,275125,2009,Prostitution,
+Raleigh West,275125,2009,Rape,
+Raleigh West,275125,2009,Robbery,
+Raleigh West,275125,2009,Runaway,
+Raleigh West,275125,2009,Sex Offenses,
+Raleigh West,275125,2009,Stolen Property,
+Raleigh West,275125,2009,Trespass,
+Raleigh West,275125,2009,Vandalism,
+Raleigh West,275125,2009,Weapons,
+Raleigh West,275125,2010,Aggravated Assault,
+Raleigh West,275125,2010,Arson,
+Raleigh West,275125,2010,"Assault, Simple",
+Raleigh West,275125,2010,Burglary,
+Raleigh West,275125,2010,Curfew,
+Raleigh West,275125,2010,Disorderly Conduct,
+Raleigh West,275125,2010,Drugs,
+Raleigh West,275125,2010,DUII,1
+Raleigh West,275125,2010,Embezzlement,
+Raleigh West,275125,2010,Forgery,
+Raleigh West,275125,2010,Fraud,
+Raleigh West,275125,2010,Gambling,
+Raleigh West,275125,2010,Homicide,
+Raleigh West,275125,2010,Kidnap,
+Raleigh West,275125,2010,Larceny,
+Raleigh West,275125,2010,Liquor Laws,
+Raleigh West,275125,2010,Motor Vehicle Theft,
+Raleigh West,275125,2010,Offenses Against Family,
+Raleigh West,275125,2010,Prostitution,
+Raleigh West,275125,2010,Rape,
+Raleigh West,275125,2010,Robbery,
+Raleigh West,275125,2010,Runaway,
+Raleigh West,275125,2010,Sex Offenses,
+Raleigh West,275125,2010,Stolen Property,
+Raleigh West,275125,2010,Trespass,
+Raleigh West,275125,2010,Vandalism,
+Raleigh West,275125,2010,Weapons,
+Raleigh West,275125,2011,Aggravated Assault,
+Raleigh West,275125,2011,Arson,
+Raleigh West,275125,2011,"Assault, Simple",
+Raleigh West,275125,2011,Burglary,
+Raleigh West,275125,2011,Curfew,
+Raleigh West,275125,2011,Disorderly Conduct,
+Raleigh West,275125,2011,Drugs,
+Raleigh West,275125,2011,DUII,
+Raleigh West,275125,2011,Embezzlement,
+Raleigh West,275125,2011,Forgery,
+Raleigh West,275125,2011,Fraud,
+Raleigh West,275125,2011,Gambling,
+Raleigh West,275125,2011,Homicide,
+Raleigh West,275125,2011,Kidnap,
+Raleigh West,275125,2011,Larceny,
+Raleigh West,275125,2011,Liquor Laws,
+Raleigh West,275125,2011,Motor Vehicle Theft,
+Raleigh West,275125,2011,Offenses Against Family,
+Raleigh West,275125,2011,Prostitution,
+Raleigh West,275125,2011,Rape,
+Raleigh West,275125,2011,Robbery,
+Raleigh West,275125,2011,Runaway,
+Raleigh West,275125,2011,Sex Offenses,
+Raleigh West,275125,2011,Stolen Property,
+Raleigh West,275125,2011,Trespass,
+Raleigh West,275125,2011,Vandalism,1
+Raleigh West,275125,2011,Weapons,
+Raleigh West,275125,2012,Aggravated Assault,
+Raleigh West,275125,2012,Arson,
+Raleigh West,275125,2012,"Assault, Simple",
+Raleigh West,275125,2012,Burglary,
+Raleigh West,275125,2012,Curfew,
+Raleigh West,275125,2012,Disorderly Conduct,
+Raleigh West,275125,2012,Drugs,
+Raleigh West,275125,2012,DUII,
+Raleigh West,275125,2012,Embezzlement,
+Raleigh West,275125,2012,Forgery,
+Raleigh West,275125,2012,Fraud,
+Raleigh West,275125,2012,Gambling,
+Raleigh West,275125,2012,Homicide,
+Raleigh West,275125,2012,Kidnap,
+Raleigh West,275125,2012,Larceny,
+Raleigh West,275125,2012,Liquor Laws,
+Raleigh West,275125,2012,Motor Vehicle Theft,
+Raleigh West,275125,2012,Offenses Against Family,
+Raleigh West,275125,2012,Prostitution,
+Raleigh West,275125,2012,Rape,
+Raleigh West,275125,2012,Robbery,
+Raleigh West,275125,2012,Runaway,
+Raleigh West,275125,2012,Sex Offenses,
+Raleigh West,275125,2012,Stolen Property,
+Raleigh West,275125,2012,Trespass,
+Raleigh West,275125,2012,Vandalism,
+Raleigh West,275125,2012,Weapons,
+Raleigh West,275125,2013,Aggravated Assault,
+Raleigh West,275125,2013,Arson,
+Raleigh West,275125,2013,"Assault, Simple",
+Raleigh West,275125,2013,Burglary,
+Raleigh West,275125,2013,Curfew,
+Raleigh West,275125,2013,Disorderly Conduct,
+Raleigh West,275125,2013,Drugs,
+Raleigh West,275125,2013,DUII,
+Raleigh West,275125,2013,Embezzlement,
+Raleigh West,275125,2013,Forgery,
+Raleigh West,275125,2013,Fraud,
+Raleigh West,275125,2013,Gambling,
+Raleigh West,275125,2013,Homicide,
+Raleigh West,275125,2013,Kidnap,
+Raleigh West,275125,2013,Larceny,2
+Raleigh West,275125,2013,Liquor Laws,
+Raleigh West,275125,2013,Motor Vehicle Theft,
+Raleigh West,275125,2013,Offenses Against Family,
+Raleigh West,275125,2013,Prostitution,
+Raleigh West,275125,2013,Rape,
+Raleigh West,275125,2013,Robbery,
+Raleigh West,275125,2013,Runaway,
+Raleigh West,275125,2013,Sex Offenses,
+Raleigh West,275125,2013,Stolen Property,
+Raleigh West,275125,2013,Trespass,
+Raleigh West,275125,2013,Vandalism,
+Raleigh West,275125,2013,Weapons,
+Raleigh West,275125,2014,Aggravated Assault,
+Raleigh West,275125,2014,Arson,
+Raleigh West,275125,2014,"Assault, Simple",
+Raleigh West,275125,2014,Burglary,
+Raleigh West,275125,2014,Curfew,
+Raleigh West,275125,2014,Disorderly Conduct,
+Raleigh West,275125,2014,Drugs,
+Raleigh West,275125,2014,DUII,
+Raleigh West,275125,2014,Embezzlement,
+Raleigh West,275125,2014,Forgery,
+Raleigh West,275125,2014,Fraud,
+Raleigh West,275125,2014,Gambling,
+Raleigh West,275125,2014,Homicide,
+Raleigh West,275125,2014,Kidnap,
+Raleigh West,275125,2014,Larceny,
+Raleigh West,275125,2014,Liquor Laws,
+Raleigh West,275125,2014,Motor Vehicle Theft,
+Raleigh West,275125,2014,Offenses Against Family,
+Raleigh West,275125,2014,Prostitution,
+Raleigh West,275125,2014,Rape,
+Raleigh West,275125,2014,Robbery,
+Raleigh West,275125,2014,Runaway,
+Raleigh West,275125,2014,Sex Offenses,
+Raleigh West,275125,2014,Stolen Property,
+Raleigh West,275125,2014,Trespass,
+Raleigh West,275125,2014,Vandalism,
+Raleigh West,275125,2014,Weapons,
+Reed,344057,2004,Aggravated Assault,2
+Reed,344057,2004,Arson,
+Reed,344057,2004,"Assault, Simple",3
+Reed,344057,2004,Burglary,14
+Reed,344057,2004,Curfew,
+Reed,344057,2004,Disorderly Conduct,2
+Reed,344057,2004,Drugs,
+Reed,344057,2004,DUII,1
+Reed,344057,2004,Embezzlement,
+Reed,344057,2004,Forgery,1
+Reed,344057,2004,Fraud,3
+Reed,344057,2004,Gambling,
+Reed,344057,2004,Homicide,
+Reed,344057,2004,Kidnap,
+Reed,344057,2004,Larceny,33
+Reed,344057,2004,Liquor Laws,
+Reed,344057,2004,Motor Vehicle Theft,13
+Reed,344057,2004,Offenses Against Family,
+Reed,344057,2004,Prostitution,
+Reed,344057,2004,Rape,
+Reed,344057,2004,Robbery,
+Reed,344057,2004,Runaway,
+Reed,344057,2004,Sex Offenses,
+Reed,344057,2004,Stolen Property,
+Reed,344057,2004,Trespass,5
+Reed,344057,2004,Vandalism,5
+Reed,344057,2004,Weapons,1
+Reed,344057,2005,Aggravated Assault,2
+Reed,344057,2005,Arson,
+Reed,344057,2005,"Assault, Simple",10
+Reed,344057,2005,Burglary,38
+Reed,344057,2005,Curfew,
+Reed,344057,2005,Disorderly Conduct,6
+Reed,344057,2005,Drugs,11
+Reed,344057,2005,DUII,1
+Reed,344057,2005,Embezzlement,1
+Reed,344057,2005,Forgery,5
+Reed,344057,2005,Fraud,4
+Reed,344057,2005,Gambling,
+Reed,344057,2005,Homicide,
+Reed,344057,2005,Kidnap,
+Reed,344057,2005,Larceny,103
+Reed,344057,2005,Liquor Laws,2
+Reed,344057,2005,Motor Vehicle Theft,35
+Reed,344057,2005,Offenses Against Family,
+Reed,344057,2005,Prostitution,
+Reed,344057,2005,Rape,
+Reed,344057,2005,Robbery,2
+Reed,344057,2005,Runaway,
+Reed,344057,2005,Sex Offenses,
+Reed,344057,2005,Stolen Property,
+Reed,344057,2005,Trespass,10
+Reed,344057,2005,Vandalism,25
+Reed,344057,2005,Weapons,1
+Reed,344057,2006,Aggravated Assault,3
+Reed,344057,2006,Arson,
+Reed,344057,2006,"Assault, Simple",10
+Reed,344057,2006,Burglary,44
+Reed,344057,2006,Curfew,
+Reed,344057,2006,Disorderly Conduct,1
+Reed,344057,2006,Drugs,10
+Reed,344057,2006,DUII,7
+Reed,344057,2006,Embezzlement,
+Reed,344057,2006,Forgery,2
+Reed,344057,2006,Fraud,4
+Reed,344057,2006,Gambling,
+Reed,344057,2006,Homicide,
+Reed,344057,2006,Kidnap,
+Reed,344057,2006,Larceny,83
+Reed,344057,2006,Liquor Laws,5
+Reed,344057,2006,Motor Vehicle Theft,45
+Reed,344057,2006,Offenses Against Family,
+Reed,344057,2006,Prostitution,
+Reed,344057,2006,Rape,
+Reed,344057,2006,Robbery,3
+Reed,344057,2006,Runaway,
+Reed,344057,2006,Sex Offenses,
+Reed,344057,2006,Stolen Property,
+Reed,344057,2006,Trespass,12
+Reed,344057,2006,Vandalism,22
+Reed,344057,2006,Weapons,1
+Reed,344057,2007,Aggravated Assault,
+Reed,344057,2007,Arson,
+Reed,344057,2007,"Assault, Simple",4
+Reed,344057,2007,Burglary,36
+Reed,344057,2007,Curfew,1
+Reed,344057,2007,Disorderly Conduct,8
+Reed,344057,2007,Drugs,5
+Reed,344057,2007,DUII,5
+Reed,344057,2007,Embezzlement,
+Reed,344057,2007,Forgery,1
+Reed,344057,2007,Fraud,12
+Reed,344057,2007,Gambling,
+Reed,344057,2007,Homicide,
+Reed,344057,2007,Kidnap,
+Reed,344057,2007,Larceny,93
+Reed,344057,2007,Liquor Laws,
+Reed,344057,2007,Motor Vehicle Theft,44
+Reed,344057,2007,Offenses Against Family,
+Reed,344057,2007,Prostitution,
+Reed,344057,2007,Rape,
+Reed,344057,2007,Robbery,2
+Reed,344057,2007,Runaway,
+Reed,344057,2007,Sex Offenses,1
+Reed,344057,2007,Stolen Property,
+Reed,344057,2007,Trespass,1
+Reed,344057,2007,Vandalism,21
+Reed,344057,2007,Weapons,2
+Reed,344057,2008,Aggravated Assault,2
+Reed,344057,2008,Arson,
+Reed,344057,2008,"Assault, Simple",3
+Reed,344057,2008,Burglary,23
+Reed,344057,2008,Curfew,
+Reed,344057,2008,Disorderly Conduct,
+Reed,344057,2008,Drugs,4
+Reed,344057,2008,DUII,3
+Reed,344057,2008,Embezzlement,
+Reed,344057,2008,Forgery,1
+Reed,344057,2008,Fraud,5
+Reed,344057,2008,Gambling,
+Reed,344057,2008,Homicide,
+Reed,344057,2008,Kidnap,
+Reed,344057,2008,Larceny,65
+Reed,344057,2008,Liquor Laws,2
+Reed,344057,2008,Motor Vehicle Theft,28
+Reed,344057,2008,Offenses Against Family,
+Reed,344057,2008,Prostitution,
+Reed,344057,2008,Rape,
+Reed,344057,2008,Robbery,2
+Reed,344057,2008,Runaway,
+Reed,344057,2008,Sex Offenses,
+Reed,344057,2008,Stolen Property,
+Reed,344057,2008,Trespass,4
+Reed,344057,2008,Vandalism,16
+Reed,344057,2008,Weapons,1
+Reed,344057,2009,Aggravated Assault,1
+Reed,344057,2009,Arson,
+Reed,344057,2009,"Assault, Simple",6
+Reed,344057,2009,Burglary,24
+Reed,344057,2009,Curfew,1
+Reed,344057,2009,Disorderly Conduct,3
+Reed,344057,2009,Drugs,1
+Reed,344057,2009,DUII,4
+Reed,344057,2009,Embezzlement,
+Reed,344057,2009,Forgery,2
+Reed,344057,2009,Fraud,4
+Reed,344057,2009,Gambling,
+Reed,344057,2009,Homicide,
+Reed,344057,2009,Kidnap,
+Reed,344057,2009,Larceny,54
+Reed,344057,2009,Liquor Laws,2
+Reed,344057,2009,Motor Vehicle Theft,23
+Reed,344057,2009,Offenses Against Family,
+Reed,344057,2009,Prostitution,
+Reed,344057,2009,Rape,
+Reed,344057,2009,Robbery,
+Reed,344057,2009,Runaway,
+Reed,344057,2009,Sex Offenses,
+Reed,344057,2009,Stolen Property,
+Reed,344057,2009,Trespass,2
+Reed,344057,2009,Vandalism,15
+Reed,344057,2009,Weapons,
+Reed,344057,2010,Aggravated Assault,2
+Reed,344057,2010,Arson,
+Reed,344057,2010,"Assault, Simple",7
+Reed,344057,2010,Burglary,22
+Reed,344057,2010,Curfew,
+Reed,344057,2010,Disorderly Conduct,4
+Reed,344057,2010,Drugs,
+Reed,344057,2010,DUII,5
+Reed,344057,2010,Embezzlement,
+Reed,344057,2010,Forgery,1
+Reed,344057,2010,Fraud,3
+Reed,344057,2010,Gambling,
+Reed,344057,2010,Homicide,
+Reed,344057,2010,Kidnap,
+Reed,344057,2010,Larceny,70
+Reed,344057,2010,Liquor Laws,1
+Reed,344057,2010,Motor Vehicle Theft,18
+Reed,344057,2010,Offenses Against Family,
+Reed,344057,2010,Prostitution,
+Reed,344057,2010,Rape,
+Reed,344057,2010,Robbery,
+Reed,344057,2010,Runaway,
+Reed,344057,2010,Sex Offenses,
+Reed,344057,2010,Stolen Property,
+Reed,344057,2010,Trespass,10
+Reed,344057,2010,Vandalism,24
+Reed,344057,2010,Weapons,
+Reed,344057,2011,Aggravated Assault,3
+Reed,344057,2011,Arson,
+Reed,344057,2011,"Assault, Simple",5
+Reed,344057,2011,Burglary,30
+Reed,344057,2011,Curfew,
+Reed,344057,2011,Disorderly Conduct,4
+Reed,344057,2011,Drugs,1
+Reed,344057,2011,DUII,2
+Reed,344057,2011,Embezzlement,
+Reed,344057,2011,Forgery,2
+Reed,344057,2011,Fraud,2
+Reed,344057,2011,Gambling,
+Reed,344057,2011,Homicide,
+Reed,344057,2011,Kidnap,
+Reed,344057,2011,Larceny,92
+Reed,344057,2011,Liquor Laws,
+Reed,344057,2011,Motor Vehicle Theft,16
+Reed,344057,2011,Offenses Against Family,
+Reed,344057,2011,Prostitution,
+Reed,344057,2011,Rape,1
+Reed,344057,2011,Robbery,2
+Reed,344057,2011,Runaway,
+Reed,344057,2011,Sex Offenses,
+Reed,344057,2011,Stolen Property,
+Reed,344057,2011,Trespass,4
+Reed,344057,2011,Vandalism,16
+Reed,344057,2011,Weapons,
+Reed,344057,2012,Aggravated Assault,1
+Reed,344057,2012,Arson,
+Reed,344057,2012,"Assault, Simple",4
+Reed,344057,2012,Burglary,42
+Reed,344057,2012,Curfew,
+Reed,344057,2012,Disorderly Conduct,6
+Reed,344057,2012,Drugs,2
+Reed,344057,2012,DUII,5
+Reed,344057,2012,Embezzlement,1
+Reed,344057,2012,Forgery,
+Reed,344057,2012,Fraud,2
+Reed,344057,2012,Gambling,
+Reed,344057,2012,Homicide,
+Reed,344057,2012,Kidnap,
+Reed,344057,2012,Larceny,99
+Reed,344057,2012,Liquor Laws,
+Reed,344057,2012,Motor Vehicle Theft,21
+Reed,344057,2012,Offenses Against Family,
+Reed,344057,2012,Prostitution,
+Reed,344057,2012,Rape,
+Reed,344057,2012,Robbery,1
+Reed,344057,2012,Runaway,
+Reed,344057,2012,Sex Offenses,
+Reed,344057,2012,Stolen Property,
+Reed,344057,2012,Trespass,3
+Reed,344057,2012,Vandalism,10
+Reed,344057,2012,Weapons,
+Reed,344057,2013,Aggravated Assault,3
+Reed,344057,2013,Arson,
+Reed,344057,2013,"Assault, Simple",3
+Reed,344057,2013,Burglary,23
+Reed,344057,2013,Curfew,
+Reed,344057,2013,Disorderly Conduct,2
+Reed,344057,2013,Drugs,2
+Reed,344057,2013,DUII,4
+Reed,344057,2013,Embezzlement,
+Reed,344057,2013,Forgery,2
+Reed,344057,2013,Fraud,10
+Reed,344057,2013,Gambling,
+Reed,344057,2013,Homicide,
+Reed,344057,2013,Kidnap,
+Reed,344057,2013,Larceny,89
+Reed,344057,2013,Liquor Laws,
+Reed,344057,2013,Motor Vehicle Theft,14
+Reed,344057,2013,Offenses Against Family,
+Reed,344057,2013,Prostitution,
+Reed,344057,2013,Rape,1
+Reed,344057,2013,Robbery,
+Reed,344057,2013,Runaway,
+Reed,344057,2013,Sex Offenses,
+Reed,344057,2013,Stolen Property,1
+Reed,344057,2013,Trespass,6
+Reed,344057,2013,Vandalism,6
+Reed,344057,2013,Weapons,1
+Reed,344057,2014,Aggravated Assault,2
+Reed,344057,2014,Arson,
+Reed,344057,2014,"Assault, Simple",1
+Reed,344057,2014,Burglary,19
+Reed,344057,2014,Curfew,
+Reed,344057,2014,Disorderly Conduct,2
+Reed,344057,2014,Drugs,2
+Reed,344057,2014,DUII,5
+Reed,344057,2014,Embezzlement,
+Reed,344057,2014,Forgery,
+Reed,344057,2014,Fraud,7
+Reed,344057,2014,Gambling,
+Reed,344057,2014,Homicide,
+Reed,344057,2014,Kidnap,
+Reed,344057,2014,Larceny,72
+Reed,344057,2014,Liquor Laws,3
+Reed,344057,2014,Motor Vehicle Theft,21
+Reed,344057,2014,Offenses Against Family,
+Reed,344057,2014,Prostitution,
+Reed,344057,2014,Rape,
+Reed,344057,2014,Robbery,
+Reed,344057,2014,Runaway,
+Reed,344057,2014,Sex Offenses,
+Reed,344057,2014,Stolen Property,
+Reed,344057,2014,Trespass,6
+Reed,344057,2014,Vandalism,12
+Reed,344057,2014,Weapons,
+Richmond,276532,2004,Aggravated Assault,13
+Richmond,276532,2004,Arson,2
+Richmond,276532,2004,"Assault, Simple",12
+Richmond,276532,2004,Burglary,88
+Richmond,276532,2004,Curfew,
+Richmond,276532,2004,Disorderly Conduct,19
+Richmond,276532,2004,Drugs,16
+Richmond,276532,2004,DUII,15
+Richmond,276532,2004,Embezzlement,
+Richmond,276532,2004,Forgery,35
+Richmond,276532,2004,Fraud,20
+Richmond,276532,2004,Gambling,
+Richmond,276532,2004,Homicide,
+Richmond,276532,2004,Kidnap,1
+Richmond,276532,2004,Larceny,336
+Richmond,276532,2004,Liquor Laws,21
+Richmond,276532,2004,Motor Vehicle Theft,65
+Richmond,276532,2004,Offenses Against Family,
+Richmond,276532,2004,Prostitution,
+Richmond,276532,2004,Rape,
+Richmond,276532,2004,Robbery,17
+Richmond,276532,2004,Runaway,
+Richmond,276532,2004,Sex Offenses,4
+Richmond,276532,2004,Stolen Property,
+Richmond,276532,2004,Trespass,16
+Richmond,276532,2004,Vandalism,87
+Richmond,276532,2004,Weapons,
+Richmond,276532,2005,Aggravated Assault,46
+Richmond,276532,2005,Arson,7
+Richmond,276532,2005,"Assault, Simple",56
+Richmond,276532,2005,Burglary,170
+Richmond,276532,2005,Curfew,
+Richmond,276532,2005,Disorderly Conduct,44
+Richmond,276532,2005,Drugs,66
+Richmond,276532,2005,DUII,47
+Richmond,276532,2005,Embezzlement,4
+Richmond,276532,2005,Forgery,78
+Richmond,276532,2005,Fraud,73
+Richmond,276532,2005,Gambling,
+Richmond,276532,2005,Homicide,
+Richmond,276532,2005,Kidnap,
+Richmond,276532,2005,Larceny,687
+Richmond,276532,2005,Liquor Laws,59
+Richmond,276532,2005,Motor Vehicle Theft,138
+Richmond,276532,2005,Offenses Against Family,
+Richmond,276532,2005,Prostitution,
+Richmond,276532,2005,Rape,1
+Richmond,276532,2005,Robbery,26
+Richmond,276532,2005,Runaway,3
+Richmond,276532,2005,Sex Offenses,3
+Richmond,276532,2005,Stolen Property,1
+Richmond,276532,2005,Trespass,54
+Richmond,276532,2005,Vandalism,194
+Richmond,276532,2005,Weapons,3
+Richmond,276532,2006,Aggravated Assault,31
+Richmond,276532,2006,Arson,3
+Richmond,276532,2006,"Assault, Simple",73
+Richmond,276532,2006,Burglary,142
+Richmond,276532,2006,Curfew,2
+Richmond,276532,2006,Disorderly Conduct,45
+Richmond,276532,2006,Drugs,50
+Richmond,276532,2006,DUII,60
+Richmond,276532,2006,Embezzlement,5
+Richmond,276532,2006,Forgery,42
+Richmond,276532,2006,Fraud,77
+Richmond,276532,2006,Gambling,
+Richmond,276532,2006,Homicide,1
+Richmond,276532,2006,Kidnap,2
+Richmond,276532,2006,Larceny,577
+Richmond,276532,2006,Liquor Laws,97
+Richmond,276532,2006,Motor Vehicle Theft,116
+Richmond,276532,2006,Offenses Against Family,
+Richmond,276532,2006,Prostitution,
+Richmond,276532,2006,Rape,
+Richmond,276532,2006,Robbery,44
+Richmond,276532,2006,Runaway,
+Richmond,276532,2006,Sex Offenses,4
+Richmond,276532,2006,Stolen Property,
+Richmond,276532,2006,Trespass,35
+Richmond,276532,2006,Vandalism,217
+Richmond,276532,2006,Weapons,7
+Richmond,276532,2007,Aggravated Assault,34
+Richmond,276532,2007,Arson,2
+Richmond,276532,2007,"Assault, Simple",60
+Richmond,276532,2007,Burglary,111
+Richmond,276532,2007,Curfew,2
+Richmond,276532,2007,Disorderly Conduct,59
+Richmond,276532,2007,Drugs,52
+Richmond,276532,2007,DUII,65
+Richmond,276532,2007,Embezzlement,4
+Richmond,276532,2007,Forgery,48
+Richmond,276532,2007,Fraud,82
+Richmond,276532,2007,Gambling,
+Richmond,276532,2007,Homicide,1
+Richmond,276532,2007,Kidnap,2
+Richmond,276532,2007,Larceny,581
+Richmond,276532,2007,Liquor Laws,88
+Richmond,276532,2007,Motor Vehicle Theft,111
+Richmond,276532,2007,Offenses Against Family,
+Richmond,276532,2007,Prostitution,
+Richmond,276532,2007,Rape,
+Richmond,276532,2007,Robbery,26
+Richmond,276532,2007,Runaway,
+Richmond,276532,2007,Sex Offenses,1
+Richmond,276532,2007,Stolen Property,2
+Richmond,276532,2007,Trespass,47
+Richmond,276532,2007,Vandalism,199
+Richmond,276532,2007,Weapons,1
+Richmond,276532,2008,Aggravated Assault,32
+Richmond,276532,2008,Arson,3
+Richmond,276532,2008,"Assault, Simple",40
+Richmond,276532,2008,Burglary,83
+Richmond,276532,2008,Curfew,
+Richmond,276532,2008,Disorderly Conduct,44
+Richmond,276532,2008,Drugs,35
+Richmond,276532,2008,DUII,50
+Richmond,276532,2008,Embezzlement,4
+Richmond,276532,2008,Forgery,30
+Richmond,276532,2008,Fraud,49
+Richmond,276532,2008,Gambling,
+Richmond,276532,2008,Homicide,
+Richmond,276532,2008,Kidnap,
+Richmond,276532,2008,Larceny,495
+Richmond,276532,2008,Liquor Laws,82
+Richmond,276532,2008,Motor Vehicle Theft,78
+Richmond,276532,2008,Offenses Against Family,
+Richmond,276532,2008,Prostitution,
+Richmond,276532,2008,Rape,2
+Richmond,276532,2008,Robbery,29
+Richmond,276532,2008,Runaway,1
+Richmond,276532,2008,Sex Offenses,4
+Richmond,276532,2008,Stolen Property,1
+Richmond,276532,2008,Trespass,60
+Richmond,276532,2008,Vandalism,124
+Richmond,276532,2008,Weapons,3
+Richmond,276532,2009,Aggravated Assault,24
+Richmond,276532,2009,Arson,4
+Richmond,276532,2009,"Assault, Simple",41
+Richmond,276532,2009,Burglary,56
+Richmond,276532,2009,Curfew,2
+Richmond,276532,2009,Disorderly Conduct,58
+Richmond,276532,2009,Drugs,28
+Richmond,276532,2009,DUII,37
+Richmond,276532,2009,Embezzlement,3
+Richmond,276532,2009,Forgery,34
+Richmond,276532,2009,Fraud,58
+Richmond,276532,2009,Gambling,
+Richmond,276532,2009,Homicide,
+Richmond,276532,2009,Kidnap,
+Richmond,276532,2009,Larceny,564
+Richmond,276532,2009,Liquor Laws,80
+Richmond,276532,2009,Motor Vehicle Theft,81
+Richmond,276532,2009,Offenses Against Family,1
+Richmond,276532,2009,Prostitution,1
+Richmond,276532,2009,Rape,1
+Richmond,276532,2009,Robbery,30
+Richmond,276532,2009,Runaway,1
+Richmond,276532,2009,Sex Offenses,5
+Richmond,276532,2009,Stolen Property,
+Richmond,276532,2009,Trespass,39
+Richmond,276532,2009,Vandalism,124
+Richmond,276532,2009,Weapons,2
+Richmond,276532,2010,Aggravated Assault,16
+Richmond,276532,2010,Arson,5
+Richmond,276532,2010,"Assault, Simple",46
+Richmond,276532,2010,Burglary,73
+Richmond,276532,2010,Curfew,
+Richmond,276532,2010,Disorderly Conduct,43
+Richmond,276532,2010,Drugs,33
+Richmond,276532,2010,DUII,55
+Richmond,276532,2010,Embezzlement,3
+Richmond,276532,2010,Forgery,29
+Richmond,276532,2010,Fraud,45
+Richmond,276532,2010,Gambling,
+Richmond,276532,2010,Homicide,
+Richmond,276532,2010,Kidnap,1
+Richmond,276532,2010,Larceny,592
+Richmond,276532,2010,Liquor Laws,63
+Richmond,276532,2010,Motor Vehicle Theft,78
+Richmond,276532,2010,Offenses Against Family,
+Richmond,276532,2010,Prostitution,
+Richmond,276532,2010,Rape,
+Richmond,276532,2010,Robbery,29
+Richmond,276532,2010,Runaway,2
+Richmond,276532,2010,Sex Offenses,3
+Richmond,276532,2010,Stolen Property,2
+Richmond,276532,2010,Trespass,48
+Richmond,276532,2010,Vandalism,175
+Richmond,276532,2010,Weapons,2
+Richmond,276532,2011,Aggravated Assault,23
+Richmond,276532,2011,Arson,1
+Richmond,276532,2011,"Assault, Simple",48
+Richmond,276532,2011,Burglary,68
+Richmond,276532,2011,Curfew,
+Richmond,276532,2011,Disorderly Conduct,57
+Richmond,276532,2011,Drugs,14
+Richmond,276532,2011,DUII,52
+Richmond,276532,2011,Embezzlement,2
+Richmond,276532,2011,Forgery,23
+Richmond,276532,2011,Fraud,40
+Richmond,276532,2011,Gambling,
+Richmond,276532,2011,Homicide,
+Richmond,276532,2011,Kidnap,
+Richmond,276532,2011,Larceny,668
+Richmond,276532,2011,Liquor Laws,55
+Richmond,276532,2011,Motor Vehicle Theft,75
+Richmond,276532,2011,Offenses Against Family,
+Richmond,276532,2011,Prostitution,
+Richmond,276532,2011,Rape,
+Richmond,276532,2011,Robbery,18
+Richmond,276532,2011,Runaway,1
+Richmond,276532,2011,Sex Offenses,1
+Richmond,276532,2011,Stolen Property,1
+Richmond,276532,2011,Trespass,24
+Richmond,276532,2011,Vandalism,144
+Richmond,276532,2011,Weapons,3
+Richmond,276532,2012,Aggravated Assault,14
+Richmond,276532,2012,Arson,1
+Richmond,276532,2012,"Assault, Simple",41
+Richmond,276532,2012,Burglary,129
+Richmond,276532,2012,Curfew,
+Richmond,276532,2012,Disorderly Conduct,42
+Richmond,276532,2012,Drugs,23
+Richmond,276532,2012,DUII,45
+Richmond,276532,2012,Embezzlement,6
+Richmond,276532,2012,Forgery,56
+Richmond,276532,2012,Fraud,48
+Richmond,276532,2012,Gambling,
+Richmond,276532,2012,Homicide,
+Richmond,276532,2012,Kidnap,
+Richmond,276532,2012,Larceny,639
+Richmond,276532,2012,Liquor Laws,32
+Richmond,276532,2012,Motor Vehicle Theft,98
+Richmond,276532,2012,Offenses Against Family,
+Richmond,276532,2012,Prostitution,
+Richmond,276532,2012,Rape,
+Richmond,276532,2012,Robbery,16
+Richmond,276532,2012,Runaway,1
+Richmond,276532,2012,Sex Offenses,1
+Richmond,276532,2012,Stolen Property,1
+Richmond,276532,2012,Trespass,28
+Richmond,276532,2012,Vandalism,130
+Richmond,276532,2012,Weapons,1
+Richmond,276532,2013,Aggravated Assault,18
+Richmond,276532,2013,Arson,1
+Richmond,276532,2013,"Assault, Simple",32
+Richmond,276532,2013,Burglary,97
+Richmond,276532,2013,Curfew,
+Richmond,276532,2013,Disorderly Conduct,37
+Richmond,276532,2013,Drugs,12
+Richmond,276532,2013,DUII,51
+Richmond,276532,2013,Embezzlement,6
+Richmond,276532,2013,Forgery,42
+Richmond,276532,2013,Fraud,51
+Richmond,276532,2013,Gambling,
+Richmond,276532,2013,Homicide,
+Richmond,276532,2013,Kidnap,1
+Richmond,276532,2013,Larceny,629
+Richmond,276532,2013,Liquor Laws,25
+Richmond,276532,2013,Motor Vehicle Theft,99
+Richmond,276532,2013,Offenses Against Family,
+Richmond,276532,2013,Prostitution,
+Richmond,276532,2013,Rape,1
+Richmond,276532,2013,Robbery,19
+Richmond,276532,2013,Runaway,
+Richmond,276532,2013,Sex Offenses,4
+Richmond,276532,2013,Stolen Property,
+Richmond,276532,2013,Trespass,21
+Richmond,276532,2013,Vandalism,277
+Richmond,276532,2013,Weapons,1
+Richmond,276532,2014,Aggravated Assault,14
+Richmond,276532,2014,Arson,2
+Richmond,276532,2014,"Assault, Simple",25
+Richmond,276532,2014,Burglary,87
+Richmond,276532,2014,Curfew,
+Richmond,276532,2014,Disorderly Conduct,44
+Richmond,276532,2014,Drugs,15
+Richmond,276532,2014,DUII,26
+Richmond,276532,2014,Embezzlement,2
+Richmond,276532,2014,Forgery,17
+Richmond,276532,2014,Fraud,69
+Richmond,276532,2014,Gambling,
+Richmond,276532,2014,Homicide,
+Richmond,276532,2014,Kidnap,
+Richmond,276532,2014,Larceny,894
+Richmond,276532,2014,Liquor Laws,28
+Richmond,276532,2014,Motor Vehicle Theft,116
+Richmond,276532,2014,Offenses Against Family,
+Richmond,276532,2014,Prostitution,
+Richmond,276532,2014,Rape,
+Richmond,276532,2014,Robbery,13
+Richmond,276532,2014,Runaway,
+Richmond,276532,2014,Sex Offenses,2
+Richmond,276532,2014,Stolen Property,
+Richmond,276532,2014,Trespass,38
+Richmond,276532,2014,Vandalism,139
+Richmond,276532,2014,Weapons,1
+Roseway,271127,2004,Aggravated Assault,9
+Roseway,271127,2004,Arson,
+Roseway,271127,2004,"Assault, Simple",16
+Roseway,271127,2004,Burglary,102
+Roseway,271127,2004,Curfew,2
+Roseway,271127,2004,Disorderly Conduct,11
+Roseway,271127,2004,Drugs,18
+Roseway,271127,2004,DUII,19
+Roseway,271127,2004,Embezzlement,4
+Roseway,271127,2004,Forgery,30
+Roseway,271127,2004,Fraud,29
+Roseway,271127,2004,Gambling,
+Roseway,271127,2004,Homicide,
+Roseway,271127,2004,Kidnap,1
+Roseway,271127,2004,Larceny,298
+Roseway,271127,2004,Liquor Laws,2
+Roseway,271127,2004,Motor Vehicle Theft,65
+Roseway,271127,2004,Offenses Against Family,
+Roseway,271127,2004,Prostitution,14
+Roseway,271127,2004,Rape,1
+Roseway,271127,2004,Robbery,12
+Roseway,271127,2004,Runaway,
+Roseway,271127,2004,Sex Offenses,
+Roseway,271127,2004,Stolen Property,1
+Roseway,271127,2004,Trespass,26
+Roseway,271127,2004,Vandalism,49
+Roseway,271127,2004,Weapons,4
+Roseway,271127,2005,Aggravated Assault,42
+Roseway,271127,2005,Arson,1
+Roseway,271127,2005,"Assault, Simple",90
+Roseway,271127,2005,Burglary,248
+Roseway,271127,2005,Curfew,4
+Roseway,271127,2005,Disorderly Conduct,80
+Roseway,271127,2005,Drugs,127
+Roseway,271127,2005,DUII,47
+Roseway,271127,2005,Embezzlement,6
+Roseway,271127,2005,Forgery,70
+Roseway,271127,2005,Fraud,112
+Roseway,271127,2005,Gambling,
+Roseway,271127,2005,Homicide,
+Roseway,271127,2005,Kidnap,
+Roseway,271127,2005,Larceny,766
+Roseway,271127,2005,Liquor Laws,89
+Roseway,271127,2005,Motor Vehicle Theft,214
+Roseway,271127,2005,Offenses Against Family,
+Roseway,271127,2005,Prostitution,21
+Roseway,271127,2005,Rape,1
+Roseway,271127,2005,Robbery,55
+Roseway,271127,2005,Runaway,2
+Roseway,271127,2005,Sex Offenses,6
+Roseway,271127,2005,Stolen Property,1
+Roseway,271127,2005,Trespass,89
+Roseway,271127,2005,Vandalism,170
+Roseway,271127,2005,Weapons,13
+Roseway,271127,2006,Aggravated Assault,34
+Roseway,271127,2006,Arson,1
+Roseway,271127,2006,"Assault, Simple",67
+Roseway,271127,2006,Burglary,229
+Roseway,271127,2006,Curfew,13
+Roseway,271127,2006,Disorderly Conduct,75
+Roseway,271127,2006,Drugs,136
+Roseway,271127,2006,DUII,59
+Roseway,271127,2006,Embezzlement,1
+Roseway,271127,2006,Forgery,58
+Roseway,271127,2006,Fraud,96
+Roseway,271127,2006,Gambling,
+Roseway,271127,2006,Homicide,2
+Roseway,271127,2006,Kidnap,2
+Roseway,271127,2006,Larceny,582
+Roseway,271127,2006,Liquor Laws,108
+Roseway,271127,2006,Motor Vehicle Theft,123
+Roseway,271127,2006,Offenses Against Family,
+Roseway,271127,2006,Prostitution,15
+Roseway,271127,2006,Rape,1
+Roseway,271127,2006,Robbery,55
+Roseway,271127,2006,Runaway,1
+Roseway,271127,2006,Sex Offenses,1
+Roseway,271127,2006,Stolen Property,2
+Roseway,271127,2006,Trespass,97
+Roseway,271127,2006,Vandalism,216
+Roseway,271127,2006,Weapons,15
+Roseway,271127,2007,Aggravated Assault,29
+Roseway,271127,2007,Arson,1
+Roseway,271127,2007,"Assault, Simple",51
+Roseway,271127,2007,Burglary,176
+Roseway,271127,2007,Curfew,8
+Roseway,271127,2007,Disorderly Conduct,96
+Roseway,271127,2007,Drugs,82
+Roseway,271127,2007,DUII,61
+Roseway,271127,2007,Embezzlement,7
+Roseway,271127,2007,Forgery,73
+Roseway,271127,2007,Fraud,76
+Roseway,271127,2007,Gambling,
+Roseway,271127,2007,Homicide,
+Roseway,271127,2007,Kidnap,1
+Roseway,271127,2007,Larceny,634
+Roseway,271127,2007,Liquor Laws,51
+Roseway,271127,2007,Motor Vehicle Theft,149
+Roseway,271127,2007,Offenses Against Family,
+Roseway,271127,2007,Prostitution,21
+Roseway,271127,2007,Rape,2
+Roseway,271127,2007,Robbery,60
+Roseway,271127,2007,Runaway,1
+Roseway,271127,2007,Sex Offenses,6
+Roseway,271127,2007,Stolen Property,
+Roseway,271127,2007,Trespass,85
+Roseway,271127,2007,Vandalism,177
+Roseway,271127,2007,Weapons,15
+Roseway,271127,2008,Aggravated Assault,30
+Roseway,271127,2008,Arson,
+Roseway,271127,2008,"Assault, Simple",53
+Roseway,271127,2008,Burglary,151
+Roseway,271127,2008,Curfew,5
+Roseway,271127,2008,Disorderly Conduct,97
+Roseway,271127,2008,Drugs,69
+Roseway,271127,2008,DUII,65
+Roseway,271127,2008,Embezzlement,6
+Roseway,271127,2008,Forgery,34
+Roseway,271127,2008,Fraud,62
+Roseway,271127,2008,Gambling,
+Roseway,271127,2008,Homicide,
+Roseway,271127,2008,Kidnap,1
+Roseway,271127,2008,Larceny,602
+Roseway,271127,2008,Liquor Laws,48
+Roseway,271127,2008,Motor Vehicle Theft,94
+Roseway,271127,2008,Offenses Against Family,
+Roseway,271127,2008,Prostitution,37
+Roseway,271127,2008,Rape,
+Roseway,271127,2008,Robbery,37
+Roseway,271127,2008,Runaway,1
+Roseway,271127,2008,Sex Offenses,
+Roseway,271127,2008,Stolen Property,1
+Roseway,271127,2008,Trespass,50
+Roseway,271127,2008,Vandalism,203
+Roseway,271127,2008,Weapons,8
+Roseway,271127,2009,Aggravated Assault,30
+Roseway,271127,2009,Arson,4
+Roseway,271127,2009,"Assault, Simple",52
+Roseway,271127,2009,Burglary,133
+Roseway,271127,2009,Curfew,5
+Roseway,271127,2009,Disorderly Conduct,105
+Roseway,271127,2009,Drugs,39
+Roseway,271127,2009,DUII,57
+Roseway,271127,2009,Embezzlement,3
+Roseway,271127,2009,Forgery,28
+Roseway,271127,2009,Fraud,69
+Roseway,271127,2009,Gambling,
+Roseway,271127,2009,Homicide,
+Roseway,271127,2009,Kidnap,1
+Roseway,271127,2009,Larceny,604
+Roseway,271127,2009,Liquor Laws,55
+Roseway,271127,2009,Motor Vehicle Theft,92
+Roseway,271127,2009,Offenses Against Family,
+Roseway,271127,2009,Prostitution,18
+Roseway,271127,2009,Rape,
+Roseway,271127,2009,Robbery,56
+Roseway,271127,2009,Runaway,2
+Roseway,271127,2009,Sex Offenses,2
+Roseway,271127,2009,Stolen Property,
+Roseway,271127,2009,Trespass,48
+Roseway,271127,2009,Vandalism,117
+Roseway,271127,2009,Weapons,4
+Roseway,271127,2010,Aggravated Assault,23
+Roseway,271127,2010,Arson,
+Roseway,271127,2010,"Assault, Simple",40
+Roseway,271127,2010,Burglary,170
+Roseway,271127,2010,Curfew,1
+Roseway,271127,2010,Disorderly Conduct,107
+Roseway,271127,2010,Drugs,46
+Roseway,271127,2010,DUII,48
+Roseway,271127,2010,Embezzlement,6
+Roseway,271127,2010,Forgery,30
+Roseway,271127,2010,Fraud,45
+Roseway,271127,2010,Gambling,
+Roseway,271127,2010,Homicide,1
+Roseway,271127,2010,Kidnap,2
+Roseway,271127,2010,Larceny,553
+Roseway,271127,2010,Liquor Laws,27
+Roseway,271127,2010,Motor Vehicle Theft,88
+Roseway,271127,2010,Offenses Against Family,
+Roseway,271127,2010,Prostitution,9
+Roseway,271127,2010,Rape,1
+Roseway,271127,2010,Robbery,32
+Roseway,271127,2010,Runaway,
+Roseway,271127,2010,Sex Offenses,6
+Roseway,271127,2010,Stolen Property,4
+Roseway,271127,2010,Trespass,38
+Roseway,271127,2010,Vandalism,120
+Roseway,271127,2010,Weapons,5
+Roseway,271127,2011,Aggravated Assault,29
+Roseway,271127,2011,Arson,
+Roseway,271127,2011,"Assault, Simple",52
+Roseway,271127,2011,Burglary,142
+Roseway,271127,2011,Curfew,
+Roseway,271127,2011,Disorderly Conduct,65
+Roseway,271127,2011,Drugs,54
+Roseway,271127,2011,DUII,45
+Roseway,271127,2011,Embezzlement,1
+Roseway,271127,2011,Forgery,28
+Roseway,271127,2011,Fraud,52
+Roseway,271127,2011,Gambling,
+Roseway,271127,2011,Homicide,
+Roseway,271127,2011,Kidnap,1
+Roseway,271127,2011,Larceny,661
+Roseway,271127,2011,Liquor Laws,23
+Roseway,271127,2011,Motor Vehicle Theft,106
+Roseway,271127,2011,Offenses Against Family,
+Roseway,271127,2011,Prostitution,42
+Roseway,271127,2011,Rape,3
+Roseway,271127,2011,Robbery,43
+Roseway,271127,2011,Runaway,
+Roseway,271127,2011,Sex Offenses,6
+Roseway,271127,2011,Stolen Property,1
+Roseway,271127,2011,Trespass,53
+Roseway,271127,2011,Vandalism,127
+Roseway,271127,2011,Weapons,7
+Roseway,271127,2012,Aggravated Assault,30
+Roseway,271127,2012,Arson,
+Roseway,271127,2012,"Assault, Simple",48
+Roseway,271127,2012,Burglary,152
+Roseway,271127,2012,Curfew,1
+Roseway,271127,2012,Disorderly Conduct,106
+Roseway,271127,2012,Drugs,88
+Roseway,271127,2012,DUII,61
+Roseway,271127,2012,Embezzlement,3
+Roseway,271127,2012,Forgery,33
+Roseway,271127,2012,Fraud,54
+Roseway,271127,2012,Gambling,
+Roseway,271127,2012,Homicide,
+Roseway,271127,2012,Kidnap,
+Roseway,271127,2012,Larceny,633
+Roseway,271127,2012,Liquor Laws,32
+Roseway,271127,2012,Motor Vehicle Theft,103
+Roseway,271127,2012,Offenses Against Family,
+Roseway,271127,2012,Prostitution,63
+Roseway,271127,2012,Rape,1
+Roseway,271127,2012,Robbery,43
+Roseway,271127,2012,Runaway,
+Roseway,271127,2012,Sex Offenses,4
+Roseway,271127,2012,Stolen Property,2
+Roseway,271127,2012,Trespass,94
+Roseway,271127,2012,Vandalism,142
+Roseway,271127,2012,Weapons,14
+Roseway,271127,2013,Aggravated Assault,21
+Roseway,271127,2013,Arson,
+Roseway,271127,2013,"Assault, Simple",43
+Roseway,271127,2013,Burglary,151
+Roseway,271127,2013,Curfew,1
+Roseway,271127,2013,Disorderly Conduct,64
+Roseway,271127,2013,Drugs,102
+Roseway,271127,2013,DUII,48
+Roseway,271127,2013,Embezzlement,4
+Roseway,271127,2013,Forgery,23
+Roseway,271127,2013,Fraud,41
+Roseway,271127,2013,Gambling,
+Roseway,271127,2013,Homicide,
+Roseway,271127,2013,Kidnap,
+Roseway,271127,2013,Larceny,590
+Roseway,271127,2013,Liquor Laws,16
+Roseway,271127,2013,Motor Vehicle Theft,106
+Roseway,271127,2013,Offenses Against Family,
+Roseway,271127,2013,Prostitution,26
+Roseway,271127,2013,Rape,1
+Roseway,271127,2013,Robbery,39
+Roseway,271127,2013,Runaway,2
+Roseway,271127,2013,Sex Offenses,3
+Roseway,271127,2013,Stolen Property,1
+Roseway,271127,2013,Trespass,78
+Roseway,271127,2013,Vandalism,256
+Roseway,271127,2013,Weapons,13
+Roseway,271127,2014,Aggravated Assault,34
+Roseway,271127,2014,Arson,
+Roseway,271127,2014,"Assault, Simple",56
+Roseway,271127,2014,Burglary,127
+Roseway,271127,2014,Curfew,1
+Roseway,271127,2014,Disorderly Conduct,73
+Roseway,271127,2014,Drugs,76
+Roseway,271127,2014,DUII,34
+Roseway,271127,2014,Embezzlement,5
+Roseway,271127,2014,Forgery,31
+Roseway,271127,2014,Fraud,92
+Roseway,271127,2014,Gambling,
+Roseway,271127,2014,Homicide,1
+Roseway,271127,2014,Kidnap,1
+Roseway,271127,2014,Larceny,558
+Roseway,271127,2014,Liquor Laws,23
+Roseway,271127,2014,Motor Vehicle Theft,91
+Roseway,271127,2014,Offenses Against Family,
+Roseway,271127,2014,Prostitution,4
+Roseway,271127,2014,Rape,1
+Roseway,271127,2014,Robbery,26
+Roseway,271127,2014,Runaway,
+Roseway,271127,2014,Sex Offenses,5
+Roseway,271127,2014,Stolen Property,1
+Roseway,271127,2014,Trespass,51
+Roseway,271127,2014,Vandalism,112
+Roseway,271127,2014,Weapons,7
+Ross Island,275256,2004,Aggravated Assault,
+Ross Island,275256,2004,Arson,
+Ross Island,275256,2004,"Assault, Simple",
+Ross Island,275256,2004,Burglary,
+Ross Island,275256,2004,Curfew,
+Ross Island,275256,2004,Disorderly Conduct,
+Ross Island,275256,2004,Drugs,
+Ross Island,275256,2004,DUII,
+Ross Island,275256,2004,Embezzlement,
+Ross Island,275256,2004,Forgery,
+Ross Island,275256,2004,Fraud,
+Ross Island,275256,2004,Gambling,
+Ross Island,275256,2004,Homicide,
+Ross Island,275256,2004,Kidnap,
+Ross Island,275256,2004,Larceny,
+Ross Island,275256,2004,Liquor Laws,
+Ross Island,275256,2004,Motor Vehicle Theft,
+Ross Island,275256,2004,Offenses Against Family,
+Ross Island,275256,2004,Prostitution,
+Ross Island,275256,2004,Rape,
+Ross Island,275256,2004,Robbery,
+Ross Island,275256,2004,Runaway,
+Ross Island,275256,2004,Sex Offenses,
+Ross Island,275256,2004,Stolen Property,
+Ross Island,275256,2004,Trespass,
+Ross Island,275256,2004,Vandalism,
+Ross Island,275256,2004,Weapons,
+Ross Island,275256,2005,Aggravated Assault,
+Ross Island,275256,2005,Arson,
+Ross Island,275256,2005,"Assault, Simple",
+Ross Island,275256,2005,Burglary,
+Ross Island,275256,2005,Curfew,
+Ross Island,275256,2005,Disorderly Conduct,
+Ross Island,275256,2005,Drugs,
+Ross Island,275256,2005,DUII,
+Ross Island,275256,2005,Embezzlement,
+Ross Island,275256,2005,Forgery,
+Ross Island,275256,2005,Fraud,
+Ross Island,275256,2005,Gambling,
+Ross Island,275256,2005,Homicide,
+Ross Island,275256,2005,Kidnap,
+Ross Island,275256,2005,Larceny,
+Ross Island,275256,2005,Liquor Laws,
+Ross Island,275256,2005,Motor Vehicle Theft,
+Ross Island,275256,2005,Offenses Against Family,
+Ross Island,275256,2005,Prostitution,
+Ross Island,275256,2005,Rape,
+Ross Island,275256,2005,Robbery,
+Ross Island,275256,2005,Runaway,
+Ross Island,275256,2005,Sex Offenses,
+Ross Island,275256,2005,Stolen Property,
+Ross Island,275256,2005,Trespass,
+Ross Island,275256,2005,Vandalism,
+Ross Island,275256,2005,Weapons,
+Ross Island,275256,2006,Aggravated Assault,
+Ross Island,275256,2006,Arson,
+Ross Island,275256,2006,"Assault, Simple",
+Ross Island,275256,2006,Burglary,
+Ross Island,275256,2006,Curfew,
+Ross Island,275256,2006,Disorderly Conduct,
+Ross Island,275256,2006,Drugs,
+Ross Island,275256,2006,DUII,
+Ross Island,275256,2006,Embezzlement,
+Ross Island,275256,2006,Forgery,
+Ross Island,275256,2006,Fraud,
+Ross Island,275256,2006,Gambling,
+Ross Island,275256,2006,Homicide,
+Ross Island,275256,2006,Kidnap,
+Ross Island,275256,2006,Larceny,
+Ross Island,275256,2006,Liquor Laws,
+Ross Island,275256,2006,Motor Vehicle Theft,
+Ross Island,275256,2006,Offenses Against Family,
+Ross Island,275256,2006,Prostitution,
+Ross Island,275256,2006,Rape,
+Ross Island,275256,2006,Robbery,
+Ross Island,275256,2006,Runaway,
+Ross Island,275256,2006,Sex Offenses,
+Ross Island,275256,2006,Stolen Property,
+Ross Island,275256,2006,Trespass,
+Ross Island,275256,2006,Vandalism,
+Ross Island,275256,2006,Weapons,
+Ross Island,275256,2007,Aggravated Assault,
+Ross Island,275256,2007,Arson,
+Ross Island,275256,2007,"Assault, Simple",
+Ross Island,275256,2007,Burglary,
+Ross Island,275256,2007,Curfew,
+Ross Island,275256,2007,Disorderly Conduct,
+Ross Island,275256,2007,Drugs,
+Ross Island,275256,2007,DUII,
+Ross Island,275256,2007,Embezzlement,
+Ross Island,275256,2007,Forgery,
+Ross Island,275256,2007,Fraud,
+Ross Island,275256,2007,Gambling,
+Ross Island,275256,2007,Homicide,
+Ross Island,275256,2007,Kidnap,
+Ross Island,275256,2007,Larceny,
+Ross Island,275256,2007,Liquor Laws,
+Ross Island,275256,2007,Motor Vehicle Theft,
+Ross Island,275256,2007,Offenses Against Family,
+Ross Island,275256,2007,Prostitution,
+Ross Island,275256,2007,Rape,
+Ross Island,275256,2007,Robbery,
+Ross Island,275256,2007,Runaway,
+Ross Island,275256,2007,Sex Offenses,
+Ross Island,275256,2007,Stolen Property,
+Ross Island,275256,2007,Trespass,
+Ross Island,275256,2007,Vandalism,
+Ross Island,275256,2007,Weapons,
+Ross Island,275256,2008,Aggravated Assault,
+Ross Island,275256,2008,Arson,
+Ross Island,275256,2008,"Assault, Simple",
+Ross Island,275256,2008,Burglary,
+Ross Island,275256,2008,Curfew,
+Ross Island,275256,2008,Disorderly Conduct,
+Ross Island,275256,2008,Drugs,
+Ross Island,275256,2008,DUII,
+Ross Island,275256,2008,Embezzlement,
+Ross Island,275256,2008,Forgery,
+Ross Island,275256,2008,Fraud,
+Ross Island,275256,2008,Gambling,
+Ross Island,275256,2008,Homicide,
+Ross Island,275256,2008,Kidnap,
+Ross Island,275256,2008,Larceny,
+Ross Island,275256,2008,Liquor Laws,
+Ross Island,275256,2008,Motor Vehicle Theft,
+Ross Island,275256,2008,Offenses Against Family,
+Ross Island,275256,2008,Prostitution,
+Ross Island,275256,2008,Rape,
+Ross Island,275256,2008,Robbery,
+Ross Island,275256,2008,Runaway,
+Ross Island,275256,2008,Sex Offenses,
+Ross Island,275256,2008,Stolen Property,
+Ross Island,275256,2008,Trespass,
+Ross Island,275256,2008,Vandalism,
+Ross Island,275256,2008,Weapons,
+Ross Island,275256,2009,Aggravated Assault,
+Ross Island,275256,2009,Arson,
+Ross Island,275256,2009,"Assault, Simple",
+Ross Island,275256,2009,Burglary,
+Ross Island,275256,2009,Curfew,
+Ross Island,275256,2009,Disorderly Conduct,
+Ross Island,275256,2009,Drugs,
+Ross Island,275256,2009,DUII,
+Ross Island,275256,2009,Embezzlement,
+Ross Island,275256,2009,Forgery,
+Ross Island,275256,2009,Fraud,
+Ross Island,275256,2009,Gambling,
+Ross Island,275256,2009,Homicide,
+Ross Island,275256,2009,Kidnap,
+Ross Island,275256,2009,Larceny,
+Ross Island,275256,2009,Liquor Laws,
+Ross Island,275256,2009,Motor Vehicle Theft,
+Ross Island,275256,2009,Offenses Against Family,
+Ross Island,275256,2009,Prostitution,
+Ross Island,275256,2009,Rape,
+Ross Island,275256,2009,Robbery,
+Ross Island,275256,2009,Runaway,
+Ross Island,275256,2009,Sex Offenses,
+Ross Island,275256,2009,Stolen Property,
+Ross Island,275256,2009,Trespass,
+Ross Island,275256,2009,Vandalism,
+Ross Island,275256,2009,Weapons,
+Ross Island,275256,2010,Aggravated Assault,
+Ross Island,275256,2010,Arson,
+Ross Island,275256,2010,"Assault, Simple",
+Ross Island,275256,2010,Burglary,
+Ross Island,275256,2010,Curfew,
+Ross Island,275256,2010,Disorderly Conduct,
+Ross Island,275256,2010,Drugs,
+Ross Island,275256,2010,DUII,
+Ross Island,275256,2010,Embezzlement,
+Ross Island,275256,2010,Forgery,
+Ross Island,275256,2010,Fraud,
+Ross Island,275256,2010,Gambling,
+Ross Island,275256,2010,Homicide,
+Ross Island,275256,2010,Kidnap,
+Ross Island,275256,2010,Larceny,
+Ross Island,275256,2010,Liquor Laws,
+Ross Island,275256,2010,Motor Vehicle Theft,
+Ross Island,275256,2010,Offenses Against Family,
+Ross Island,275256,2010,Prostitution,
+Ross Island,275256,2010,Rape,
+Ross Island,275256,2010,Robbery,
+Ross Island,275256,2010,Runaway,
+Ross Island,275256,2010,Sex Offenses,
+Ross Island,275256,2010,Stolen Property,
+Ross Island,275256,2010,Trespass,
+Ross Island,275256,2010,Vandalism,
+Ross Island,275256,2010,Weapons,
+Ross Island,275256,2011,Aggravated Assault,
+Ross Island,275256,2011,Arson,
+Ross Island,275256,2011,"Assault, Simple",
+Ross Island,275256,2011,Burglary,
+Ross Island,275256,2011,Curfew,
+Ross Island,275256,2011,Disorderly Conduct,
+Ross Island,275256,2011,Drugs,
+Ross Island,275256,2011,DUII,
+Ross Island,275256,2011,Embezzlement,
+Ross Island,275256,2011,Forgery,
+Ross Island,275256,2011,Fraud,
+Ross Island,275256,2011,Gambling,
+Ross Island,275256,2011,Homicide,
+Ross Island,275256,2011,Kidnap,
+Ross Island,275256,2011,Larceny,
+Ross Island,275256,2011,Liquor Laws,
+Ross Island,275256,2011,Motor Vehicle Theft,
+Ross Island,275256,2011,Offenses Against Family,
+Ross Island,275256,2011,Prostitution,
+Ross Island,275256,2011,Rape,
+Ross Island,275256,2011,Robbery,
+Ross Island,275256,2011,Runaway,
+Ross Island,275256,2011,Sex Offenses,
+Ross Island,275256,2011,Stolen Property,
+Ross Island,275256,2011,Trespass,
+Ross Island,275256,2011,Vandalism,
+Ross Island,275256,2011,Weapons,
+Ross Island,275256,2012,Aggravated Assault,
+Ross Island,275256,2012,Arson,
+Ross Island,275256,2012,"Assault, Simple",
+Ross Island,275256,2012,Burglary,
+Ross Island,275256,2012,Curfew,
+Ross Island,275256,2012,Disorderly Conduct,
+Ross Island,275256,2012,Drugs,
+Ross Island,275256,2012,DUII,
+Ross Island,275256,2012,Embezzlement,
+Ross Island,275256,2012,Forgery,
+Ross Island,275256,2012,Fraud,
+Ross Island,275256,2012,Gambling,
+Ross Island,275256,2012,Homicide,
+Ross Island,275256,2012,Kidnap,
+Ross Island,275256,2012,Larceny,
+Ross Island,275256,2012,Liquor Laws,
+Ross Island,275256,2012,Motor Vehicle Theft,
+Ross Island,275256,2012,Offenses Against Family,
+Ross Island,275256,2012,Prostitution,
+Ross Island,275256,2012,Rape,
+Ross Island,275256,2012,Robbery,
+Ross Island,275256,2012,Runaway,
+Ross Island,275256,2012,Sex Offenses,
+Ross Island,275256,2012,Stolen Property,
+Ross Island,275256,2012,Trespass,
+Ross Island,275256,2012,Vandalism,
+Ross Island,275256,2012,Weapons,
+Ross Island,275256,2013,Aggravated Assault,
+Ross Island,275256,2013,Arson,
+Ross Island,275256,2013,"Assault, Simple",
+Ross Island,275256,2013,Burglary,
+Ross Island,275256,2013,Curfew,
+Ross Island,275256,2013,Disorderly Conduct,
+Ross Island,275256,2013,Drugs,
+Ross Island,275256,2013,DUII,
+Ross Island,275256,2013,Embezzlement,
+Ross Island,275256,2013,Forgery,
+Ross Island,275256,2013,Fraud,
+Ross Island,275256,2013,Gambling,
+Ross Island,275256,2013,Homicide,
+Ross Island,275256,2013,Kidnap,
+Ross Island,275256,2013,Larceny,
+Ross Island,275256,2013,Liquor Laws,
+Ross Island,275256,2013,Motor Vehicle Theft,
+Ross Island,275256,2013,Offenses Against Family,
+Ross Island,275256,2013,Prostitution,
+Ross Island,275256,2013,Rape,
+Ross Island,275256,2013,Robbery,
+Ross Island,275256,2013,Runaway,
+Ross Island,275256,2013,Sex Offenses,
+Ross Island,275256,2013,Stolen Property,
+Ross Island,275256,2013,Trespass,
+Ross Island,275256,2013,Vandalism,
+Ross Island,275256,2013,Weapons,
+Ross Island,275256,2014,Aggravated Assault,
+Ross Island,275256,2014,Arson,
+Ross Island,275256,2014,"Assault, Simple",
+Ross Island,275256,2014,Burglary,
+Ross Island,275256,2014,Curfew,
+Ross Island,275256,2014,Disorderly Conduct,
+Ross Island,275256,2014,Drugs,
+Ross Island,275256,2014,DUII,
+Ross Island,275256,2014,Embezzlement,
+Ross Island,275256,2014,Forgery,
+Ross Island,275256,2014,Fraud,
+Ross Island,275256,2014,Gambling,
+Ross Island,275256,2014,Homicide,
+Ross Island,275256,2014,Kidnap,
+Ross Island,275256,2014,Larceny,
+Ross Island,275256,2014,Liquor Laws,
+Ross Island,275256,2014,Motor Vehicle Theft,
+Ross Island,275256,2014,Offenses Against Family,
+Ross Island,275256,2014,Prostitution,
+Ross Island,275256,2014,Rape,
+Ross Island,275256,2014,Robbery,
+Ross Island,275256,2014,Runaway,
+Ross Island,275256,2014,Sex Offenses,
+Ross Island,275256,2014,Stolen Property,
+Ross Island,275256,2014,Trespass,
+Ross Island,275256,2014,Vandalism,
+Ross Island,275256,2014,Weapons,
+Saintjohns,275553,2004,Aggravated Assault,4
+Saintjohns,275553,2004,Arson,
+Saintjohns,275553,2004,"Assault, Simple",14
+Saintjohns,275553,2004,Burglary,13
+Saintjohns,275553,2004,Curfew,2
+Saintjohns,275553,2004,Disorderly Conduct,15
+Saintjohns,275553,2004,Drugs,5
+Saintjohns,275553,2004,DUII,7
+Saintjohns,275553,2004,Embezzlement,
+Saintjohns,275553,2004,Forgery,2
+Saintjohns,275553,2004,Fraud,9
+Saintjohns,275553,2004,Gambling,
+Saintjohns,275553,2004,Homicide,1
+Saintjohns,275553,2004,Kidnap,
+Saintjohns,275553,2004,Larceny,40
+Saintjohns,275553,2004,Liquor Laws,2
+Saintjohns,275553,2004,Motor Vehicle Theft,3
+Saintjohns,275553,2004,Offenses Against Family,
+Saintjohns,275553,2004,Prostitution,
+Saintjohns,275553,2004,Rape,
+Saintjohns,275553,2004,Robbery,4
+Saintjohns,275553,2004,Runaway,
+Saintjohns,275553,2004,Sex Offenses,1
+Saintjohns,275553,2004,Stolen Property,
+Saintjohns,275553,2004,Trespass,12
+Saintjohns,275553,2004,Vandalism,23
+Saintjohns,275553,2004,Weapons,3
+Saintjohns,275553,2005,Aggravated Assault,42
+Saintjohns,275553,2005,Arson,2
+Saintjohns,275553,2005,"Assault, Simple",42
+Saintjohns,275553,2005,Burglary,58
+Saintjohns,275553,2005,Curfew,3
+Saintjohns,275553,2005,Disorderly Conduct,36
+Saintjohns,275553,2005,Drugs,26
+Saintjohns,275553,2005,DUII,20
+Saintjohns,275553,2005,Embezzlement,3
+Saintjohns,275553,2005,Forgery,12
+Saintjohns,275553,2005,Fraud,39
+Saintjohns,275553,2005,Gambling,
+Saintjohns,275553,2005,Homicide,
+Saintjohns,275553,2005,Kidnap,1
+Saintjohns,275553,2005,Larceny,187
+Saintjohns,275553,2005,Liquor Laws,6
+Saintjohns,275553,2005,Motor Vehicle Theft,58
+Saintjohns,275553,2005,Offenses Against Family,
+Saintjohns,275553,2005,Prostitution,
+Saintjohns,275553,2005,Rape,2
+Saintjohns,275553,2005,Robbery,10
+Saintjohns,275553,2005,Runaway,
+Saintjohns,275553,2005,Sex Offenses,
+Saintjohns,275553,2005,Stolen Property,3
+Saintjohns,275553,2005,Trespass,29
+Saintjohns,275553,2005,Vandalism,94
+Saintjohns,275553,2005,Weapons,6
+Saintjohns,275553,2006,Aggravated Assault,39
+Saintjohns,275553,2006,Arson,3
+Saintjohns,275553,2006,"Assault, Simple",53
+Saintjohns,275553,2006,Burglary,77
+Saintjohns,275553,2006,Curfew,2
+Saintjohns,275553,2006,Disorderly Conduct,28
+Saintjohns,275553,2006,Drugs,24
+Saintjohns,275553,2006,DUII,17
+Saintjohns,275553,2006,Embezzlement,6
+Saintjohns,275553,2006,Forgery,7
+Saintjohns,275553,2006,Fraud,30
+Saintjohns,275553,2006,Gambling,
+Saintjohns,275553,2006,Homicide,
+Saintjohns,275553,2006,Kidnap,1
+Saintjohns,275553,2006,Larceny,191
+Saintjohns,275553,2006,Liquor Laws,2
+Saintjohns,275553,2006,Motor Vehicle Theft,55
+Saintjohns,275553,2006,Offenses Against Family,
+Saintjohns,275553,2006,Prostitution,
+Saintjohns,275553,2006,Rape,1
+Saintjohns,275553,2006,Robbery,12
+Saintjohns,275553,2006,Runaway,
+Saintjohns,275553,2006,Sex Offenses,2
+Saintjohns,275553,2006,Stolen Property,3
+Saintjohns,275553,2006,Trespass,47
+Saintjohns,275553,2006,Vandalism,115
+Saintjohns,275553,2006,Weapons,2
+Saintjohns,275553,2007,Aggravated Assault,26
+Saintjohns,275553,2007,Arson,1
+Saintjohns,275553,2007,"Assault, Simple",25
+Saintjohns,275553,2007,Burglary,51
+Saintjohns,275553,2007,Curfew,9
+Saintjohns,275553,2007,Disorderly Conduct,29
+Saintjohns,275553,2007,Drugs,21
+Saintjohns,275553,2007,DUII,18
+Saintjohns,275553,2007,Embezzlement,3
+Saintjohns,275553,2007,Forgery,4
+Saintjohns,275553,2007,Fraud,17
+Saintjohns,275553,2007,Gambling,
+Saintjohns,275553,2007,Homicide,1
+Saintjohns,275553,2007,Kidnap,
+Saintjohns,275553,2007,Larceny,178
+Saintjohns,275553,2007,Liquor Laws,13
+Saintjohns,275553,2007,Motor Vehicle Theft,58
+Saintjohns,275553,2007,Offenses Against Family,
+Saintjohns,275553,2007,Prostitution,
+Saintjohns,275553,2007,Rape,
+Saintjohns,275553,2007,Robbery,19
+Saintjohns,275553,2007,Runaway,1
+Saintjohns,275553,2007,Sex Offenses,2
+Saintjohns,275553,2007,Stolen Property,3
+Saintjohns,275553,2007,Trespass,38
+Saintjohns,275553,2007,Vandalism,90
+Saintjohns,275553,2007,Weapons,3
+Saintjohns,275553,2008,Aggravated Assault,21
+Saintjohns,275553,2008,Arson,
+Saintjohns,275553,2008,"Assault, Simple",30
+Saintjohns,275553,2008,Burglary,48
+Saintjohns,275553,2008,Curfew,
+Saintjohns,275553,2008,Disorderly Conduct,27
+Saintjohns,275553,2008,Drugs,14
+Saintjohns,275553,2008,DUII,19
+Saintjohns,275553,2008,Embezzlement,4
+Saintjohns,275553,2008,Forgery,6
+Saintjohns,275553,2008,Fraud,9
+Saintjohns,275553,2008,Gambling,
+Saintjohns,275553,2008,Homicide,
+Saintjohns,275553,2008,Kidnap,1
+Saintjohns,275553,2008,Larceny,159
+Saintjohns,275553,2008,Liquor Laws,13
+Saintjohns,275553,2008,Motor Vehicle Theft,44
+Saintjohns,275553,2008,Offenses Against Family,
+Saintjohns,275553,2008,Prostitution,
+Saintjohns,275553,2008,Rape,
+Saintjohns,275553,2008,Robbery,15
+Saintjohns,275553,2008,Runaway,
+Saintjohns,275553,2008,Sex Offenses,1
+Saintjohns,275553,2008,Stolen Property,1
+Saintjohns,275553,2008,Trespass,31
+Saintjohns,275553,2008,Vandalism,85
+Saintjohns,275553,2008,Weapons,4
+Saintjohns,275553,2009,Aggravated Assault,19
+Saintjohns,275553,2009,Arson,5
+Saintjohns,275553,2009,"Assault, Simple",30
+Saintjohns,275553,2009,Burglary,55
+Saintjohns,275553,2009,Curfew,1
+Saintjohns,275553,2009,Disorderly Conduct,21
+Saintjohns,275553,2009,Drugs,24
+Saintjohns,275553,2009,DUII,20
+Saintjohns,275553,2009,Embezzlement,2
+Saintjohns,275553,2009,Forgery,4
+Saintjohns,275553,2009,Fraud,12
+Saintjohns,275553,2009,Gambling,
+Saintjohns,275553,2009,Homicide,1
+Saintjohns,275553,2009,Kidnap,
+Saintjohns,275553,2009,Larceny,127
+Saintjohns,275553,2009,Liquor Laws,5
+Saintjohns,275553,2009,Motor Vehicle Theft,77
+Saintjohns,275553,2009,Offenses Against Family,
+Saintjohns,275553,2009,Prostitution,
+Saintjohns,275553,2009,Rape,1
+Saintjohns,275553,2009,Robbery,13
+Saintjohns,275553,2009,Runaway,
+Saintjohns,275553,2009,Sex Offenses,1
+Saintjohns,275553,2009,Stolen Property,1
+Saintjohns,275553,2009,Trespass,18
+Saintjohns,275553,2009,Vandalism,77
+Saintjohns,275553,2009,Weapons,5
+Saintjohns,275553,2010,Aggravated Assault,11
+Saintjohns,275553,2010,Arson,
+Saintjohns,275553,2010,"Assault, Simple",22
+Saintjohns,275553,2010,Burglary,42
+Saintjohns,275553,2010,Curfew,
+Saintjohns,275553,2010,Disorderly Conduct,27
+Saintjohns,275553,2010,Drugs,13
+Saintjohns,275553,2010,DUII,16
+Saintjohns,275553,2010,Embezzlement,2
+Saintjohns,275553,2010,Forgery,4
+Saintjohns,275553,2010,Fraud,12
+Saintjohns,275553,2010,Gambling,
+Saintjohns,275553,2010,Homicide,
+Saintjohns,275553,2010,Kidnap,
+Saintjohns,275553,2010,Larceny,126
+Saintjohns,275553,2010,Liquor Laws,5
+Saintjohns,275553,2010,Motor Vehicle Theft,37
+Saintjohns,275553,2010,Offenses Against Family,
+Saintjohns,275553,2010,Prostitution,
+Saintjohns,275553,2010,Rape,
+Saintjohns,275553,2010,Robbery,8
+Saintjohns,275553,2010,Runaway,
+Saintjohns,275553,2010,Sex Offenses,2
+Saintjohns,275553,2010,Stolen Property,1
+Saintjohns,275553,2010,Trespass,28
+Saintjohns,275553,2010,Vandalism,58
+Saintjohns,275553,2010,Weapons,3
+Saintjohns,275553,2011,Aggravated Assault,19
+Saintjohns,275553,2011,Arson,1
+Saintjohns,275553,2011,"Assault, Simple",23
+Saintjohns,275553,2011,Burglary,50
+Saintjohns,275553,2011,Curfew,
+Saintjohns,275553,2011,Disorderly Conduct,20
+Saintjohns,275553,2011,Drugs,12
+Saintjohns,275553,2011,DUII,12
+Saintjohns,275553,2011,Embezzlement,1
+Saintjohns,275553,2011,Forgery,3
+Saintjohns,275553,2011,Fraud,11
+Saintjohns,275553,2011,Gambling,
+Saintjohns,275553,2011,Homicide,
+Saintjohns,275553,2011,Kidnap,
+Saintjohns,275553,2011,Larceny,144
+Saintjohns,275553,2011,Liquor Laws,2
+Saintjohns,275553,2011,Motor Vehicle Theft,46
+Saintjohns,275553,2011,Offenses Against Family,
+Saintjohns,275553,2011,Prostitution,
+Saintjohns,275553,2011,Rape,
+Saintjohns,275553,2011,Robbery,8
+Saintjohns,275553,2011,Runaway,
+Saintjohns,275553,2011,Sex Offenses,3
+Saintjohns,275553,2011,Stolen Property,1
+Saintjohns,275553,2011,Trespass,23
+Saintjohns,275553,2011,Vandalism,49
+Saintjohns,275553,2011,Weapons,2
+Saintjohns,275553,2012,Aggravated Assault,20
+Saintjohns,275553,2012,Arson,
+Saintjohns,275553,2012,"Assault, Simple",20
+Saintjohns,275553,2012,Burglary,22
+Saintjohns,275553,2012,Curfew,
+Saintjohns,275553,2012,Disorderly Conduct,17
+Saintjohns,275553,2012,Drugs,11
+Saintjohns,275553,2012,DUII,12
+Saintjohns,275553,2012,Embezzlement,3
+Saintjohns,275553,2012,Forgery,7
+Saintjohns,275553,2012,Fraud,7
+Saintjohns,275553,2012,Gambling,
+Saintjohns,275553,2012,Homicide,1
+Saintjohns,275553,2012,Kidnap,
+Saintjohns,275553,2012,Larceny,138
+Saintjohns,275553,2012,Liquor Laws,3
+Saintjohns,275553,2012,Motor Vehicle Theft,45
+Saintjohns,275553,2012,Offenses Against Family,
+Saintjohns,275553,2012,Prostitution,1
+Saintjohns,275553,2012,Rape,1
+Saintjohns,275553,2012,Robbery,7
+Saintjohns,275553,2012,Runaway,
+Saintjohns,275553,2012,Sex Offenses,1
+Saintjohns,275553,2012,Stolen Property,
+Saintjohns,275553,2012,Trespass,20
+Saintjohns,275553,2012,Vandalism,55
+Saintjohns,275553,2012,Weapons,3
+Saintjohns,275553,2013,Aggravated Assault,20
+Saintjohns,275553,2013,Arson,2
+Saintjohns,275553,2013,"Assault, Simple",25
+Saintjohns,275553,2013,Burglary,23
+Saintjohns,275553,2013,Curfew,
+Saintjohns,275553,2013,Disorderly Conduct,35
+Saintjohns,275553,2013,Drugs,16
+Saintjohns,275553,2013,DUII,10
+Saintjohns,275553,2013,Embezzlement,
+Saintjohns,275553,2013,Forgery,11
+Saintjohns,275553,2013,Fraud,5
+Saintjohns,275553,2013,Gambling,
+Saintjohns,275553,2013,Homicide,1
+Saintjohns,275553,2013,Kidnap,
+Saintjohns,275553,2013,Larceny,129
+Saintjohns,275553,2013,Liquor Laws,1
+Saintjohns,275553,2013,Motor Vehicle Theft,40
+Saintjohns,275553,2013,Offenses Against Family,1
+Saintjohns,275553,2013,Prostitution,
+Saintjohns,275553,2013,Rape,
+Saintjohns,275553,2013,Robbery,13
+Saintjohns,275553,2013,Runaway,
+Saintjohns,275553,2013,Sex Offenses,
+Saintjohns,275553,2013,Stolen Property,2
+Saintjohns,275553,2013,Trespass,24
+Saintjohns,275553,2013,Vandalism,48
+Saintjohns,275553,2013,Weapons,5
+Saintjohns,275553,2014,Aggravated Assault,14
+Saintjohns,275553,2014,Arson,1
+Saintjohns,275553,2014,"Assault, Simple",23
+Saintjohns,275553,2014,Burglary,32
+Saintjohns,275553,2014,Curfew,
+Saintjohns,275553,2014,Disorderly Conduct,24
+Saintjohns,275553,2014,Drugs,11
+Saintjohns,275553,2014,DUII,13
+Saintjohns,275553,2014,Embezzlement,2
+Saintjohns,275553,2014,Forgery,2
+Saintjohns,275553,2014,Fraud,10
+Saintjohns,275553,2014,Gambling,
+Saintjohns,275553,2014,Homicide,
+Saintjohns,275553,2014,Kidnap,1
+Saintjohns,275553,2014,Larceny,90
+Saintjohns,275553,2014,Liquor Laws,5
+Saintjohns,275553,2014,Motor Vehicle Theft,28
+Saintjohns,275553,2014,Offenses Against Family,
+Saintjohns,275553,2014,Prostitution,
+Saintjohns,275553,2014,Rape,1
+Saintjohns,275553,2014,Robbery,8
+Saintjohns,275553,2014,Runaway,
+Saintjohns,275553,2014,Sex Offenses,
+Saintjohns,275553,2014,Stolen Property,
+Saintjohns,275553,2014,Trespass,18
+Saintjohns,275553,2014,Vandalism,40
+Saintjohns,275553,2014,Weapons,3
+Sellwood-Moreland,275327,2004,Aggravated Assault,5
+Sellwood-Moreland,275327,2004,Arson,1
+Sellwood-Moreland,275327,2004,"Assault, Simple",5
+Sellwood-Moreland,275327,2004,Burglary,30
+Sellwood-Moreland,275327,2004,Curfew,
+Sellwood-Moreland,275327,2004,Disorderly Conduct,6
+Sellwood-Moreland,275327,2004,Drugs,4
+Sellwood-Moreland,275327,2004,DUII,7
+Sellwood-Moreland,275327,2004,Embezzlement,1
+Sellwood-Moreland,275327,2004,Forgery,9
+Sellwood-Moreland,275327,2004,Fraud,9
+Sellwood-Moreland,275327,2004,Gambling,
+Sellwood-Moreland,275327,2004,Homicide,
+Sellwood-Moreland,275327,2004,Kidnap,1
+Sellwood-Moreland,275327,2004,Larceny,127
+Sellwood-Moreland,275327,2004,Liquor Laws,5
+Sellwood-Moreland,275327,2004,Motor Vehicle Theft,28
+Sellwood-Moreland,275327,2004,Offenses Against Family,
+Sellwood-Moreland,275327,2004,Prostitution,
+Sellwood-Moreland,275327,2004,Rape,
+Sellwood-Moreland,275327,2004,Robbery,
+Sellwood-Moreland,275327,2004,Runaway,
+Sellwood-Moreland,275327,2004,Sex Offenses,3
+Sellwood-Moreland,275327,2004,Stolen Property,
+Sellwood-Moreland,275327,2004,Trespass,8
+Sellwood-Moreland,275327,2004,Vandalism,18
+Sellwood-Moreland,275327,2004,Weapons,
+Sellwood-Moreland,275327,2005,Aggravated Assault,12
+Sellwood-Moreland,275327,2005,Arson,1
+Sellwood-Moreland,275327,2005,"Assault, Simple",17
+Sellwood-Moreland,275327,2005,Burglary,82
+Sellwood-Moreland,275327,2005,Curfew,1
+Sellwood-Moreland,275327,2005,Disorderly Conduct,25
+Sellwood-Moreland,275327,2005,Drugs,28
+Sellwood-Moreland,275327,2005,DUII,16
+Sellwood-Moreland,275327,2005,Embezzlement,2
+Sellwood-Moreland,275327,2005,Forgery,9
+Sellwood-Moreland,275327,2005,Fraud,36
+Sellwood-Moreland,275327,2005,Gambling,
+Sellwood-Moreland,275327,2005,Homicide,
+Sellwood-Moreland,275327,2005,Kidnap,
+Sellwood-Moreland,275327,2005,Larceny,361
+Sellwood-Moreland,275327,2005,Liquor Laws,13
+Sellwood-Moreland,275327,2005,Motor Vehicle Theft,64
+Sellwood-Moreland,275327,2005,Offenses Against Family,
+Sellwood-Moreland,275327,2005,Prostitution,
+Sellwood-Moreland,275327,2005,Rape,1
+Sellwood-Moreland,275327,2005,Robbery,10
+Sellwood-Moreland,275327,2005,Runaway,1
+Sellwood-Moreland,275327,2005,Sex Offenses,1
+Sellwood-Moreland,275327,2005,Stolen Property,
+Sellwood-Moreland,275327,2005,Trespass,21
+Sellwood-Moreland,275327,2005,Vandalism,78
+Sellwood-Moreland,275327,2005,Weapons,2
+Sellwood-Moreland,275327,2006,Aggravated Assault,10
+Sellwood-Moreland,275327,2006,Arson,
+Sellwood-Moreland,275327,2006,"Assault, Simple",15
+Sellwood-Moreland,275327,2006,Burglary,103
+Sellwood-Moreland,275327,2006,Curfew,1
+Sellwood-Moreland,275327,2006,Disorderly Conduct,22
+Sellwood-Moreland,275327,2006,Drugs,19
+Sellwood-Moreland,275327,2006,DUII,31
+Sellwood-Moreland,275327,2006,Embezzlement,1
+Sellwood-Moreland,275327,2006,Forgery,8
+Sellwood-Moreland,275327,2006,Fraud,40
+Sellwood-Moreland,275327,2006,Gambling,
+Sellwood-Moreland,275327,2006,Homicide,
+Sellwood-Moreland,275327,2006,Kidnap,
+Sellwood-Moreland,275327,2006,Larceny,295
+Sellwood-Moreland,275327,2006,Liquor Laws,31
+Sellwood-Moreland,275327,2006,Motor Vehicle Theft,94
+Sellwood-Moreland,275327,2006,Offenses Against Family,
+Sellwood-Moreland,275327,2006,Prostitution,
+Sellwood-Moreland,275327,2006,Rape,
+Sellwood-Moreland,275327,2006,Robbery,7
+Sellwood-Moreland,275327,2006,Runaway,
+Sellwood-Moreland,275327,2006,Sex Offenses,5
+Sellwood-Moreland,275327,2006,Stolen Property,2
+Sellwood-Moreland,275327,2006,Trespass,27
+Sellwood-Moreland,275327,2006,Vandalism,79
+Sellwood-Moreland,275327,2006,Weapons,2
+Sellwood-Moreland,275327,2007,Aggravated Assault,16
+Sellwood-Moreland,275327,2007,Arson,1
+Sellwood-Moreland,275327,2007,"Assault, Simple",20
+Sellwood-Moreland,275327,2007,Burglary,72
+Sellwood-Moreland,275327,2007,Curfew,
+Sellwood-Moreland,275327,2007,Disorderly Conduct,17
+Sellwood-Moreland,275327,2007,Drugs,17
+Sellwood-Moreland,275327,2007,DUII,23
+Sellwood-Moreland,275327,2007,Embezzlement,2
+Sellwood-Moreland,275327,2007,Forgery,11
+Sellwood-Moreland,275327,2007,Fraud,19
+Sellwood-Moreland,275327,2007,Gambling,
+Sellwood-Moreland,275327,2007,Homicide,
+Sellwood-Moreland,275327,2007,Kidnap,
+Sellwood-Moreland,275327,2007,Larceny,250
+Sellwood-Moreland,275327,2007,Liquor Laws,16
+Sellwood-Moreland,275327,2007,Motor Vehicle Theft,69
+Sellwood-Moreland,275327,2007,Offenses Against Family,1
+Sellwood-Moreland,275327,2007,Prostitution,
+Sellwood-Moreland,275327,2007,Rape,1
+Sellwood-Moreland,275327,2007,Robbery,10
+Sellwood-Moreland,275327,2007,Runaway,
+Sellwood-Moreland,275327,2007,Sex Offenses,1
+Sellwood-Moreland,275327,2007,Stolen Property,1
+Sellwood-Moreland,275327,2007,Trespass,18
+Sellwood-Moreland,275327,2007,Vandalism,74
+Sellwood-Moreland,275327,2007,Weapons,2
+Sellwood-Moreland,275327,2008,Aggravated Assault,12
+Sellwood-Moreland,275327,2008,Arson,1
+Sellwood-Moreland,275327,2008,"Assault, Simple",26
+Sellwood-Moreland,275327,2008,Burglary,61
+Sellwood-Moreland,275327,2008,Curfew,
+Sellwood-Moreland,275327,2008,Disorderly Conduct,16
+Sellwood-Moreland,275327,2008,Drugs,9
+Sellwood-Moreland,275327,2008,DUII,19
+Sellwood-Moreland,275327,2008,Embezzlement,1
+Sellwood-Moreland,275327,2008,Forgery,6
+Sellwood-Moreland,275327,2008,Fraud,26
+Sellwood-Moreland,275327,2008,Gambling,
+Sellwood-Moreland,275327,2008,Homicide,
+Sellwood-Moreland,275327,2008,Kidnap,
+Sellwood-Moreland,275327,2008,Larceny,278
+Sellwood-Moreland,275327,2008,Liquor Laws,6
+Sellwood-Moreland,275327,2008,Motor Vehicle Theft,62
+Sellwood-Moreland,275327,2008,Offenses Against Family,
+Sellwood-Moreland,275327,2008,Prostitution,
+Sellwood-Moreland,275327,2008,Rape,
+Sellwood-Moreland,275327,2008,Robbery,7
+Sellwood-Moreland,275327,2008,Runaway,
+Sellwood-Moreland,275327,2008,Sex Offenses,4
+Sellwood-Moreland,275327,2008,Stolen Property,2
+Sellwood-Moreland,275327,2008,Trespass,11
+Sellwood-Moreland,275327,2008,Vandalism,100
+Sellwood-Moreland,275327,2008,Weapons,3
+Sellwood-Moreland,275327,2009,Aggravated Assault,6
+Sellwood-Moreland,275327,2009,Arson,
+Sellwood-Moreland,275327,2009,"Assault, Simple",13
+Sellwood-Moreland,275327,2009,Burglary,55
+Sellwood-Moreland,275327,2009,Curfew,
+Sellwood-Moreland,275327,2009,Disorderly Conduct,18
+Sellwood-Moreland,275327,2009,Drugs,3
+Sellwood-Moreland,275327,2009,DUII,18
+Sellwood-Moreland,275327,2009,Embezzlement,1
+Sellwood-Moreland,275327,2009,Forgery,12
+Sellwood-Moreland,275327,2009,Fraud,12
+Sellwood-Moreland,275327,2009,Gambling,
+Sellwood-Moreland,275327,2009,Homicide,
+Sellwood-Moreland,275327,2009,Kidnap,
+Sellwood-Moreland,275327,2009,Larceny,205
+Sellwood-Moreland,275327,2009,Liquor Laws,6
+Sellwood-Moreland,275327,2009,Motor Vehicle Theft,36
+Sellwood-Moreland,275327,2009,Offenses Against Family,
+Sellwood-Moreland,275327,2009,Prostitution,
+Sellwood-Moreland,275327,2009,Rape,
+Sellwood-Moreland,275327,2009,Robbery,8
+Sellwood-Moreland,275327,2009,Runaway,
+Sellwood-Moreland,275327,2009,Sex Offenses,1
+Sellwood-Moreland,275327,2009,Stolen Property,1
+Sellwood-Moreland,275327,2009,Trespass,13
+Sellwood-Moreland,275327,2009,Vandalism,83
+Sellwood-Moreland,275327,2009,Weapons,
+Sellwood-Moreland,275327,2010,Aggravated Assault,12
+Sellwood-Moreland,275327,2010,Arson,1
+Sellwood-Moreland,275327,2010,"Assault, Simple",10
+Sellwood-Moreland,275327,2010,Burglary,48
+Sellwood-Moreland,275327,2010,Curfew,
+Sellwood-Moreland,275327,2010,Disorderly Conduct,14
+Sellwood-Moreland,275327,2010,Drugs,3
+Sellwood-Moreland,275327,2010,DUII,19
+Sellwood-Moreland,275327,2010,Embezzlement,4
+Sellwood-Moreland,275327,2010,Forgery,4
+Sellwood-Moreland,275327,2010,Fraud,12
+Sellwood-Moreland,275327,2010,Gambling,
+Sellwood-Moreland,275327,2010,Homicide,
+Sellwood-Moreland,275327,2010,Kidnap,
+Sellwood-Moreland,275327,2010,Larceny,250
+Sellwood-Moreland,275327,2010,Liquor Laws,13
+Sellwood-Moreland,275327,2010,Motor Vehicle Theft,49
+Sellwood-Moreland,275327,2010,Offenses Against Family,
+Sellwood-Moreland,275327,2010,Prostitution,
+Sellwood-Moreland,275327,2010,Rape,
+Sellwood-Moreland,275327,2010,Robbery,4
+Sellwood-Moreland,275327,2010,Runaway,
+Sellwood-Moreland,275327,2010,Sex Offenses,1
+Sellwood-Moreland,275327,2010,Stolen Property,
+Sellwood-Moreland,275327,2010,Trespass,8
+Sellwood-Moreland,275327,2010,Vandalism,46
+Sellwood-Moreland,275327,2010,Weapons,1
+Sellwood-Moreland,275327,2011,Aggravated Assault,4
+Sellwood-Moreland,275327,2011,Arson,
+Sellwood-Moreland,275327,2011,"Assault, Simple",18
+Sellwood-Moreland,275327,2011,Burglary,66
+Sellwood-Moreland,275327,2011,Curfew,
+Sellwood-Moreland,275327,2011,Disorderly Conduct,22
+Sellwood-Moreland,275327,2011,Drugs,4
+Sellwood-Moreland,275327,2011,DUII,17
+Sellwood-Moreland,275327,2011,Embezzlement,
+Sellwood-Moreland,275327,2011,Forgery,5
+Sellwood-Moreland,275327,2011,Fraud,13
+Sellwood-Moreland,275327,2011,Gambling,
+Sellwood-Moreland,275327,2011,Homicide,
+Sellwood-Moreland,275327,2011,Kidnap,
+Sellwood-Moreland,275327,2011,Larceny,424
+Sellwood-Moreland,275327,2011,Liquor Laws,14
+Sellwood-Moreland,275327,2011,Motor Vehicle Theft,61
+Sellwood-Moreland,275327,2011,Offenses Against Family,
+Sellwood-Moreland,275327,2011,Prostitution,
+Sellwood-Moreland,275327,2011,Rape,
+Sellwood-Moreland,275327,2011,Robbery,8
+Sellwood-Moreland,275327,2011,Runaway,
+Sellwood-Moreland,275327,2011,Sex Offenses,1
+Sellwood-Moreland,275327,2011,Stolen Property,
+Sellwood-Moreland,275327,2011,Trespass,9
+Sellwood-Moreland,275327,2011,Vandalism,65
+Sellwood-Moreland,275327,2011,Weapons,1
+Sellwood-Moreland,275327,2012,Aggravated Assault,6
+Sellwood-Moreland,275327,2012,Arson,1
+Sellwood-Moreland,275327,2012,"Assault, Simple",12
+Sellwood-Moreland,275327,2012,Burglary,102
+Sellwood-Moreland,275327,2012,Curfew,
+Sellwood-Moreland,275327,2012,Disorderly Conduct,17
+Sellwood-Moreland,275327,2012,Drugs,8
+Sellwood-Moreland,275327,2012,DUII,18
+Sellwood-Moreland,275327,2012,Embezzlement,
+Sellwood-Moreland,275327,2012,Forgery,10
+Sellwood-Moreland,275327,2012,Fraud,9
+Sellwood-Moreland,275327,2012,Gambling,
+Sellwood-Moreland,275327,2012,Homicide,
+Sellwood-Moreland,275327,2012,Kidnap,
+Sellwood-Moreland,275327,2012,Larceny,373
+Sellwood-Moreland,275327,2012,Liquor Laws,6
+Sellwood-Moreland,275327,2012,Motor Vehicle Theft,92
+Sellwood-Moreland,275327,2012,Offenses Against Family,
+Sellwood-Moreland,275327,2012,Prostitution,
+Sellwood-Moreland,275327,2012,Rape,1
+Sellwood-Moreland,275327,2012,Robbery,4
+Sellwood-Moreland,275327,2012,Runaway,
+Sellwood-Moreland,275327,2012,Sex Offenses,
+Sellwood-Moreland,275327,2012,Stolen Property,
+Sellwood-Moreland,275327,2012,Trespass,13
+Sellwood-Moreland,275327,2012,Vandalism,62
+Sellwood-Moreland,275327,2012,Weapons,2
+Sellwood-Moreland,275327,2013,Aggravated Assault,4
+Sellwood-Moreland,275327,2013,Arson,
+Sellwood-Moreland,275327,2013,"Assault, Simple",12
+Sellwood-Moreland,275327,2013,Burglary,59
+Sellwood-Moreland,275327,2013,Curfew,
+Sellwood-Moreland,275327,2013,Disorderly Conduct,20
+Sellwood-Moreland,275327,2013,Drugs,4
+Sellwood-Moreland,275327,2013,DUII,20
+Sellwood-Moreland,275327,2013,Embezzlement,2
+Sellwood-Moreland,275327,2013,Forgery,9
+Sellwood-Moreland,275327,2013,Fraud,17
+Sellwood-Moreland,275327,2013,Gambling,
+Sellwood-Moreland,275327,2013,Homicide,
+Sellwood-Moreland,275327,2013,Kidnap,
+Sellwood-Moreland,275327,2013,Larceny,354
+Sellwood-Moreland,275327,2013,Liquor Laws,3
+Sellwood-Moreland,275327,2013,Motor Vehicle Theft,48
+Sellwood-Moreland,275327,2013,Offenses Against Family,
+Sellwood-Moreland,275327,2013,Prostitution,
+Sellwood-Moreland,275327,2013,Rape,
+Sellwood-Moreland,275327,2013,Robbery,2
+Sellwood-Moreland,275327,2013,Runaway,
+Sellwood-Moreland,275327,2013,Sex Offenses,1
+Sellwood-Moreland,275327,2013,Stolen Property,
+Sellwood-Moreland,275327,2013,Trespass,7
+Sellwood-Moreland,275327,2013,Vandalism,74
+Sellwood-Moreland,275327,2013,Weapons,1
+Sellwood-Moreland,275327,2014,Aggravated Assault,2
+Sellwood-Moreland,275327,2014,Arson,1
+Sellwood-Moreland,275327,2014,"Assault, Simple",17
+Sellwood-Moreland,275327,2014,Burglary,54
+Sellwood-Moreland,275327,2014,Curfew,
+Sellwood-Moreland,275327,2014,Disorderly Conduct,15
+Sellwood-Moreland,275327,2014,Drugs,7
+Sellwood-Moreland,275327,2014,DUII,18
+Sellwood-Moreland,275327,2014,Embezzlement,
+Sellwood-Moreland,275327,2014,Forgery,5
+Sellwood-Moreland,275327,2014,Fraud,19
+Sellwood-Moreland,275327,2014,Gambling,
+Sellwood-Moreland,275327,2014,Homicide,
+Sellwood-Moreland,275327,2014,Kidnap,
+Sellwood-Moreland,275327,2014,Larceny,314
+Sellwood-Moreland,275327,2014,Liquor Laws,1
+Sellwood-Moreland,275327,2014,Motor Vehicle Theft,60
+Sellwood-Moreland,275327,2014,Offenses Against Family,
+Sellwood-Moreland,275327,2014,Prostitution,
+Sellwood-Moreland,275327,2014,Rape,1
+Sellwood-Moreland,275327,2014,Robbery,2
+Sellwood-Moreland,275327,2014,Runaway,
+Sellwood-Moreland,275327,2014,Sex Offenses,
+Sellwood-Moreland,275327,2014,Stolen Property,
+Sellwood-Moreland,275327,2014,Trespass,12
+Sellwood-Moreland,275327,2014,Vandalism,58
+Sellwood-Moreland,275327,2014,Weapons,1
+Sexton Mountain,271131,2004,Aggravated Assault,
+Sexton Mountain,271131,2004,Arson,
+Sexton Mountain,271131,2004,"Assault, Simple",
+Sexton Mountain,271131,2004,Burglary,
+Sexton Mountain,271131,2004,Curfew,
+Sexton Mountain,271131,2004,Disorderly Conduct,
+Sexton Mountain,271131,2004,Drugs,
+Sexton Mountain,271131,2004,DUII,
+Sexton Mountain,271131,2004,Embezzlement,
+Sexton Mountain,271131,2004,Forgery,
+Sexton Mountain,271131,2004,Fraud,
+Sexton Mountain,271131,2004,Gambling,
+Sexton Mountain,271131,2004,Homicide,
+Sexton Mountain,271131,2004,Kidnap,
+Sexton Mountain,271131,2004,Larceny,
+Sexton Mountain,271131,2004,Liquor Laws,
+Sexton Mountain,271131,2004,Motor Vehicle Theft,
+Sexton Mountain,271131,2004,Offenses Against Family,
+Sexton Mountain,271131,2004,Prostitution,
+Sexton Mountain,271131,2004,Rape,
+Sexton Mountain,271131,2004,Robbery,
+Sexton Mountain,271131,2004,Runaway,
+Sexton Mountain,271131,2004,Sex Offenses,
+Sexton Mountain,271131,2004,Stolen Property,
+Sexton Mountain,271131,2004,Trespass,
+Sexton Mountain,271131,2004,Vandalism,
+Sexton Mountain,271131,2004,Weapons,
+Sexton Mountain,271131,2005,Aggravated Assault,
+Sexton Mountain,271131,2005,Arson,
+Sexton Mountain,271131,2005,"Assault, Simple",
+Sexton Mountain,271131,2005,Burglary,
+Sexton Mountain,271131,2005,Curfew,
+Sexton Mountain,271131,2005,Disorderly Conduct,
+Sexton Mountain,271131,2005,Drugs,
+Sexton Mountain,271131,2005,DUII,
+Sexton Mountain,271131,2005,Embezzlement,
+Sexton Mountain,271131,2005,Forgery,
+Sexton Mountain,271131,2005,Fraud,
+Sexton Mountain,271131,2005,Gambling,
+Sexton Mountain,271131,2005,Homicide,
+Sexton Mountain,271131,2005,Kidnap,
+Sexton Mountain,271131,2005,Larceny,
+Sexton Mountain,271131,2005,Liquor Laws,
+Sexton Mountain,271131,2005,Motor Vehicle Theft,
+Sexton Mountain,271131,2005,Offenses Against Family,
+Sexton Mountain,271131,2005,Prostitution,
+Sexton Mountain,271131,2005,Rape,
+Sexton Mountain,271131,2005,Robbery,
+Sexton Mountain,271131,2005,Runaway,
+Sexton Mountain,271131,2005,Sex Offenses,
+Sexton Mountain,271131,2005,Stolen Property,
+Sexton Mountain,271131,2005,Trespass,
+Sexton Mountain,271131,2005,Vandalism,
+Sexton Mountain,271131,2005,Weapons,
+Sexton Mountain,271131,2006,Aggravated Assault,
+Sexton Mountain,271131,2006,Arson,
+Sexton Mountain,271131,2006,"Assault, Simple",
+Sexton Mountain,271131,2006,Burglary,
+Sexton Mountain,271131,2006,Curfew,
+Sexton Mountain,271131,2006,Disorderly Conduct,
+Sexton Mountain,271131,2006,Drugs,
+Sexton Mountain,271131,2006,DUII,
+Sexton Mountain,271131,2006,Embezzlement,
+Sexton Mountain,271131,2006,Forgery,
+Sexton Mountain,271131,2006,Fraud,
+Sexton Mountain,271131,2006,Gambling,
+Sexton Mountain,271131,2006,Homicide,
+Sexton Mountain,271131,2006,Kidnap,
+Sexton Mountain,271131,2006,Larceny,
+Sexton Mountain,271131,2006,Liquor Laws,
+Sexton Mountain,271131,2006,Motor Vehicle Theft,
+Sexton Mountain,271131,2006,Offenses Against Family,
+Sexton Mountain,271131,2006,Prostitution,
+Sexton Mountain,271131,2006,Rape,
+Sexton Mountain,271131,2006,Robbery,
+Sexton Mountain,271131,2006,Runaway,
+Sexton Mountain,271131,2006,Sex Offenses,
+Sexton Mountain,271131,2006,Stolen Property,
+Sexton Mountain,271131,2006,Trespass,
+Sexton Mountain,271131,2006,Vandalism,
+Sexton Mountain,271131,2006,Weapons,
+Sexton Mountain,271131,2007,Aggravated Assault,
+Sexton Mountain,271131,2007,Arson,
+Sexton Mountain,271131,2007,"Assault, Simple",
+Sexton Mountain,271131,2007,Burglary,
+Sexton Mountain,271131,2007,Curfew,
+Sexton Mountain,271131,2007,Disorderly Conduct,
+Sexton Mountain,271131,2007,Drugs,
+Sexton Mountain,271131,2007,DUII,
+Sexton Mountain,271131,2007,Embezzlement,
+Sexton Mountain,271131,2007,Forgery,
+Sexton Mountain,271131,2007,Fraud,
+Sexton Mountain,271131,2007,Gambling,
+Sexton Mountain,271131,2007,Homicide,
+Sexton Mountain,271131,2007,Kidnap,
+Sexton Mountain,271131,2007,Larceny,
+Sexton Mountain,271131,2007,Liquor Laws,
+Sexton Mountain,271131,2007,Motor Vehicle Theft,
+Sexton Mountain,271131,2007,Offenses Against Family,
+Sexton Mountain,271131,2007,Prostitution,
+Sexton Mountain,271131,2007,Rape,
+Sexton Mountain,271131,2007,Robbery,
+Sexton Mountain,271131,2007,Runaway,
+Sexton Mountain,271131,2007,Sex Offenses,
+Sexton Mountain,271131,2007,Stolen Property,
+Sexton Mountain,271131,2007,Trespass,
+Sexton Mountain,271131,2007,Vandalism,
+Sexton Mountain,271131,2007,Weapons,
+Sexton Mountain,271131,2008,Aggravated Assault,
+Sexton Mountain,271131,2008,Arson,
+Sexton Mountain,271131,2008,"Assault, Simple",
+Sexton Mountain,271131,2008,Burglary,
+Sexton Mountain,271131,2008,Curfew,
+Sexton Mountain,271131,2008,Disorderly Conduct,
+Sexton Mountain,271131,2008,Drugs,
+Sexton Mountain,271131,2008,DUII,
+Sexton Mountain,271131,2008,Embezzlement,
+Sexton Mountain,271131,2008,Forgery,
+Sexton Mountain,271131,2008,Fraud,
+Sexton Mountain,271131,2008,Gambling,
+Sexton Mountain,271131,2008,Homicide,
+Sexton Mountain,271131,2008,Kidnap,
+Sexton Mountain,271131,2008,Larceny,
+Sexton Mountain,271131,2008,Liquor Laws,
+Sexton Mountain,271131,2008,Motor Vehicle Theft,
+Sexton Mountain,271131,2008,Offenses Against Family,
+Sexton Mountain,271131,2008,Prostitution,
+Sexton Mountain,271131,2008,Rape,
+Sexton Mountain,271131,2008,Robbery,
+Sexton Mountain,271131,2008,Runaway,
+Sexton Mountain,271131,2008,Sex Offenses,
+Sexton Mountain,271131,2008,Stolen Property,
+Sexton Mountain,271131,2008,Trespass,
+Sexton Mountain,271131,2008,Vandalism,
+Sexton Mountain,271131,2008,Weapons,
+Sexton Mountain,271131,2009,Aggravated Assault,
+Sexton Mountain,271131,2009,Arson,
+Sexton Mountain,271131,2009,"Assault, Simple",
+Sexton Mountain,271131,2009,Burglary,
+Sexton Mountain,271131,2009,Curfew,
+Sexton Mountain,271131,2009,Disorderly Conduct,
+Sexton Mountain,271131,2009,Drugs,
+Sexton Mountain,271131,2009,DUII,
+Sexton Mountain,271131,2009,Embezzlement,
+Sexton Mountain,271131,2009,Forgery,
+Sexton Mountain,271131,2009,Fraud,
+Sexton Mountain,271131,2009,Gambling,
+Sexton Mountain,271131,2009,Homicide,
+Sexton Mountain,271131,2009,Kidnap,
+Sexton Mountain,271131,2009,Larceny,
+Sexton Mountain,271131,2009,Liquor Laws,
+Sexton Mountain,271131,2009,Motor Vehicle Theft,
+Sexton Mountain,271131,2009,Offenses Against Family,
+Sexton Mountain,271131,2009,Prostitution,
+Sexton Mountain,271131,2009,Rape,
+Sexton Mountain,271131,2009,Robbery,
+Sexton Mountain,271131,2009,Runaway,
+Sexton Mountain,271131,2009,Sex Offenses,
+Sexton Mountain,271131,2009,Stolen Property,
+Sexton Mountain,271131,2009,Trespass,
+Sexton Mountain,271131,2009,Vandalism,
+Sexton Mountain,271131,2009,Weapons,
+Sexton Mountain,271131,2010,Aggravated Assault,
+Sexton Mountain,271131,2010,Arson,
+Sexton Mountain,271131,2010,"Assault, Simple",
+Sexton Mountain,271131,2010,Burglary,
+Sexton Mountain,271131,2010,Curfew,
+Sexton Mountain,271131,2010,Disorderly Conduct,
+Sexton Mountain,271131,2010,Drugs,
+Sexton Mountain,271131,2010,DUII,
+Sexton Mountain,271131,2010,Embezzlement,
+Sexton Mountain,271131,2010,Forgery,
+Sexton Mountain,271131,2010,Fraud,
+Sexton Mountain,271131,2010,Gambling,
+Sexton Mountain,271131,2010,Homicide,
+Sexton Mountain,271131,2010,Kidnap,
+Sexton Mountain,271131,2010,Larceny,
+Sexton Mountain,271131,2010,Liquor Laws,
+Sexton Mountain,271131,2010,Motor Vehicle Theft,
+Sexton Mountain,271131,2010,Offenses Against Family,
+Sexton Mountain,271131,2010,Prostitution,
+Sexton Mountain,271131,2010,Rape,
+Sexton Mountain,271131,2010,Robbery,
+Sexton Mountain,271131,2010,Runaway,
+Sexton Mountain,271131,2010,Sex Offenses,
+Sexton Mountain,271131,2010,Stolen Property,
+Sexton Mountain,271131,2010,Trespass,
+Sexton Mountain,271131,2010,Vandalism,
+Sexton Mountain,271131,2010,Weapons,
+Sexton Mountain,271131,2011,Aggravated Assault,
+Sexton Mountain,271131,2011,Arson,
+Sexton Mountain,271131,2011,"Assault, Simple",
+Sexton Mountain,271131,2011,Burglary,
+Sexton Mountain,271131,2011,Curfew,
+Sexton Mountain,271131,2011,Disorderly Conduct,
+Sexton Mountain,271131,2011,Drugs,
+Sexton Mountain,271131,2011,DUII,
+Sexton Mountain,271131,2011,Embezzlement,
+Sexton Mountain,271131,2011,Forgery,
+Sexton Mountain,271131,2011,Fraud,
+Sexton Mountain,271131,2011,Gambling,
+Sexton Mountain,271131,2011,Homicide,
+Sexton Mountain,271131,2011,Kidnap,
+Sexton Mountain,271131,2011,Larceny,
+Sexton Mountain,271131,2011,Liquor Laws,
+Sexton Mountain,271131,2011,Motor Vehicle Theft,
+Sexton Mountain,271131,2011,Offenses Against Family,
+Sexton Mountain,271131,2011,Prostitution,
+Sexton Mountain,271131,2011,Rape,
+Sexton Mountain,271131,2011,Robbery,
+Sexton Mountain,271131,2011,Runaway,
+Sexton Mountain,271131,2011,Sex Offenses,
+Sexton Mountain,271131,2011,Stolen Property,
+Sexton Mountain,271131,2011,Trespass,
+Sexton Mountain,271131,2011,Vandalism,
+Sexton Mountain,271131,2011,Weapons,
+Sexton Mountain,271131,2012,Aggravated Assault,
+Sexton Mountain,271131,2012,Arson,
+Sexton Mountain,271131,2012,"Assault, Simple",
+Sexton Mountain,271131,2012,Burglary,
+Sexton Mountain,271131,2012,Curfew,
+Sexton Mountain,271131,2012,Disorderly Conduct,
+Sexton Mountain,271131,2012,Drugs,
+Sexton Mountain,271131,2012,DUII,
+Sexton Mountain,271131,2012,Embezzlement,
+Sexton Mountain,271131,2012,Forgery,
+Sexton Mountain,271131,2012,Fraud,
+Sexton Mountain,271131,2012,Gambling,
+Sexton Mountain,271131,2012,Homicide,
+Sexton Mountain,271131,2012,Kidnap,
+Sexton Mountain,271131,2012,Larceny,
+Sexton Mountain,271131,2012,Liquor Laws,
+Sexton Mountain,271131,2012,Motor Vehicle Theft,
+Sexton Mountain,271131,2012,Offenses Against Family,
+Sexton Mountain,271131,2012,Prostitution,
+Sexton Mountain,271131,2012,Rape,
+Sexton Mountain,271131,2012,Robbery,
+Sexton Mountain,271131,2012,Runaway,
+Sexton Mountain,271131,2012,Sex Offenses,
+Sexton Mountain,271131,2012,Stolen Property,
+Sexton Mountain,271131,2012,Trespass,
+Sexton Mountain,271131,2012,Vandalism,
+Sexton Mountain,271131,2012,Weapons,
+Sexton Mountain,271131,2013,Aggravated Assault,
+Sexton Mountain,271131,2013,Arson,
+Sexton Mountain,271131,2013,"Assault, Simple",
+Sexton Mountain,271131,2013,Burglary,
+Sexton Mountain,271131,2013,Curfew,
+Sexton Mountain,271131,2013,Disorderly Conduct,
+Sexton Mountain,271131,2013,Drugs,
+Sexton Mountain,271131,2013,DUII,
+Sexton Mountain,271131,2013,Embezzlement,
+Sexton Mountain,271131,2013,Forgery,
+Sexton Mountain,271131,2013,Fraud,
+Sexton Mountain,271131,2013,Gambling,
+Sexton Mountain,271131,2013,Homicide,
+Sexton Mountain,271131,2013,Kidnap,
+Sexton Mountain,271131,2013,Larceny,
+Sexton Mountain,271131,2013,Liquor Laws,
+Sexton Mountain,271131,2013,Motor Vehicle Theft,
+Sexton Mountain,271131,2013,Offenses Against Family,
+Sexton Mountain,271131,2013,Prostitution,
+Sexton Mountain,271131,2013,Rape,
+Sexton Mountain,271131,2013,Robbery,
+Sexton Mountain,271131,2013,Runaway,
+Sexton Mountain,271131,2013,Sex Offenses,
+Sexton Mountain,271131,2013,Stolen Property,
+Sexton Mountain,271131,2013,Trespass,
+Sexton Mountain,271131,2013,Vandalism,
+Sexton Mountain,271131,2013,Weapons,
+Sexton Mountain,271131,2014,Aggravated Assault,
+Sexton Mountain,271131,2014,Arson,
+Sexton Mountain,271131,2014,"Assault, Simple",
+Sexton Mountain,271131,2014,Burglary,
+Sexton Mountain,271131,2014,Curfew,
+Sexton Mountain,271131,2014,Disorderly Conduct,
+Sexton Mountain,271131,2014,Drugs,
+Sexton Mountain,271131,2014,DUII,
+Sexton Mountain,271131,2014,Embezzlement,
+Sexton Mountain,271131,2014,Forgery,
+Sexton Mountain,271131,2014,Fraud,
+Sexton Mountain,271131,2014,Gambling,
+Sexton Mountain,271131,2014,Homicide,
+Sexton Mountain,271131,2014,Kidnap,
+Sexton Mountain,271131,2014,Larceny,
+Sexton Mountain,271131,2014,Liquor Laws,
+Sexton Mountain,271131,2014,Motor Vehicle Theft,
+Sexton Mountain,271131,2014,Offenses Against Family,
+Sexton Mountain,271131,2014,Prostitution,
+Sexton Mountain,271131,2014,Rape,
+Sexton Mountain,271131,2014,Robbery,
+Sexton Mountain,271131,2014,Runaway,
+Sexton Mountain,271131,2014,Sex Offenses,
+Sexton Mountain,271131,2014,Stolen Property,
+Sexton Mountain,271131,2014,Trespass,
+Sexton Mountain,271131,2014,Vandalism,
+Sexton Mountain,271131,2014,Weapons,
+South Beaverton,275412,2004,Aggravated Assault,
+South Beaverton,275412,2004,Arson,
+South Beaverton,275412,2004,"Assault, Simple",
+South Beaverton,275412,2004,Burglary,
+South Beaverton,275412,2004,Curfew,
+South Beaverton,275412,2004,Disorderly Conduct,
+South Beaverton,275412,2004,Drugs,
+South Beaverton,275412,2004,DUII,
+South Beaverton,275412,2004,Embezzlement,
+South Beaverton,275412,2004,Forgery,
+South Beaverton,275412,2004,Fraud,
+South Beaverton,275412,2004,Gambling,
+South Beaverton,275412,2004,Homicide,
+South Beaverton,275412,2004,Kidnap,
+South Beaverton,275412,2004,Larceny,
+South Beaverton,275412,2004,Liquor Laws,
+South Beaverton,275412,2004,Motor Vehicle Theft,
+South Beaverton,275412,2004,Offenses Against Family,
+South Beaverton,275412,2004,Prostitution,
+South Beaverton,275412,2004,Rape,
+South Beaverton,275412,2004,Robbery,
+South Beaverton,275412,2004,Runaway,
+South Beaverton,275412,2004,Sex Offenses,
+South Beaverton,275412,2004,Stolen Property,
+South Beaverton,275412,2004,Trespass,
+South Beaverton,275412,2004,Vandalism,
+South Beaverton,275412,2004,Weapons,
+South Beaverton,275412,2005,Aggravated Assault,
+South Beaverton,275412,2005,Arson,
+South Beaverton,275412,2005,"Assault, Simple",
+South Beaverton,275412,2005,Burglary,
+South Beaverton,275412,2005,Curfew,
+South Beaverton,275412,2005,Disorderly Conduct,
+South Beaverton,275412,2005,Drugs,
+South Beaverton,275412,2005,DUII,
+South Beaverton,275412,2005,Embezzlement,
+South Beaverton,275412,2005,Forgery,
+South Beaverton,275412,2005,Fraud,
+South Beaverton,275412,2005,Gambling,
+South Beaverton,275412,2005,Homicide,
+South Beaverton,275412,2005,Kidnap,
+South Beaverton,275412,2005,Larceny,
+South Beaverton,275412,2005,Liquor Laws,
+South Beaverton,275412,2005,Motor Vehicle Theft,
+South Beaverton,275412,2005,Offenses Against Family,
+South Beaverton,275412,2005,Prostitution,
+South Beaverton,275412,2005,Rape,
+South Beaverton,275412,2005,Robbery,
+South Beaverton,275412,2005,Runaway,
+South Beaverton,275412,2005,Sex Offenses,
+South Beaverton,275412,2005,Stolen Property,
+South Beaverton,275412,2005,Trespass,
+South Beaverton,275412,2005,Vandalism,
+South Beaverton,275412,2005,Weapons,
+South Beaverton,275412,2006,Aggravated Assault,
+South Beaverton,275412,2006,Arson,
+South Beaverton,275412,2006,"Assault, Simple",
+South Beaverton,275412,2006,Burglary,
+South Beaverton,275412,2006,Curfew,
+South Beaverton,275412,2006,Disorderly Conduct,
+South Beaverton,275412,2006,Drugs,
+South Beaverton,275412,2006,DUII,
+South Beaverton,275412,2006,Embezzlement,
+South Beaverton,275412,2006,Forgery,
+South Beaverton,275412,2006,Fraud,
+South Beaverton,275412,2006,Gambling,
+South Beaverton,275412,2006,Homicide,
+South Beaverton,275412,2006,Kidnap,
+South Beaverton,275412,2006,Larceny,
+South Beaverton,275412,2006,Liquor Laws,
+South Beaverton,275412,2006,Motor Vehicle Theft,
+South Beaverton,275412,2006,Offenses Against Family,
+South Beaverton,275412,2006,Prostitution,
+South Beaverton,275412,2006,Rape,
+South Beaverton,275412,2006,Robbery,
+South Beaverton,275412,2006,Runaway,
+South Beaverton,275412,2006,Sex Offenses,
+South Beaverton,275412,2006,Stolen Property,
+South Beaverton,275412,2006,Trespass,
+South Beaverton,275412,2006,Vandalism,
+South Beaverton,275412,2006,Weapons,
+South Beaverton,275412,2007,Aggravated Assault,
+South Beaverton,275412,2007,Arson,
+South Beaverton,275412,2007,"Assault, Simple",
+South Beaverton,275412,2007,Burglary,
+South Beaverton,275412,2007,Curfew,
+South Beaverton,275412,2007,Disorderly Conduct,
+South Beaverton,275412,2007,Drugs,
+South Beaverton,275412,2007,DUII,
+South Beaverton,275412,2007,Embezzlement,
+South Beaverton,275412,2007,Forgery,
+South Beaverton,275412,2007,Fraud,
+South Beaverton,275412,2007,Gambling,
+South Beaverton,275412,2007,Homicide,
+South Beaverton,275412,2007,Kidnap,
+South Beaverton,275412,2007,Larceny,
+South Beaverton,275412,2007,Liquor Laws,
+South Beaverton,275412,2007,Motor Vehicle Theft,
+South Beaverton,275412,2007,Offenses Against Family,
+South Beaverton,275412,2007,Prostitution,
+South Beaverton,275412,2007,Rape,
+South Beaverton,275412,2007,Robbery,
+South Beaverton,275412,2007,Runaway,
+South Beaverton,275412,2007,Sex Offenses,
+South Beaverton,275412,2007,Stolen Property,
+South Beaverton,275412,2007,Trespass,
+South Beaverton,275412,2007,Vandalism,
+South Beaverton,275412,2007,Weapons,
+South Beaverton,275412,2008,Aggravated Assault,
+South Beaverton,275412,2008,Arson,
+South Beaverton,275412,2008,"Assault, Simple",
+South Beaverton,275412,2008,Burglary,
+South Beaverton,275412,2008,Curfew,
+South Beaverton,275412,2008,Disorderly Conduct,
+South Beaverton,275412,2008,Drugs,
+South Beaverton,275412,2008,DUII,
+South Beaverton,275412,2008,Embezzlement,
+South Beaverton,275412,2008,Forgery,
+South Beaverton,275412,2008,Fraud,
+South Beaverton,275412,2008,Gambling,
+South Beaverton,275412,2008,Homicide,
+South Beaverton,275412,2008,Kidnap,
+South Beaverton,275412,2008,Larceny,
+South Beaverton,275412,2008,Liquor Laws,
+South Beaverton,275412,2008,Motor Vehicle Theft,
+South Beaverton,275412,2008,Offenses Against Family,
+South Beaverton,275412,2008,Prostitution,
+South Beaverton,275412,2008,Rape,
+South Beaverton,275412,2008,Robbery,
+South Beaverton,275412,2008,Runaway,
+South Beaverton,275412,2008,Sex Offenses,
+South Beaverton,275412,2008,Stolen Property,
+South Beaverton,275412,2008,Trespass,
+South Beaverton,275412,2008,Vandalism,
+South Beaverton,275412,2008,Weapons,
+South Beaverton,275412,2009,Aggravated Assault,
+South Beaverton,275412,2009,Arson,
+South Beaverton,275412,2009,"Assault, Simple",
+South Beaverton,275412,2009,Burglary,
+South Beaverton,275412,2009,Curfew,
+South Beaverton,275412,2009,Disorderly Conduct,
+South Beaverton,275412,2009,Drugs,
+South Beaverton,275412,2009,DUII,
+South Beaverton,275412,2009,Embezzlement,
+South Beaverton,275412,2009,Forgery,
+South Beaverton,275412,2009,Fraud,
+South Beaverton,275412,2009,Gambling,
+South Beaverton,275412,2009,Homicide,
+South Beaverton,275412,2009,Kidnap,
+South Beaverton,275412,2009,Larceny,
+South Beaverton,275412,2009,Liquor Laws,
+South Beaverton,275412,2009,Motor Vehicle Theft,
+South Beaverton,275412,2009,Offenses Against Family,
+South Beaverton,275412,2009,Prostitution,
+South Beaverton,275412,2009,Rape,
+South Beaverton,275412,2009,Robbery,
+South Beaverton,275412,2009,Runaway,
+South Beaverton,275412,2009,Sex Offenses,
+South Beaverton,275412,2009,Stolen Property,
+South Beaverton,275412,2009,Trespass,
+South Beaverton,275412,2009,Vandalism,
+South Beaverton,275412,2009,Weapons,
+South Beaverton,275412,2010,Aggravated Assault,
+South Beaverton,275412,2010,Arson,
+South Beaverton,275412,2010,"Assault, Simple",
+South Beaverton,275412,2010,Burglary,
+South Beaverton,275412,2010,Curfew,
+South Beaverton,275412,2010,Disorderly Conduct,
+South Beaverton,275412,2010,Drugs,
+South Beaverton,275412,2010,DUII,
+South Beaverton,275412,2010,Embezzlement,
+South Beaverton,275412,2010,Forgery,
+South Beaverton,275412,2010,Fraud,
+South Beaverton,275412,2010,Gambling,
+South Beaverton,275412,2010,Homicide,
+South Beaverton,275412,2010,Kidnap,
+South Beaverton,275412,2010,Larceny,
+South Beaverton,275412,2010,Liquor Laws,
+South Beaverton,275412,2010,Motor Vehicle Theft,
+South Beaverton,275412,2010,Offenses Against Family,
+South Beaverton,275412,2010,Prostitution,
+South Beaverton,275412,2010,Rape,
+South Beaverton,275412,2010,Robbery,
+South Beaverton,275412,2010,Runaway,
+South Beaverton,275412,2010,Sex Offenses,
+South Beaverton,275412,2010,Stolen Property,
+South Beaverton,275412,2010,Trespass,
+South Beaverton,275412,2010,Vandalism,
+South Beaverton,275412,2010,Weapons,
+South Beaverton,275412,2011,Aggravated Assault,
+South Beaverton,275412,2011,Arson,
+South Beaverton,275412,2011,"Assault, Simple",
+South Beaverton,275412,2011,Burglary,
+South Beaverton,275412,2011,Curfew,
+South Beaverton,275412,2011,Disorderly Conduct,
+South Beaverton,275412,2011,Drugs,
+South Beaverton,275412,2011,DUII,
+South Beaverton,275412,2011,Embezzlement,
+South Beaverton,275412,2011,Forgery,
+South Beaverton,275412,2011,Fraud,
+South Beaverton,275412,2011,Gambling,
+South Beaverton,275412,2011,Homicide,
+South Beaverton,275412,2011,Kidnap,
+South Beaverton,275412,2011,Larceny,
+South Beaverton,275412,2011,Liquor Laws,
+South Beaverton,275412,2011,Motor Vehicle Theft,
+South Beaverton,275412,2011,Offenses Against Family,
+South Beaverton,275412,2011,Prostitution,
+South Beaverton,275412,2011,Rape,
+South Beaverton,275412,2011,Robbery,
+South Beaverton,275412,2011,Runaway,
+South Beaverton,275412,2011,Sex Offenses,
+South Beaverton,275412,2011,Stolen Property,
+South Beaverton,275412,2011,Trespass,
+South Beaverton,275412,2011,Vandalism,
+South Beaverton,275412,2011,Weapons,
+South Beaverton,275412,2012,Aggravated Assault,
+South Beaverton,275412,2012,Arson,
+South Beaverton,275412,2012,"Assault, Simple",
+South Beaverton,275412,2012,Burglary,
+South Beaverton,275412,2012,Curfew,
+South Beaverton,275412,2012,Disorderly Conduct,
+South Beaverton,275412,2012,Drugs,
+South Beaverton,275412,2012,DUII,
+South Beaverton,275412,2012,Embezzlement,
+South Beaverton,275412,2012,Forgery,
+South Beaverton,275412,2012,Fraud,
+South Beaverton,275412,2012,Gambling,
+South Beaverton,275412,2012,Homicide,
+South Beaverton,275412,2012,Kidnap,
+South Beaverton,275412,2012,Larceny,
+South Beaverton,275412,2012,Liquor Laws,
+South Beaverton,275412,2012,Motor Vehicle Theft,
+South Beaverton,275412,2012,Offenses Against Family,
+South Beaverton,275412,2012,Prostitution,
+South Beaverton,275412,2012,Rape,
+South Beaverton,275412,2012,Robbery,
+South Beaverton,275412,2012,Runaway,
+South Beaverton,275412,2012,Sex Offenses,
+South Beaverton,275412,2012,Stolen Property,
+South Beaverton,275412,2012,Trespass,
+South Beaverton,275412,2012,Vandalism,
+South Beaverton,275412,2012,Weapons,
+South Beaverton,275412,2013,Aggravated Assault,
+South Beaverton,275412,2013,Arson,
+South Beaverton,275412,2013,"Assault, Simple",
+South Beaverton,275412,2013,Burglary,
+South Beaverton,275412,2013,Curfew,
+South Beaverton,275412,2013,Disorderly Conduct,
+South Beaverton,275412,2013,Drugs,
+South Beaverton,275412,2013,DUII,
+South Beaverton,275412,2013,Embezzlement,
+South Beaverton,275412,2013,Forgery,
+South Beaverton,275412,2013,Fraud,
+South Beaverton,275412,2013,Gambling,
+South Beaverton,275412,2013,Homicide,
+South Beaverton,275412,2013,Kidnap,
+South Beaverton,275412,2013,Larceny,
+South Beaverton,275412,2013,Liquor Laws,
+South Beaverton,275412,2013,Motor Vehicle Theft,
+South Beaverton,275412,2013,Offenses Against Family,
+South Beaverton,275412,2013,Prostitution,
+South Beaverton,275412,2013,Rape,
+South Beaverton,275412,2013,Robbery,
+South Beaverton,275412,2013,Runaway,
+South Beaverton,275412,2013,Sex Offenses,
+South Beaverton,275412,2013,Stolen Property,
+South Beaverton,275412,2013,Trespass,
+South Beaverton,275412,2013,Vandalism,
+South Beaverton,275412,2013,Weapons,
+South Beaverton,275412,2014,Aggravated Assault,
+South Beaverton,275412,2014,Arson,
+South Beaverton,275412,2014,"Assault, Simple",
+South Beaverton,275412,2014,Burglary,
+South Beaverton,275412,2014,Curfew,
+South Beaverton,275412,2014,Disorderly Conduct,
+South Beaverton,275412,2014,Drugs,
+South Beaverton,275412,2014,DUII,
+South Beaverton,275412,2014,Embezzlement,
+South Beaverton,275412,2014,Forgery,
+South Beaverton,275412,2014,Fraud,
+South Beaverton,275412,2014,Gambling,
+South Beaverton,275412,2014,Homicide,
+South Beaverton,275412,2014,Kidnap,
+South Beaverton,275412,2014,Larceny,
+South Beaverton,275412,2014,Liquor Laws,
+South Beaverton,275412,2014,Motor Vehicle Theft,
+South Beaverton,275412,2014,Offenses Against Family,
+South Beaverton,275412,2014,Prostitution,
+South Beaverton,275412,2014,Rape,
+South Beaverton,275412,2014,Robbery,
+South Beaverton,275412,2014,Runaway,
+South Beaverton,275412,2014,Sex Offenses,
+South Beaverton,275412,2014,Stolen Property,
+South Beaverton,275412,2014,Trespass,
+South Beaverton,275412,2014,Vandalism,
+South Beaverton,275412,2014,Weapons,
+South Tabor,344059,2004,Aggravated Assault,5
+South Tabor,344059,2004,Arson,
+South Tabor,344059,2004,"Assault, Simple",18
+South Tabor,344059,2004,Burglary,42
+South Tabor,344059,2004,Curfew,1
+South Tabor,344059,2004,Disorderly Conduct,7
+South Tabor,344059,2004,Drugs,16
+South Tabor,344059,2004,DUII,8
+South Tabor,344059,2004,Embezzlement,
+South Tabor,344059,2004,Forgery,13
+South Tabor,344059,2004,Fraud,6
+South Tabor,344059,2004,Gambling,
+South Tabor,344059,2004,Homicide,
+South Tabor,344059,2004,Kidnap,
+South Tabor,344059,2004,Larceny,61
+South Tabor,344059,2004,Liquor Laws,2
+South Tabor,344059,2004,Motor Vehicle Theft,15
+South Tabor,344059,2004,Offenses Against Family,
+South Tabor,344059,2004,Prostitution,14
+South Tabor,344059,2004,Rape,
+South Tabor,344059,2004,Robbery,5
+South Tabor,344059,2004,Runaway,
+South Tabor,344059,2004,Sex Offenses,
+South Tabor,344059,2004,Stolen Property,1
+South Tabor,344059,2004,Trespass,18
+South Tabor,344059,2004,Vandalism,26
+South Tabor,344059,2004,Weapons,2
+South Tabor,344059,2005,Aggravated Assault,17
+South Tabor,344059,2005,Arson,1
+South Tabor,344059,2005,"Assault, Simple",33
+South Tabor,344059,2005,Burglary,86
+South Tabor,344059,2005,Curfew,2
+South Tabor,344059,2005,Disorderly Conduct,29
+South Tabor,344059,2005,Drugs,73
+South Tabor,344059,2005,DUII,21
+South Tabor,344059,2005,Embezzlement,
+South Tabor,344059,2005,Forgery,26
+South Tabor,344059,2005,Fraud,30
+South Tabor,344059,2005,Gambling,
+South Tabor,344059,2005,Homicide,1
+South Tabor,344059,2005,Kidnap,1
+South Tabor,344059,2005,Larceny,204
+South Tabor,344059,2005,Liquor Laws,8
+South Tabor,344059,2005,Motor Vehicle Theft,58
+South Tabor,344059,2005,Offenses Against Family,
+South Tabor,344059,2005,Prostitution,29
+South Tabor,344059,2005,Rape,
+South Tabor,344059,2005,Robbery,12
+South Tabor,344059,2005,Runaway,
+South Tabor,344059,2005,Sex Offenses,
+South Tabor,344059,2005,Stolen Property,4
+South Tabor,344059,2005,Trespass,46
+South Tabor,344059,2005,Vandalism,95
+South Tabor,344059,2005,Weapons,6
+South Tabor,344059,2006,Aggravated Assault,20
+South Tabor,344059,2006,Arson,1
+South Tabor,344059,2006,"Assault, Simple",36
+South Tabor,344059,2006,Burglary,48
+South Tabor,344059,2006,Curfew,3
+South Tabor,344059,2006,Disorderly Conduct,15
+South Tabor,344059,2006,Drugs,41
+South Tabor,344059,2006,DUII,34
+South Tabor,344059,2006,Embezzlement,
+South Tabor,344059,2006,Forgery,11
+South Tabor,344059,2006,Fraud,22
+South Tabor,344059,2006,Gambling,
+South Tabor,344059,2006,Homicide,
+South Tabor,344059,2006,Kidnap,
+South Tabor,344059,2006,Larceny,159
+South Tabor,344059,2006,Liquor Laws,11
+South Tabor,344059,2006,Motor Vehicle Theft,44
+South Tabor,344059,2006,Offenses Against Family,
+South Tabor,344059,2006,Prostitution,24
+South Tabor,344059,2006,Rape,
+South Tabor,344059,2006,Robbery,10
+South Tabor,344059,2006,Runaway,1
+South Tabor,344059,2006,Sex Offenses,2
+South Tabor,344059,2006,Stolen Property,1
+South Tabor,344059,2006,Trespass,35
+South Tabor,344059,2006,Vandalism,78
+South Tabor,344059,2006,Weapons,6
+South Tabor,344059,2007,Aggravated Assault,18
+South Tabor,344059,2007,Arson,
+South Tabor,344059,2007,"Assault, Simple",24
+South Tabor,344059,2007,Burglary,67
+South Tabor,344059,2007,Curfew,2
+South Tabor,344059,2007,Disorderly Conduct,23
+South Tabor,344059,2007,Drugs,39
+South Tabor,344059,2007,DUII,32
+South Tabor,344059,2007,Embezzlement,3
+South Tabor,344059,2007,Forgery,9
+South Tabor,344059,2007,Fraud,18
+South Tabor,344059,2007,Gambling,
+South Tabor,344059,2007,Homicide,
+South Tabor,344059,2007,Kidnap,1
+South Tabor,344059,2007,Larceny,166
+South Tabor,344059,2007,Liquor Laws,7
+South Tabor,344059,2007,Motor Vehicle Theft,59
+South Tabor,344059,2007,Offenses Against Family,
+South Tabor,344059,2007,Prostitution,17
+South Tabor,344059,2007,Rape,1
+South Tabor,344059,2007,Robbery,12
+South Tabor,344059,2007,Runaway,
+South Tabor,344059,2007,Sex Offenses,1
+South Tabor,344059,2007,Stolen Property,4
+South Tabor,344059,2007,Trespass,17
+South Tabor,344059,2007,Vandalism,125
+South Tabor,344059,2007,Weapons,4
+South Tabor,344059,2008,Aggravated Assault,13
+South Tabor,344059,2008,Arson,
+South Tabor,344059,2008,"Assault, Simple",39
+South Tabor,344059,2008,Burglary,33
+South Tabor,344059,2008,Curfew,9
+South Tabor,344059,2008,Disorderly Conduct,29
+South Tabor,344059,2008,Drugs,30
+South Tabor,344059,2008,DUII,23
+South Tabor,344059,2008,Embezzlement,2
+South Tabor,344059,2008,Forgery,15
+South Tabor,344059,2008,Fraud,28
+South Tabor,344059,2008,Gambling,
+South Tabor,344059,2008,Homicide,
+South Tabor,344059,2008,Kidnap,
+South Tabor,344059,2008,Larceny,139
+South Tabor,344059,2008,Liquor Laws,13
+South Tabor,344059,2008,Motor Vehicle Theft,43
+South Tabor,344059,2008,Offenses Against Family,
+South Tabor,344059,2008,Prostitution,27
+South Tabor,344059,2008,Rape,
+South Tabor,344059,2008,Robbery,14
+South Tabor,344059,2008,Runaway,
+South Tabor,344059,2008,Sex Offenses,1
+South Tabor,344059,2008,Stolen Property,
+South Tabor,344059,2008,Trespass,19
+South Tabor,344059,2008,Vandalism,60
+South Tabor,344059,2008,Weapons,7
+South Tabor,344059,2009,Aggravated Assault,11
+South Tabor,344059,2009,Arson,
+South Tabor,344059,2009,"Assault, Simple",21
+South Tabor,344059,2009,Burglary,48
+South Tabor,344059,2009,Curfew,
+South Tabor,344059,2009,Disorderly Conduct,24
+South Tabor,344059,2009,Drugs,22
+South Tabor,344059,2009,DUII,14
+South Tabor,344059,2009,Embezzlement,2
+South Tabor,344059,2009,Forgery,1
+South Tabor,344059,2009,Fraud,11
+South Tabor,344059,2009,Gambling,
+South Tabor,344059,2009,Homicide,
+South Tabor,344059,2009,Kidnap,
+South Tabor,344059,2009,Larceny,127
+South Tabor,344059,2009,Liquor Laws,9
+South Tabor,344059,2009,Motor Vehicle Theft,27
+South Tabor,344059,2009,Offenses Against Family,
+South Tabor,344059,2009,Prostitution,15
+South Tabor,344059,2009,Rape,1
+South Tabor,344059,2009,Robbery,6
+South Tabor,344059,2009,Runaway,1
+South Tabor,344059,2009,Sex Offenses,1
+South Tabor,344059,2009,Stolen Property,
+South Tabor,344059,2009,Trespass,12
+South Tabor,344059,2009,Vandalism,40
+South Tabor,344059,2009,Weapons,3
+South Tabor,344059,2010,Aggravated Assault,6
+South Tabor,344059,2010,Arson,
+South Tabor,344059,2010,"Assault, Simple",20
+South Tabor,344059,2010,Burglary,33
+South Tabor,344059,2010,Curfew,3
+South Tabor,344059,2010,Disorderly Conduct,18
+South Tabor,344059,2010,Drugs,15
+South Tabor,344059,2010,DUII,18
+South Tabor,344059,2010,Embezzlement,1
+South Tabor,344059,2010,Forgery,3
+South Tabor,344059,2010,Fraud,7
+South Tabor,344059,2010,Gambling,
+South Tabor,344059,2010,Homicide,
+South Tabor,344059,2010,Kidnap,
+South Tabor,344059,2010,Larceny,201
+South Tabor,344059,2010,Liquor Laws,5
+South Tabor,344059,2010,Motor Vehicle Theft,45
+South Tabor,344059,2010,Offenses Against Family,
+South Tabor,344059,2010,Prostitution,4
+South Tabor,344059,2010,Rape,
+South Tabor,344059,2010,Robbery,5
+South Tabor,344059,2010,Runaway,
+South Tabor,344059,2010,Sex Offenses,1
+South Tabor,344059,2010,Stolen Property,1
+South Tabor,344059,2010,Trespass,9
+South Tabor,344059,2010,Vandalism,65
+South Tabor,344059,2010,Weapons,6
+South Tabor,344059,2011,Aggravated Assault,9
+South Tabor,344059,2011,Arson,
+South Tabor,344059,2011,"Assault, Simple",11
+South Tabor,344059,2011,Burglary,58
+South Tabor,344059,2011,Curfew,
+South Tabor,344059,2011,Disorderly Conduct,20
+South Tabor,344059,2011,Drugs,9
+South Tabor,344059,2011,DUII,21
+South Tabor,344059,2011,Embezzlement,
+South Tabor,344059,2011,Forgery,12
+South Tabor,344059,2011,Fraud,14
+South Tabor,344059,2011,Gambling,
+South Tabor,344059,2011,Homicide,1
+South Tabor,344059,2011,Kidnap,
+South Tabor,344059,2011,Larceny,183
+South Tabor,344059,2011,Liquor Laws,4
+South Tabor,344059,2011,Motor Vehicle Theft,36
+South Tabor,344059,2011,Offenses Against Family,1
+South Tabor,344059,2011,Prostitution,7
+South Tabor,344059,2011,Rape,1
+South Tabor,344059,2011,Robbery,11
+South Tabor,344059,2011,Runaway,
+South Tabor,344059,2011,Sex Offenses,1
+South Tabor,344059,2011,Stolen Property,
+South Tabor,344059,2011,Trespass,20
+South Tabor,344059,2011,Vandalism,60
+South Tabor,344059,2011,Weapons,1
+South Tabor,344059,2012,Aggravated Assault,13
+South Tabor,344059,2012,Arson,
+South Tabor,344059,2012,"Assault, Simple",17
+South Tabor,344059,2012,Burglary,95
+South Tabor,344059,2012,Curfew,
+South Tabor,344059,2012,Disorderly Conduct,25
+South Tabor,344059,2012,Drugs,18
+South Tabor,344059,2012,DUII,16
+South Tabor,344059,2012,Embezzlement,2
+South Tabor,344059,2012,Forgery,4
+South Tabor,344059,2012,Fraud,20
+South Tabor,344059,2012,Gambling,
+South Tabor,344059,2012,Homicide,
+South Tabor,344059,2012,Kidnap,
+South Tabor,344059,2012,Larceny,217
+South Tabor,344059,2012,Liquor Laws,3
+South Tabor,344059,2012,Motor Vehicle Theft,35
+South Tabor,344059,2012,Offenses Against Family,
+South Tabor,344059,2012,Prostitution,5
+South Tabor,344059,2012,Rape,1
+South Tabor,344059,2012,Robbery,17
+South Tabor,344059,2012,Runaway,
+South Tabor,344059,2012,Sex Offenses,
+South Tabor,344059,2012,Stolen Property,
+South Tabor,344059,2012,Trespass,21
+South Tabor,344059,2012,Vandalism,68
+South Tabor,344059,2012,Weapons,
+South Tabor,344059,2013,Aggravated Assault,7
+South Tabor,344059,2013,Arson,1
+South Tabor,344059,2013,"Assault, Simple",20
+South Tabor,344059,2013,Burglary,62
+South Tabor,344059,2013,Curfew,
+South Tabor,344059,2013,Disorderly Conduct,25
+South Tabor,344059,2013,Drugs,26
+South Tabor,344059,2013,DUII,15
+South Tabor,344059,2013,Embezzlement,
+South Tabor,344059,2013,Forgery,8
+South Tabor,344059,2013,Fraud,18
+South Tabor,344059,2013,Gambling,
+South Tabor,344059,2013,Homicide,
+South Tabor,344059,2013,Kidnap,
+South Tabor,344059,2013,Larceny,186
+South Tabor,344059,2013,Liquor Laws,1
+South Tabor,344059,2013,Motor Vehicle Theft,27
+South Tabor,344059,2013,Offenses Against Family,
+South Tabor,344059,2013,Prostitution,9
+South Tabor,344059,2013,Rape,
+South Tabor,344059,2013,Robbery,7
+South Tabor,344059,2013,Runaway,
+South Tabor,344059,2013,Sex Offenses,
+South Tabor,344059,2013,Stolen Property,
+South Tabor,344059,2013,Trespass,24
+South Tabor,344059,2013,Vandalism,40
+South Tabor,344059,2013,Weapons,1
+South Tabor,344059,2014,Aggravated Assault,8
+South Tabor,344059,2014,Arson,
+South Tabor,344059,2014,"Assault, Simple",20
+South Tabor,344059,2014,Burglary,47
+South Tabor,344059,2014,Curfew,
+South Tabor,344059,2014,Disorderly Conduct,14
+South Tabor,344059,2014,Drugs,21
+South Tabor,344059,2014,DUII,11
+South Tabor,344059,2014,Embezzlement,
+South Tabor,344059,2014,Forgery,4
+South Tabor,344059,2014,Fraud,15
+South Tabor,344059,2014,Gambling,
+South Tabor,344059,2014,Homicide,
+South Tabor,344059,2014,Kidnap,
+South Tabor,344059,2014,Larceny,190
+South Tabor,344059,2014,Liquor Laws,5
+South Tabor,344059,2014,Motor Vehicle Theft,20
+South Tabor,344059,2014,Offenses Against Family,
+South Tabor,344059,2014,Prostitution,
+South Tabor,344059,2014,Rape,1
+South Tabor,344059,2014,Robbery,5
+South Tabor,344059,2014,Runaway,1
+South Tabor,344059,2014,Sex Offenses,1
+South Tabor,344059,2014,Stolen Property,
+South Tabor,344059,2014,Trespass,14
+South Tabor,344059,2014,Vandalism,20
+South Tabor,344059,2014,Weapons,2
+Southwest Hills,271136,2004,Aggravated Assault,
+Southwest Hills,271136,2004,Arson,
+Southwest Hills,271136,2004,"Assault, Simple",
+Southwest Hills,271136,2004,Burglary,5
+Southwest Hills,271136,2004,Curfew,
+Southwest Hills,271136,2004,Disorderly Conduct,1
+Southwest Hills,271136,2004,Drugs,
+Southwest Hills,271136,2004,DUII,
+Southwest Hills,271136,2004,Embezzlement,1
+Southwest Hills,271136,2004,Forgery,
+Southwest Hills,271136,2004,Fraud,
+Southwest Hills,271136,2004,Gambling,
+Southwest Hills,271136,2004,Homicide,
+Southwest Hills,271136,2004,Kidnap,
+Southwest Hills,271136,2004,Larceny,15
+Southwest Hills,271136,2004,Liquor Laws,1
+Southwest Hills,271136,2004,Motor Vehicle Theft,2
+Southwest Hills,271136,2004,Offenses Against Family,
+Southwest Hills,271136,2004,Prostitution,
+Southwest Hills,271136,2004,Rape,
+Southwest Hills,271136,2004,Robbery,
+Southwest Hills,271136,2004,Runaway,
+Southwest Hills,271136,2004,Sex Offenses,
+Southwest Hills,271136,2004,Stolen Property,
+Southwest Hills,271136,2004,Trespass,
+Southwest Hills,271136,2004,Vandalism,3
+Southwest Hills,271136,2004,Weapons,
+Southwest Hills,271136,2005,Aggravated Assault,8
+Southwest Hills,271136,2005,Arson,
+Southwest Hills,271136,2005,"Assault, Simple",3
+Southwest Hills,271136,2005,Burglary,31
+Southwest Hills,271136,2005,Curfew,
+Southwest Hills,271136,2005,Disorderly Conduct,4
+Southwest Hills,271136,2005,Drugs,6
+Southwest Hills,271136,2005,DUII,18
+Southwest Hills,271136,2005,Embezzlement,
+Southwest Hills,271136,2005,Forgery,4
+Southwest Hills,271136,2005,Fraud,8
+Southwest Hills,271136,2005,Gambling,
+Southwest Hills,271136,2005,Homicide,
+Southwest Hills,271136,2005,Kidnap,
+Southwest Hills,271136,2005,Larceny,103
+Southwest Hills,271136,2005,Liquor Laws,3
+Southwest Hills,271136,2005,Motor Vehicle Theft,20
+Southwest Hills,271136,2005,Offenses Against Family,
+Southwest Hills,271136,2005,Prostitution,
+Southwest Hills,271136,2005,Rape,
+Southwest Hills,271136,2005,Robbery,
+Southwest Hills,271136,2005,Runaway,
+Southwest Hills,271136,2005,Sex Offenses,1
+Southwest Hills,271136,2005,Stolen Property,
+Southwest Hills,271136,2005,Trespass,6
+Southwest Hills,271136,2005,Vandalism,29
+Southwest Hills,271136,2005,Weapons,1
+Southwest Hills,271136,2006,Aggravated Assault,5
+Southwest Hills,271136,2006,Arson,
+Southwest Hills,271136,2006,"Assault, Simple",1
+Southwest Hills,271136,2006,Burglary,19
+Southwest Hills,271136,2006,Curfew,
+Southwest Hills,271136,2006,Disorderly Conduct,5
+Southwest Hills,271136,2006,Drugs,3
+Southwest Hills,271136,2006,DUII,18
+Southwest Hills,271136,2006,Embezzlement,
+Southwest Hills,271136,2006,Forgery,
+Southwest Hills,271136,2006,Fraud,5
+Southwest Hills,271136,2006,Gambling,
+Southwest Hills,271136,2006,Homicide,
+Southwest Hills,271136,2006,Kidnap,
+Southwest Hills,271136,2006,Larceny,94
+Southwest Hills,271136,2006,Liquor Laws,8
+Southwest Hills,271136,2006,Motor Vehicle Theft,8
+Southwest Hills,271136,2006,Offenses Against Family,
+Southwest Hills,271136,2006,Prostitution,
+Southwest Hills,271136,2006,Rape,
+Southwest Hills,271136,2006,Robbery,1
+Southwest Hills,271136,2006,Runaway,
+Southwest Hills,271136,2006,Sex Offenses,
+Southwest Hills,271136,2006,Stolen Property,
+Southwest Hills,271136,2006,Trespass,9
+Southwest Hills,271136,2006,Vandalism,40
+Southwest Hills,271136,2006,Weapons,
+Southwest Hills,271136,2007,Aggravated Assault,
+Southwest Hills,271136,2007,Arson,
+Southwest Hills,271136,2007,"Assault, Simple",3
+Southwest Hills,271136,2007,Burglary,18
+Southwest Hills,271136,2007,Curfew,
+Southwest Hills,271136,2007,Disorderly Conduct,3
+Southwest Hills,271136,2007,Drugs,5
+Southwest Hills,271136,2007,DUII,10
+Southwest Hills,271136,2007,Embezzlement,
+Southwest Hills,271136,2007,Forgery,1
+Southwest Hills,271136,2007,Fraud,18
+Southwest Hills,271136,2007,Gambling,
+Southwest Hills,271136,2007,Homicide,
+Southwest Hills,271136,2007,Kidnap,
+Southwest Hills,271136,2007,Larceny,110
+Southwest Hills,271136,2007,Liquor Laws,3
+Southwest Hills,271136,2007,Motor Vehicle Theft,15
+Southwest Hills,271136,2007,Offenses Against Family,
+Southwest Hills,271136,2007,Prostitution,
+Southwest Hills,271136,2007,Rape,
+Southwest Hills,271136,2007,Robbery,
+Southwest Hills,271136,2007,Runaway,
+Southwest Hills,271136,2007,Sex Offenses,
+Southwest Hills,271136,2007,Stolen Property,
+Southwest Hills,271136,2007,Trespass,4
+Southwest Hills,271136,2007,Vandalism,29
+Southwest Hills,271136,2007,Weapons,1
+Southwest Hills,271136,2008,Aggravated Assault,1
+Southwest Hills,271136,2008,Arson,
+Southwest Hills,271136,2008,"Assault, Simple",3
+Southwest Hills,271136,2008,Burglary,15
+Southwest Hills,271136,2008,Curfew,
+Southwest Hills,271136,2008,Disorderly Conduct,6
+Southwest Hills,271136,2008,Drugs,1
+Southwest Hills,271136,2008,DUII,12
+Southwest Hills,271136,2008,Embezzlement,
+Southwest Hills,271136,2008,Forgery,
+Southwest Hills,271136,2008,Fraud,6
+Southwest Hills,271136,2008,Gambling,
+Southwest Hills,271136,2008,Homicide,
+Southwest Hills,271136,2008,Kidnap,
+Southwest Hills,271136,2008,Larceny,80
+Southwest Hills,271136,2008,Liquor Laws,6
+Southwest Hills,271136,2008,Motor Vehicle Theft,13
+Southwest Hills,271136,2008,Offenses Against Family,
+Southwest Hills,271136,2008,Prostitution,
+Southwest Hills,271136,2008,Rape,
+Southwest Hills,271136,2008,Robbery,
+Southwest Hills,271136,2008,Runaway,
+Southwest Hills,271136,2008,Sex Offenses,1
+Southwest Hills,271136,2008,Stolen Property,
+Southwest Hills,271136,2008,Trespass,5
+Southwest Hills,271136,2008,Vandalism,19
+Southwest Hills,271136,2008,Weapons,
+Southwest Hills,271136,2009,Aggravated Assault,2
+Southwest Hills,271136,2009,Arson,
+Southwest Hills,271136,2009,"Assault, Simple",4
+Southwest Hills,271136,2009,Burglary,13
+Southwest Hills,271136,2009,Curfew,
+Southwest Hills,271136,2009,Disorderly Conduct,3
+Southwest Hills,271136,2009,Drugs,2
+Southwest Hills,271136,2009,DUII,4
+Southwest Hills,271136,2009,Embezzlement,
+Southwest Hills,271136,2009,Forgery,
+Southwest Hills,271136,2009,Fraud,11
+Southwest Hills,271136,2009,Gambling,
+Southwest Hills,271136,2009,Homicide,
+Southwest Hills,271136,2009,Kidnap,
+Southwest Hills,271136,2009,Larceny,67
+Southwest Hills,271136,2009,Liquor Laws,6
+Southwest Hills,271136,2009,Motor Vehicle Theft,10
+Southwest Hills,271136,2009,Offenses Against Family,
+Southwest Hills,271136,2009,Prostitution,
+Southwest Hills,271136,2009,Rape,
+Southwest Hills,271136,2009,Robbery,1
+Southwest Hills,271136,2009,Runaway,
+Southwest Hills,271136,2009,Sex Offenses,
+Southwest Hills,271136,2009,Stolen Property,
+Southwest Hills,271136,2009,Trespass,2
+Southwest Hills,271136,2009,Vandalism,11
+Southwest Hills,271136,2009,Weapons,
+Southwest Hills,271136,2010,Aggravated Assault,1
+Southwest Hills,271136,2010,Arson,
+Southwest Hills,271136,2010,"Assault, Simple",4
+Southwest Hills,271136,2010,Burglary,22
+Southwest Hills,271136,2010,Curfew,
+Southwest Hills,271136,2010,Disorderly Conduct,1
+Southwest Hills,271136,2010,Drugs,3
+Southwest Hills,271136,2010,DUII,9
+Southwest Hills,271136,2010,Embezzlement,
+Southwest Hills,271136,2010,Forgery,
+Southwest Hills,271136,2010,Fraud,3
+Southwest Hills,271136,2010,Gambling,
+Southwest Hills,271136,2010,Homicide,
+Southwest Hills,271136,2010,Kidnap,
+Southwest Hills,271136,2010,Larceny,85
+Southwest Hills,271136,2010,Liquor Laws,2
+Southwest Hills,271136,2010,Motor Vehicle Theft,9
+Southwest Hills,271136,2010,Offenses Against Family,
+Southwest Hills,271136,2010,Prostitution,
+Southwest Hills,271136,2010,Rape,
+Southwest Hills,271136,2010,Robbery,
+Southwest Hills,271136,2010,Runaway,
+Southwest Hills,271136,2010,Sex Offenses,
+Southwest Hills,271136,2010,Stolen Property,
+Southwest Hills,271136,2010,Trespass,3
+Southwest Hills,271136,2010,Vandalism,16
+Southwest Hills,271136,2010,Weapons,
+Southwest Hills,271136,2011,Aggravated Assault,1
+Southwest Hills,271136,2011,Arson,
+Southwest Hills,271136,2011,"Assault, Simple",1
+Southwest Hills,271136,2011,Burglary,36
+Southwest Hills,271136,2011,Curfew,
+Southwest Hills,271136,2011,Disorderly Conduct,3
+Southwest Hills,271136,2011,Drugs,4
+Southwest Hills,271136,2011,DUII,3
+Southwest Hills,271136,2011,Embezzlement,1
+Southwest Hills,271136,2011,Forgery,
+Southwest Hills,271136,2011,Fraud,8
+Southwest Hills,271136,2011,Gambling,
+Southwest Hills,271136,2011,Homicide,
+Southwest Hills,271136,2011,Kidnap,
+Southwest Hills,271136,2011,Larceny,68
+Southwest Hills,271136,2011,Liquor Laws,3
+Southwest Hills,271136,2011,Motor Vehicle Theft,6
+Southwest Hills,271136,2011,Offenses Against Family,
+Southwest Hills,271136,2011,Prostitution,
+Southwest Hills,271136,2011,Rape,
+Southwest Hills,271136,2011,Robbery,2
+Southwest Hills,271136,2011,Runaway,
+Southwest Hills,271136,2011,Sex Offenses,1
+Southwest Hills,271136,2011,Stolen Property,
+Southwest Hills,271136,2011,Trespass,1
+Southwest Hills,271136,2011,Vandalism,41
+Southwest Hills,271136,2011,Weapons,1
+Southwest Hills,271136,2012,Aggravated Assault,
+Southwest Hills,271136,2012,Arson,
+Southwest Hills,271136,2012,"Assault, Simple",1
+Southwest Hills,271136,2012,Burglary,23
+Southwest Hills,271136,2012,Curfew,
+Southwest Hills,271136,2012,Disorderly Conduct,2
+Southwest Hills,271136,2012,Drugs,1
+Southwest Hills,271136,2012,DUII,5
+Southwest Hills,271136,2012,Embezzlement,
+Southwest Hills,271136,2012,Forgery,
+Southwest Hills,271136,2012,Fraud,5
+Southwest Hills,271136,2012,Gambling,
+Southwest Hills,271136,2012,Homicide,1
+Southwest Hills,271136,2012,Kidnap,
+Southwest Hills,271136,2012,Larceny,86
+Southwest Hills,271136,2012,Liquor Laws,6
+Southwest Hills,271136,2012,Motor Vehicle Theft,12
+Southwest Hills,271136,2012,Offenses Against Family,
+Southwest Hills,271136,2012,Prostitution,
+Southwest Hills,271136,2012,Rape,
+Southwest Hills,271136,2012,Robbery,2
+Southwest Hills,271136,2012,Runaway,
+Southwest Hills,271136,2012,Sex Offenses,
+Southwest Hills,271136,2012,Stolen Property,
+Southwest Hills,271136,2012,Trespass,4
+Southwest Hills,271136,2012,Vandalism,26
+Southwest Hills,271136,2012,Weapons,
+Southwest Hills,271136,2013,Aggravated Assault,1
+Southwest Hills,271136,2013,Arson,
+Southwest Hills,271136,2013,"Assault, Simple",4
+Southwest Hills,271136,2013,Burglary,24
+Southwest Hills,271136,2013,Curfew,
+Southwest Hills,271136,2013,Disorderly Conduct,4
+Southwest Hills,271136,2013,Drugs,6
+Southwest Hills,271136,2013,DUII,8
+Southwest Hills,271136,2013,Embezzlement,
+Southwest Hills,271136,2013,Forgery,
+Southwest Hills,271136,2013,Fraud,1
+Southwest Hills,271136,2013,Gambling,
+Southwest Hills,271136,2013,Homicide,
+Southwest Hills,271136,2013,Kidnap,
+Southwest Hills,271136,2013,Larceny,58
+Southwest Hills,271136,2013,Liquor Laws,
+Southwest Hills,271136,2013,Motor Vehicle Theft,6
+Southwest Hills,271136,2013,Offenses Against Family,
+Southwest Hills,271136,2013,Prostitution,
+Southwest Hills,271136,2013,Rape,
+Southwest Hills,271136,2013,Robbery,
+Southwest Hills,271136,2013,Runaway,
+Southwest Hills,271136,2013,Sex Offenses,
+Southwest Hills,271136,2013,Stolen Property,
+Southwest Hills,271136,2013,Trespass,4
+Southwest Hills,271136,2013,Vandalism,10
+Southwest Hills,271136,2013,Weapons,
+Southwest Hills,271136,2014,Aggravated Assault,1
+Southwest Hills,271136,2014,Arson,
+Southwest Hills,271136,2014,"Assault, Simple",2
+Southwest Hills,271136,2014,Burglary,37
+Southwest Hills,271136,2014,Curfew,
+Southwest Hills,271136,2014,Disorderly Conduct,1
+Southwest Hills,271136,2014,Drugs,2
+Southwest Hills,271136,2014,DUII,3
+Southwest Hills,271136,2014,Embezzlement,
+Southwest Hills,271136,2014,Forgery,
+Southwest Hills,271136,2014,Fraud,6
+Southwest Hills,271136,2014,Gambling,
+Southwest Hills,271136,2014,Homicide,
+Southwest Hills,271136,2014,Kidnap,
+Southwest Hills,271136,2014,Larceny,78
+Southwest Hills,271136,2014,Liquor Laws,1
+Southwest Hills,271136,2014,Motor Vehicle Theft,8
+Southwest Hills,271136,2014,Offenses Against Family,
+Southwest Hills,271136,2014,Prostitution,
+Southwest Hills,271136,2014,Rape,
+Southwest Hills,271136,2014,Robbery,
+Southwest Hills,271136,2014,Runaway,
+Southwest Hills,271136,2014,Sex Offenses,1
+Southwest Hills,271136,2014,Stolen Property,
+Southwest Hills,271136,2014,Trespass,1
+Southwest Hills,271136,2014,Vandalism,11
+Southwest Hills,271136,2014,Weapons,
+Sunderland,271139,2004,Aggravated Assault,1
+Sunderland,271139,2004,Arson,
+Sunderland,271139,2004,"Assault, Simple",3
+Sunderland,271139,2004,Burglary,1
+Sunderland,271139,2004,Curfew,
+Sunderland,271139,2004,Disorderly Conduct,
+Sunderland,271139,2004,Drugs,
+Sunderland,271139,2004,DUII,1
+Sunderland,271139,2004,Embezzlement,
+Sunderland,271139,2004,Forgery,
+Sunderland,271139,2004,Fraud,2
+Sunderland,271139,2004,Gambling,
+Sunderland,271139,2004,Homicide,
+Sunderland,271139,2004,Kidnap,
+Sunderland,271139,2004,Larceny,16
+Sunderland,271139,2004,Liquor Laws,
+Sunderland,271139,2004,Motor Vehicle Theft,1
+Sunderland,271139,2004,Offenses Against Family,
+Sunderland,271139,2004,Prostitution,
+Sunderland,271139,2004,Rape,
+Sunderland,271139,2004,Robbery,
+Sunderland,271139,2004,Runaway,
+Sunderland,271139,2004,Sex Offenses,
+Sunderland,271139,2004,Stolen Property,
+Sunderland,271139,2004,Trespass,
+Sunderland,271139,2004,Vandalism,1
+Sunderland,271139,2004,Weapons,
+Sunderland,271139,2005,Aggravated Assault,1
+Sunderland,271139,2005,Arson,
+Sunderland,271139,2005,"Assault, Simple",5
+Sunderland,271139,2005,Burglary,15
+Sunderland,271139,2005,Curfew,
+Sunderland,271139,2005,Disorderly Conduct,5
+Sunderland,271139,2005,Drugs,4
+Sunderland,271139,2005,DUII,5
+Sunderland,271139,2005,Embezzlement,2
+Sunderland,271139,2005,Forgery,
+Sunderland,271139,2005,Fraud,4
+Sunderland,271139,2005,Gambling,
+Sunderland,271139,2005,Homicide,
+Sunderland,271139,2005,Kidnap,1
+Sunderland,271139,2005,Larceny,70
+Sunderland,271139,2005,Liquor Laws,
+Sunderland,271139,2005,Motor Vehicle Theft,20
+Sunderland,271139,2005,Offenses Against Family,
+Sunderland,271139,2005,Prostitution,
+Sunderland,271139,2005,Rape,
+Sunderland,271139,2005,Robbery,1
+Sunderland,271139,2005,Runaway,
+Sunderland,271139,2005,Sex Offenses,
+Sunderland,271139,2005,Stolen Property,
+Sunderland,271139,2005,Trespass,4
+Sunderland,271139,2005,Vandalism,7
+Sunderland,271139,2005,Weapons,
+Sunderland,271139,2006,Aggravated Assault,1
+Sunderland,271139,2006,Arson,
+Sunderland,271139,2006,"Assault, Simple",1
+Sunderland,271139,2006,Burglary,14
+Sunderland,271139,2006,Curfew,
+Sunderland,271139,2006,Disorderly Conduct,5
+Sunderland,271139,2006,Drugs,3
+Sunderland,271139,2006,DUII,7
+Sunderland,271139,2006,Embezzlement,2
+Sunderland,271139,2006,Forgery,4
+Sunderland,271139,2006,Fraud,3
+Sunderland,271139,2006,Gambling,
+Sunderland,271139,2006,Homicide,1
+Sunderland,271139,2006,Kidnap,
+Sunderland,271139,2006,Larceny,64
+Sunderland,271139,2006,Liquor Laws,
+Sunderland,271139,2006,Motor Vehicle Theft,13
+Sunderland,271139,2006,Offenses Against Family,
+Sunderland,271139,2006,Prostitution,
+Sunderland,271139,2006,Rape,
+Sunderland,271139,2006,Robbery,1
+Sunderland,271139,2006,Runaway,
+Sunderland,271139,2006,Sex Offenses,
+Sunderland,271139,2006,Stolen Property,
+Sunderland,271139,2006,Trespass,
+Sunderland,271139,2006,Vandalism,8
+Sunderland,271139,2006,Weapons,
+Sunderland,271139,2007,Aggravated Assault,7
+Sunderland,271139,2007,Arson,
+Sunderland,271139,2007,"Assault, Simple",3
+Sunderland,271139,2007,Burglary,14
+Sunderland,271139,2007,Curfew,
+Sunderland,271139,2007,Disorderly Conduct,8
+Sunderland,271139,2007,Drugs,3
+Sunderland,271139,2007,DUII,4
+Sunderland,271139,2007,Embezzlement,1
+Sunderland,271139,2007,Forgery,
+Sunderland,271139,2007,Fraud,1
+Sunderland,271139,2007,Gambling,
+Sunderland,271139,2007,Homicide,
+Sunderland,271139,2007,Kidnap,
+Sunderland,271139,2007,Larceny,78
+Sunderland,271139,2007,Liquor Laws,1
+Sunderland,271139,2007,Motor Vehicle Theft,12
+Sunderland,271139,2007,Offenses Against Family,
+Sunderland,271139,2007,Prostitution,
+Sunderland,271139,2007,Rape,
+Sunderland,271139,2007,Robbery,
+Sunderland,271139,2007,Runaway,
+Sunderland,271139,2007,Sex Offenses,
+Sunderland,271139,2007,Stolen Property,
+Sunderland,271139,2007,Trespass,7
+Sunderland,271139,2007,Vandalism,8
+Sunderland,271139,2007,Weapons,1
+Sunderland,271139,2008,Aggravated Assault,9
+Sunderland,271139,2008,Arson,
+Sunderland,271139,2008,"Assault, Simple",4
+Sunderland,271139,2008,Burglary,7
+Sunderland,271139,2008,Curfew,
+Sunderland,271139,2008,Disorderly Conduct,3
+Sunderland,271139,2008,Drugs,3
+Sunderland,271139,2008,DUII,4
+Sunderland,271139,2008,Embezzlement,7
+Sunderland,271139,2008,Forgery,4
+Sunderland,271139,2008,Fraud,7
+Sunderland,271139,2008,Gambling,
+Sunderland,271139,2008,Homicide,
+Sunderland,271139,2008,Kidnap,
+Sunderland,271139,2008,Larceny,131
+Sunderland,271139,2008,Liquor Laws,2
+Sunderland,271139,2008,Motor Vehicle Theft,18
+Sunderland,271139,2008,Offenses Against Family,
+Sunderland,271139,2008,Prostitution,
+Sunderland,271139,2008,Rape,
+Sunderland,271139,2008,Robbery,2
+Sunderland,271139,2008,Runaway,
+Sunderland,271139,2008,Sex Offenses,
+Sunderland,271139,2008,Stolen Property,
+Sunderland,271139,2008,Trespass,4
+Sunderland,271139,2008,Vandalism,9
+Sunderland,271139,2008,Weapons,
+Sunderland,271139,2009,Aggravated Assault,4
+Sunderland,271139,2009,Arson,
+Sunderland,271139,2009,"Assault, Simple",
+Sunderland,271139,2009,Burglary,5
+Sunderland,271139,2009,Curfew,
+Sunderland,271139,2009,Disorderly Conduct,3
+Sunderland,271139,2009,Drugs,
+Sunderland,271139,2009,DUII,3
+Sunderland,271139,2009,Embezzlement,3
+Sunderland,271139,2009,Forgery,9
+Sunderland,271139,2009,Fraud,11
+Sunderland,271139,2009,Gambling,
+Sunderland,271139,2009,Homicide,
+Sunderland,271139,2009,Kidnap,
+Sunderland,271139,2009,Larceny,131
+Sunderland,271139,2009,Liquor Laws,3
+Sunderland,271139,2009,Motor Vehicle Theft,12
+Sunderland,271139,2009,Offenses Against Family,
+Sunderland,271139,2009,Prostitution,2
+Sunderland,271139,2009,Rape,
+Sunderland,271139,2009,Robbery,1
+Sunderland,271139,2009,Runaway,
+Sunderland,271139,2009,Sex Offenses,1
+Sunderland,271139,2009,Stolen Property,
+Sunderland,271139,2009,Trespass,10
+Sunderland,271139,2009,Vandalism,11
+Sunderland,271139,2009,Weapons,
+Sunderland,271139,2010,Aggravated Assault,3
+Sunderland,271139,2010,Arson,
+Sunderland,271139,2010,"Assault, Simple",6
+Sunderland,271139,2010,Burglary,9
+Sunderland,271139,2010,Curfew,
+Sunderland,271139,2010,Disorderly Conduct,4
+Sunderland,271139,2010,Drugs,10
+Sunderland,271139,2010,DUII,6
+Sunderland,271139,2010,Embezzlement,1
+Sunderland,271139,2010,Forgery,5
+Sunderland,271139,2010,Fraud,8
+Sunderland,271139,2010,Gambling,
+Sunderland,271139,2010,Homicide,
+Sunderland,271139,2010,Kidnap,
+Sunderland,271139,2010,Larceny,232
+Sunderland,271139,2010,Liquor Laws,
+Sunderland,271139,2010,Motor Vehicle Theft,14
+Sunderland,271139,2010,Offenses Against Family,
+Sunderland,271139,2010,Prostitution,2
+Sunderland,271139,2010,Rape,
+Sunderland,271139,2010,Robbery,4
+Sunderland,271139,2010,Runaway,
+Sunderland,271139,2010,Sex Offenses,
+Sunderland,271139,2010,Stolen Property,
+Sunderland,271139,2010,Trespass,9
+Sunderland,271139,2010,Vandalism,14
+Sunderland,271139,2010,Weapons,
+Sunderland,271139,2011,Aggravated Assault,6
+Sunderland,271139,2011,Arson,
+Sunderland,271139,2011,"Assault, Simple",4
+Sunderland,271139,2011,Burglary,7
+Sunderland,271139,2011,Curfew,
+Sunderland,271139,2011,Disorderly Conduct,6
+Sunderland,271139,2011,Drugs,6
+Sunderland,271139,2011,DUII,1
+Sunderland,271139,2011,Embezzlement,4
+Sunderland,271139,2011,Forgery,7
+Sunderland,271139,2011,Fraud,8
+Sunderland,271139,2011,Gambling,
+Sunderland,271139,2011,Homicide,
+Sunderland,271139,2011,Kidnap,
+Sunderland,271139,2011,Larceny,218
+Sunderland,271139,2011,Liquor Laws,
+Sunderland,271139,2011,Motor Vehicle Theft,12
+Sunderland,271139,2011,Offenses Against Family,
+Sunderland,271139,2011,Prostitution,
+Sunderland,271139,2011,Rape,
+Sunderland,271139,2011,Robbery,1
+Sunderland,271139,2011,Runaway,
+Sunderland,271139,2011,Sex Offenses,
+Sunderland,271139,2011,Stolen Property,
+Sunderland,271139,2011,Trespass,8
+Sunderland,271139,2011,Vandalism,9
+Sunderland,271139,2011,Weapons,1
+Sunderland,271139,2012,Aggravated Assault,3
+Sunderland,271139,2012,Arson,
+Sunderland,271139,2012,"Assault, Simple",8
+Sunderland,271139,2012,Burglary,8
+Sunderland,271139,2012,Curfew,
+Sunderland,271139,2012,Disorderly Conduct,4
+Sunderland,271139,2012,Drugs,8
+Sunderland,271139,2012,DUII,
+Sunderland,271139,2012,Embezzlement,2
+Sunderland,271139,2012,Forgery,7
+Sunderland,271139,2012,Fraud,15
+Sunderland,271139,2012,Gambling,
+Sunderland,271139,2012,Homicide,
+Sunderland,271139,2012,Kidnap,
+Sunderland,271139,2012,Larceny,193
+Sunderland,271139,2012,Liquor Laws,
+Sunderland,271139,2012,Motor Vehicle Theft,18
+Sunderland,271139,2012,Offenses Against Family,
+Sunderland,271139,2012,Prostitution,1
+Sunderland,271139,2012,Rape,
+Sunderland,271139,2012,Robbery,4
+Sunderland,271139,2012,Runaway,
+Sunderland,271139,2012,Sex Offenses,
+Sunderland,271139,2012,Stolen Property,
+Sunderland,271139,2012,Trespass,5
+Sunderland,271139,2012,Vandalism,14
+Sunderland,271139,2012,Weapons,1
+Sunderland,271139,2013,Aggravated Assault,1
+Sunderland,271139,2013,Arson,
+Sunderland,271139,2013,"Assault, Simple",1
+Sunderland,271139,2013,Burglary,11
+Sunderland,271139,2013,Curfew,
+Sunderland,271139,2013,Disorderly Conduct,4
+Sunderland,271139,2013,Drugs,1
+Sunderland,271139,2013,DUII,6
+Sunderland,271139,2013,Embezzlement,6
+Sunderland,271139,2013,Forgery,8
+Sunderland,271139,2013,Fraud,12
+Sunderland,271139,2013,Gambling,
+Sunderland,271139,2013,Homicide,
+Sunderland,271139,2013,Kidnap,
+Sunderland,271139,2013,Larceny,197
+Sunderland,271139,2013,Liquor Laws,
+Sunderland,271139,2013,Motor Vehicle Theft,12
+Sunderland,271139,2013,Offenses Against Family,
+Sunderland,271139,2013,Prostitution,1
+Sunderland,271139,2013,Rape,
+Sunderland,271139,2013,Robbery,2
+Sunderland,271139,2013,Runaway,
+Sunderland,271139,2013,Sex Offenses,
+Sunderland,271139,2013,Stolen Property,
+Sunderland,271139,2013,Trespass,6
+Sunderland,271139,2013,Vandalism,15
+Sunderland,271139,2013,Weapons,1
+Sunderland,271139,2014,Aggravated Assault,2
+Sunderland,271139,2014,Arson,
+Sunderland,271139,2014,"Assault, Simple",1
+Sunderland,271139,2014,Burglary,4
+Sunderland,271139,2014,Curfew,
+Sunderland,271139,2014,Disorderly Conduct,6
+Sunderland,271139,2014,Drugs,8
+Sunderland,271139,2014,DUII,3
+Sunderland,271139,2014,Embezzlement,2
+Sunderland,271139,2014,Forgery,10
+Sunderland,271139,2014,Fraud,26
+Sunderland,271139,2014,Gambling,
+Sunderland,271139,2014,Homicide,
+Sunderland,271139,2014,Kidnap,
+Sunderland,271139,2014,Larceny,194
+Sunderland,271139,2014,Liquor Laws,
+Sunderland,271139,2014,Motor Vehicle Theft,22
+Sunderland,271139,2014,Offenses Against Family,
+Sunderland,271139,2014,Prostitution,3
+Sunderland,271139,2014,Rape,
+Sunderland,271139,2014,Robbery,1
+Sunderland,271139,2014,Runaway,
+Sunderland,271139,2014,Sex Offenses,
+Sunderland,271139,2014,Stolen Property,
+Sunderland,271139,2014,Trespass,4
+Sunderland,271139,2014,Vandalism,15
+Sunderland,271139,2014,Weapons,1
+Triple Creek,271142,2004,Aggravated Assault,
+Triple Creek,271142,2004,Arson,
+Triple Creek,271142,2004,"Assault, Simple",
+Triple Creek,271142,2004,Burglary,
+Triple Creek,271142,2004,Curfew,
+Triple Creek,271142,2004,Disorderly Conduct,
+Triple Creek,271142,2004,Drugs,
+Triple Creek,271142,2004,DUII,
+Triple Creek,271142,2004,Embezzlement,
+Triple Creek,271142,2004,Forgery,
+Triple Creek,271142,2004,Fraud,
+Triple Creek,271142,2004,Gambling,
+Triple Creek,271142,2004,Homicide,
+Triple Creek,271142,2004,Kidnap,
+Triple Creek,271142,2004,Larceny,
+Triple Creek,271142,2004,Liquor Laws,
+Triple Creek,271142,2004,Motor Vehicle Theft,
+Triple Creek,271142,2004,Offenses Against Family,
+Triple Creek,271142,2004,Prostitution,
+Triple Creek,271142,2004,Rape,
+Triple Creek,271142,2004,Robbery,
+Triple Creek,271142,2004,Runaway,
+Triple Creek,271142,2004,Sex Offenses,
+Triple Creek,271142,2004,Stolen Property,
+Triple Creek,271142,2004,Trespass,
+Triple Creek,271142,2004,Vandalism,
+Triple Creek,271142,2004,Weapons,
+Triple Creek,271142,2005,Aggravated Assault,
+Triple Creek,271142,2005,Arson,
+Triple Creek,271142,2005,"Assault, Simple",
+Triple Creek,271142,2005,Burglary,
+Triple Creek,271142,2005,Curfew,
+Triple Creek,271142,2005,Disorderly Conduct,
+Triple Creek,271142,2005,Drugs,
+Triple Creek,271142,2005,DUII,
+Triple Creek,271142,2005,Embezzlement,
+Triple Creek,271142,2005,Forgery,
+Triple Creek,271142,2005,Fraud,
+Triple Creek,271142,2005,Gambling,
+Triple Creek,271142,2005,Homicide,
+Triple Creek,271142,2005,Kidnap,
+Triple Creek,271142,2005,Larceny,
+Triple Creek,271142,2005,Liquor Laws,
+Triple Creek,271142,2005,Motor Vehicle Theft,
+Triple Creek,271142,2005,Offenses Against Family,
+Triple Creek,271142,2005,Prostitution,
+Triple Creek,271142,2005,Rape,
+Triple Creek,271142,2005,Robbery,
+Triple Creek,271142,2005,Runaway,
+Triple Creek,271142,2005,Sex Offenses,
+Triple Creek,271142,2005,Stolen Property,
+Triple Creek,271142,2005,Trespass,
+Triple Creek,271142,2005,Vandalism,
+Triple Creek,271142,2005,Weapons,
+Triple Creek,271142,2006,Aggravated Assault,
+Triple Creek,271142,2006,Arson,
+Triple Creek,271142,2006,"Assault, Simple",
+Triple Creek,271142,2006,Burglary,
+Triple Creek,271142,2006,Curfew,
+Triple Creek,271142,2006,Disorderly Conduct,
+Triple Creek,271142,2006,Drugs,
+Triple Creek,271142,2006,DUII,
+Triple Creek,271142,2006,Embezzlement,
+Triple Creek,271142,2006,Forgery,
+Triple Creek,271142,2006,Fraud,
+Triple Creek,271142,2006,Gambling,
+Triple Creek,271142,2006,Homicide,
+Triple Creek,271142,2006,Kidnap,
+Triple Creek,271142,2006,Larceny,
+Triple Creek,271142,2006,Liquor Laws,
+Triple Creek,271142,2006,Motor Vehicle Theft,
+Triple Creek,271142,2006,Offenses Against Family,
+Triple Creek,271142,2006,Prostitution,
+Triple Creek,271142,2006,Rape,
+Triple Creek,271142,2006,Robbery,
+Triple Creek,271142,2006,Runaway,
+Triple Creek,271142,2006,Sex Offenses,
+Triple Creek,271142,2006,Stolen Property,
+Triple Creek,271142,2006,Trespass,
+Triple Creek,271142,2006,Vandalism,
+Triple Creek,271142,2006,Weapons,
+Triple Creek,271142,2007,Aggravated Assault,
+Triple Creek,271142,2007,Arson,
+Triple Creek,271142,2007,"Assault, Simple",
+Triple Creek,271142,2007,Burglary,
+Triple Creek,271142,2007,Curfew,
+Triple Creek,271142,2007,Disorderly Conduct,
+Triple Creek,271142,2007,Drugs,
+Triple Creek,271142,2007,DUII,
+Triple Creek,271142,2007,Embezzlement,
+Triple Creek,271142,2007,Forgery,
+Triple Creek,271142,2007,Fraud,
+Triple Creek,271142,2007,Gambling,
+Triple Creek,271142,2007,Homicide,
+Triple Creek,271142,2007,Kidnap,
+Triple Creek,271142,2007,Larceny,
+Triple Creek,271142,2007,Liquor Laws,
+Triple Creek,271142,2007,Motor Vehicle Theft,
+Triple Creek,271142,2007,Offenses Against Family,
+Triple Creek,271142,2007,Prostitution,
+Triple Creek,271142,2007,Rape,
+Triple Creek,271142,2007,Robbery,
+Triple Creek,271142,2007,Runaway,
+Triple Creek,271142,2007,Sex Offenses,
+Triple Creek,271142,2007,Stolen Property,
+Triple Creek,271142,2007,Trespass,
+Triple Creek,271142,2007,Vandalism,
+Triple Creek,271142,2007,Weapons,
+Triple Creek,271142,2008,Aggravated Assault,
+Triple Creek,271142,2008,Arson,
+Triple Creek,271142,2008,"Assault, Simple",
+Triple Creek,271142,2008,Burglary,
+Triple Creek,271142,2008,Curfew,
+Triple Creek,271142,2008,Disorderly Conduct,
+Triple Creek,271142,2008,Drugs,
+Triple Creek,271142,2008,DUII,
+Triple Creek,271142,2008,Embezzlement,
+Triple Creek,271142,2008,Forgery,
+Triple Creek,271142,2008,Fraud,
+Triple Creek,271142,2008,Gambling,
+Triple Creek,271142,2008,Homicide,
+Triple Creek,271142,2008,Kidnap,
+Triple Creek,271142,2008,Larceny,
+Triple Creek,271142,2008,Liquor Laws,
+Triple Creek,271142,2008,Motor Vehicle Theft,
+Triple Creek,271142,2008,Offenses Against Family,
+Triple Creek,271142,2008,Prostitution,
+Triple Creek,271142,2008,Rape,
+Triple Creek,271142,2008,Robbery,
+Triple Creek,271142,2008,Runaway,
+Triple Creek,271142,2008,Sex Offenses,
+Triple Creek,271142,2008,Stolen Property,
+Triple Creek,271142,2008,Trespass,
+Triple Creek,271142,2008,Vandalism,
+Triple Creek,271142,2008,Weapons,
+Triple Creek,271142,2009,Aggravated Assault,
+Triple Creek,271142,2009,Arson,
+Triple Creek,271142,2009,"Assault, Simple",
+Triple Creek,271142,2009,Burglary,
+Triple Creek,271142,2009,Curfew,
+Triple Creek,271142,2009,Disorderly Conduct,
+Triple Creek,271142,2009,Drugs,
+Triple Creek,271142,2009,DUII,
+Triple Creek,271142,2009,Embezzlement,
+Triple Creek,271142,2009,Forgery,
+Triple Creek,271142,2009,Fraud,
+Triple Creek,271142,2009,Gambling,
+Triple Creek,271142,2009,Homicide,
+Triple Creek,271142,2009,Kidnap,
+Triple Creek,271142,2009,Larceny,
+Triple Creek,271142,2009,Liquor Laws,
+Triple Creek,271142,2009,Motor Vehicle Theft,
+Triple Creek,271142,2009,Offenses Against Family,
+Triple Creek,271142,2009,Prostitution,
+Triple Creek,271142,2009,Rape,
+Triple Creek,271142,2009,Robbery,
+Triple Creek,271142,2009,Runaway,
+Triple Creek,271142,2009,Sex Offenses,
+Triple Creek,271142,2009,Stolen Property,
+Triple Creek,271142,2009,Trespass,
+Triple Creek,271142,2009,Vandalism,
+Triple Creek,271142,2009,Weapons,
+Triple Creek,271142,2010,Aggravated Assault,
+Triple Creek,271142,2010,Arson,
+Triple Creek,271142,2010,"Assault, Simple",
+Triple Creek,271142,2010,Burglary,
+Triple Creek,271142,2010,Curfew,
+Triple Creek,271142,2010,Disorderly Conduct,
+Triple Creek,271142,2010,Drugs,
+Triple Creek,271142,2010,DUII,
+Triple Creek,271142,2010,Embezzlement,
+Triple Creek,271142,2010,Forgery,
+Triple Creek,271142,2010,Fraud,
+Triple Creek,271142,2010,Gambling,
+Triple Creek,271142,2010,Homicide,
+Triple Creek,271142,2010,Kidnap,
+Triple Creek,271142,2010,Larceny,
+Triple Creek,271142,2010,Liquor Laws,
+Triple Creek,271142,2010,Motor Vehicle Theft,
+Triple Creek,271142,2010,Offenses Against Family,
+Triple Creek,271142,2010,Prostitution,
+Triple Creek,271142,2010,Rape,
+Triple Creek,271142,2010,Robbery,
+Triple Creek,271142,2010,Runaway,
+Triple Creek,271142,2010,Sex Offenses,
+Triple Creek,271142,2010,Stolen Property,
+Triple Creek,271142,2010,Trespass,
+Triple Creek,271142,2010,Vandalism,
+Triple Creek,271142,2010,Weapons,
+Triple Creek,271142,2011,Aggravated Assault,
+Triple Creek,271142,2011,Arson,
+Triple Creek,271142,2011,"Assault, Simple",
+Triple Creek,271142,2011,Burglary,
+Triple Creek,271142,2011,Curfew,
+Triple Creek,271142,2011,Disorderly Conduct,
+Triple Creek,271142,2011,Drugs,1
+Triple Creek,271142,2011,DUII,
+Triple Creek,271142,2011,Embezzlement,
+Triple Creek,271142,2011,Forgery,
+Triple Creek,271142,2011,Fraud,
+Triple Creek,271142,2011,Gambling,
+Triple Creek,271142,2011,Homicide,
+Triple Creek,271142,2011,Kidnap,
+Triple Creek,271142,2011,Larceny,
+Triple Creek,271142,2011,Liquor Laws,
+Triple Creek,271142,2011,Motor Vehicle Theft,
+Triple Creek,271142,2011,Offenses Against Family,
+Triple Creek,271142,2011,Prostitution,
+Triple Creek,271142,2011,Rape,
+Triple Creek,271142,2011,Robbery,
+Triple Creek,271142,2011,Runaway,
+Triple Creek,271142,2011,Sex Offenses,
+Triple Creek,271142,2011,Stolen Property,
+Triple Creek,271142,2011,Trespass,
+Triple Creek,271142,2011,Vandalism,
+Triple Creek,271142,2011,Weapons,
+Triple Creek,271142,2012,Aggravated Assault,
+Triple Creek,271142,2012,Arson,
+Triple Creek,271142,2012,"Assault, Simple",
+Triple Creek,271142,2012,Burglary,
+Triple Creek,271142,2012,Curfew,
+Triple Creek,271142,2012,Disorderly Conduct,
+Triple Creek,271142,2012,Drugs,
+Triple Creek,271142,2012,DUII,
+Triple Creek,271142,2012,Embezzlement,
+Triple Creek,271142,2012,Forgery,
+Triple Creek,271142,2012,Fraud,
+Triple Creek,271142,2012,Gambling,
+Triple Creek,271142,2012,Homicide,
+Triple Creek,271142,2012,Kidnap,
+Triple Creek,271142,2012,Larceny,
+Triple Creek,271142,2012,Liquor Laws,
+Triple Creek,271142,2012,Motor Vehicle Theft,
+Triple Creek,271142,2012,Offenses Against Family,
+Triple Creek,271142,2012,Prostitution,
+Triple Creek,271142,2012,Rape,
+Triple Creek,271142,2012,Robbery,
+Triple Creek,271142,2012,Runaway,
+Triple Creek,271142,2012,Sex Offenses,
+Triple Creek,271142,2012,Stolen Property,
+Triple Creek,271142,2012,Trespass,
+Triple Creek,271142,2012,Vandalism,
+Triple Creek,271142,2012,Weapons,
+Triple Creek,271142,2013,Aggravated Assault,
+Triple Creek,271142,2013,Arson,
+Triple Creek,271142,2013,"Assault, Simple",
+Triple Creek,271142,2013,Burglary,
+Triple Creek,271142,2013,Curfew,
+Triple Creek,271142,2013,Disorderly Conduct,
+Triple Creek,271142,2013,Drugs,
+Triple Creek,271142,2013,DUII,
+Triple Creek,271142,2013,Embezzlement,
+Triple Creek,271142,2013,Forgery,
+Triple Creek,271142,2013,Fraud,
+Triple Creek,271142,2013,Gambling,
+Triple Creek,271142,2013,Homicide,
+Triple Creek,271142,2013,Kidnap,
+Triple Creek,271142,2013,Larceny,
+Triple Creek,271142,2013,Liquor Laws,
+Triple Creek,271142,2013,Motor Vehicle Theft,
+Triple Creek,271142,2013,Offenses Against Family,
+Triple Creek,271142,2013,Prostitution,
+Triple Creek,271142,2013,Rape,
+Triple Creek,271142,2013,Robbery,
+Triple Creek,271142,2013,Runaway,
+Triple Creek,271142,2013,Sex Offenses,
+Triple Creek,271142,2013,Stolen Property,
+Triple Creek,271142,2013,Trespass,
+Triple Creek,271142,2013,Vandalism,
+Triple Creek,271142,2013,Weapons,
+Triple Creek,271142,2014,Aggravated Assault,
+Triple Creek,271142,2014,Arson,
+Triple Creek,271142,2014,"Assault, Simple",
+Triple Creek,271142,2014,Burglary,
+Triple Creek,271142,2014,Curfew,
+Triple Creek,271142,2014,Disorderly Conduct,
+Triple Creek,271142,2014,Drugs,
+Triple Creek,271142,2014,DUII,
+Triple Creek,271142,2014,Embezzlement,
+Triple Creek,271142,2014,Forgery,
+Triple Creek,271142,2014,Fraud,
+Triple Creek,271142,2014,Gambling,
+Triple Creek,271142,2014,Homicide,
+Triple Creek,271142,2014,Kidnap,
+Triple Creek,271142,2014,Larceny,
+Triple Creek,271142,2014,Liquor Laws,
+Triple Creek,271142,2014,Motor Vehicle Theft,
+Triple Creek,271142,2014,Offenses Against Family,
+Triple Creek,271142,2014,Prostitution,
+Triple Creek,271142,2014,Rape,
+Triple Creek,271142,2014,Robbery,
+Triple Creek,271142,2014,Runaway,
+Triple Creek,271142,2014,Sex Offenses,
+Triple Creek,271142,2014,Stolen Property,
+Triple Creek,271142,2014,Trespass,
+Triple Creek,271142,2014,Vandalism,
+Triple Creek,271142,2014,Weapons,
+University Park,207639,2004,Aggravated Assault,2
+University Park,207639,2004,Arson,
+University Park,207639,2004,"Assault, Simple",1
+University Park,207639,2004,Burglary,8
+University Park,207639,2004,Curfew,
+University Park,207639,2004,Disorderly Conduct,1
+University Park,207639,2004,Drugs,1
+University Park,207639,2004,DUII,7
+University Park,207639,2004,Embezzlement,
+University Park,207639,2004,Forgery,1
+University Park,207639,2004,Fraud,2
+University Park,207639,2004,Gambling,
+University Park,207639,2004,Homicide,
+University Park,207639,2004,Kidnap,
+University Park,207639,2004,Larceny,51
+University Park,207639,2004,Liquor Laws,3
+University Park,207639,2004,Motor Vehicle Theft,6
+University Park,207639,2004,Offenses Against Family,
+University Park,207639,2004,Prostitution,
+University Park,207639,2004,Rape,
+University Park,207639,2004,Robbery,3
+University Park,207639,2004,Runaway,
+University Park,207639,2004,Sex Offenses,1
+University Park,207639,2004,Stolen Property,
+University Park,207639,2004,Trespass,3
+University Park,207639,2004,Vandalism,13
+University Park,207639,2004,Weapons,
+University Park,207639,2005,Aggravated Assault,9
+University Park,207639,2005,Arson,2
+University Park,207639,2005,"Assault, Simple",19
+University Park,207639,2005,Burglary,42
+University Park,207639,2005,Curfew,
+University Park,207639,2005,Disorderly Conduct,9
+University Park,207639,2005,Drugs,7
+University Park,207639,2005,DUII,26
+University Park,207639,2005,Embezzlement,
+University Park,207639,2005,Forgery,11
+University Park,207639,2005,Fraud,21
+University Park,207639,2005,Gambling,
+University Park,207639,2005,Homicide,
+University Park,207639,2005,Kidnap,
+University Park,207639,2005,Larceny,165
+University Park,207639,2005,Liquor Laws,8
+University Park,207639,2005,Motor Vehicle Theft,48
+University Park,207639,2005,Offenses Against Family,
+University Park,207639,2005,Prostitution,
+University Park,207639,2005,Rape,1
+University Park,207639,2005,Robbery,9
+University Park,207639,2005,Runaway,
+University Park,207639,2005,Sex Offenses,
+University Park,207639,2005,Stolen Property,
+University Park,207639,2005,Trespass,7
+University Park,207639,2005,Vandalism,48
+University Park,207639,2005,Weapons,1
+University Park,207639,2006,Aggravated Assault,8
+University Park,207639,2006,Arson,2
+University Park,207639,2006,"Assault, Simple",18
+University Park,207639,2006,Burglary,22
+University Park,207639,2006,Curfew,1
+University Park,207639,2006,Disorderly Conduct,12
+University Park,207639,2006,Drugs,8
+University Park,207639,2006,DUII,22
+University Park,207639,2006,Embezzlement,
+University Park,207639,2006,Forgery,10
+University Park,207639,2006,Fraud,13
+University Park,207639,2006,Gambling,
+University Park,207639,2006,Homicide,
+University Park,207639,2006,Kidnap,1
+University Park,207639,2006,Larceny,161
+University Park,207639,2006,Liquor Laws,4
+University Park,207639,2006,Motor Vehicle Theft,26
+University Park,207639,2006,Offenses Against Family,
+University Park,207639,2006,Prostitution,
+University Park,207639,2006,Rape,
+University Park,207639,2006,Robbery,7
+University Park,207639,2006,Runaway,
+University Park,207639,2006,Sex Offenses,
+University Park,207639,2006,Stolen Property,1
+University Park,207639,2006,Trespass,18
+University Park,207639,2006,Vandalism,37
+University Park,207639,2006,Weapons,
+University Park,207639,2007,Aggravated Assault,10
+University Park,207639,2007,Arson,
+University Park,207639,2007,"Assault, Simple",19
+University Park,207639,2007,Burglary,34
+University Park,207639,2007,Curfew,3
+University Park,207639,2007,Disorderly Conduct,12
+University Park,207639,2007,Drugs,6
+University Park,207639,2007,DUII,18
+University Park,207639,2007,Embezzlement,1
+University Park,207639,2007,Forgery,3
+University Park,207639,2007,Fraud,11
+University Park,207639,2007,Gambling,
+University Park,207639,2007,Homicide,
+University Park,207639,2007,Kidnap,
+University Park,207639,2007,Larceny,92
+University Park,207639,2007,Liquor Laws,11
+University Park,207639,2007,Motor Vehicle Theft,39
+University Park,207639,2007,Offenses Against Family,
+University Park,207639,2007,Prostitution,
+University Park,207639,2007,Rape,
+University Park,207639,2007,Robbery,9
+University Park,207639,2007,Runaway,
+University Park,207639,2007,Sex Offenses,
+University Park,207639,2007,Stolen Property,
+University Park,207639,2007,Trespass,6
+University Park,207639,2007,Vandalism,54
+University Park,207639,2007,Weapons,2
+University Park,207639,2008,Aggravated Assault,11
+University Park,207639,2008,Arson,
+University Park,207639,2008,"Assault, Simple",12
+University Park,207639,2008,Burglary,26
+University Park,207639,2008,Curfew,
+University Park,207639,2008,Disorderly Conduct,16
+University Park,207639,2008,Drugs,6
+University Park,207639,2008,DUII,13
+University Park,207639,2008,Embezzlement,1
+University Park,207639,2008,Forgery,3
+University Park,207639,2008,Fraud,15
+University Park,207639,2008,Gambling,
+University Park,207639,2008,Homicide,
+University Park,207639,2008,Kidnap,
+University Park,207639,2008,Larceny,132
+University Park,207639,2008,Liquor Laws,2
+University Park,207639,2008,Motor Vehicle Theft,25
+University Park,207639,2008,Offenses Against Family,
+University Park,207639,2008,Prostitution,
+University Park,207639,2008,Rape,
+University Park,207639,2008,Robbery,9
+University Park,207639,2008,Runaway,
+University Park,207639,2008,Sex Offenses,
+University Park,207639,2008,Stolen Property,
+University Park,207639,2008,Trespass,7
+University Park,207639,2008,Vandalism,47
+University Park,207639,2008,Weapons,1
+University Park,207639,2009,Aggravated Assault,7
+University Park,207639,2009,Arson,3
+University Park,207639,2009,"Assault, Simple",6
+University Park,207639,2009,Burglary,53
+University Park,207639,2009,Curfew,1
+University Park,207639,2009,Disorderly Conduct,13
+University Park,207639,2009,Drugs,7
+University Park,207639,2009,DUII,9
+University Park,207639,2009,Embezzlement,
+University Park,207639,2009,Forgery,3
+University Park,207639,2009,Fraud,6
+University Park,207639,2009,Gambling,
+University Park,207639,2009,Homicide,1
+University Park,207639,2009,Kidnap,
+University Park,207639,2009,Larceny,156
+University Park,207639,2009,Liquor Laws,5
+University Park,207639,2009,Motor Vehicle Theft,50
+University Park,207639,2009,Offenses Against Family,
+University Park,207639,2009,Prostitution,
+University Park,207639,2009,Rape,
+University Park,207639,2009,Robbery,6
+University Park,207639,2009,Runaway,
+University Park,207639,2009,Sex Offenses,1
+University Park,207639,2009,Stolen Property,
+University Park,207639,2009,Trespass,10
+University Park,207639,2009,Vandalism,41
+University Park,207639,2009,Weapons,1
+University Park,207639,2010,Aggravated Assault,9
+University Park,207639,2010,Arson,3
+University Park,207639,2010,"Assault, Simple",10
+University Park,207639,2010,Burglary,60
+University Park,207639,2010,Curfew,1
+University Park,207639,2010,Disorderly Conduct,16
+University Park,207639,2010,Drugs,10
+University Park,207639,2010,DUII,17
+University Park,207639,2010,Embezzlement,1
+University Park,207639,2010,Forgery,
+University Park,207639,2010,Fraud,6
+University Park,207639,2010,Gambling,
+University Park,207639,2010,Homicide,
+University Park,207639,2010,Kidnap,
+University Park,207639,2010,Larceny,165
+University Park,207639,2010,Liquor Laws,6
+University Park,207639,2010,Motor Vehicle Theft,27
+University Park,207639,2010,Offenses Against Family,
+University Park,207639,2010,Prostitution,
+University Park,207639,2010,Rape,
+University Park,207639,2010,Robbery,10
+University Park,207639,2010,Runaway,
+University Park,207639,2010,Sex Offenses,
+University Park,207639,2010,Stolen Property,
+University Park,207639,2010,Trespass,13
+University Park,207639,2010,Vandalism,53
+University Park,207639,2010,Weapons,3
+University Park,207639,2011,Aggravated Assault,13
+University Park,207639,2011,Arson,
+University Park,207639,2011,"Assault, Simple",14
+University Park,207639,2011,Burglary,39
+University Park,207639,2011,Curfew,
+University Park,207639,2011,Disorderly Conduct,21
+University Park,207639,2011,Drugs,3
+University Park,207639,2011,DUII,12
+University Park,207639,2011,Embezzlement,
+University Park,207639,2011,Forgery,
+University Park,207639,2011,Fraud,4
+University Park,207639,2011,Gambling,
+University Park,207639,2011,Homicide,
+University Park,207639,2011,Kidnap,1
+University Park,207639,2011,Larceny,140
+University Park,207639,2011,Liquor Laws,6
+University Park,207639,2011,Motor Vehicle Theft,27
+University Park,207639,2011,Offenses Against Family,
+University Park,207639,2011,Prostitution,
+University Park,207639,2011,Rape,
+University Park,207639,2011,Robbery,6
+University Park,207639,2011,Runaway,
+University Park,207639,2011,Sex Offenses,1
+University Park,207639,2011,Stolen Property,1
+University Park,207639,2011,Trespass,12
+University Park,207639,2011,Vandalism,29
+University Park,207639,2011,Weapons,1
+University Park,207639,2012,Aggravated Assault,1
+University Park,207639,2012,Arson,
+University Park,207639,2012,"Assault, Simple",11
+University Park,207639,2012,Burglary,43
+University Park,207639,2012,Curfew,
+University Park,207639,2012,Disorderly Conduct,13
+University Park,207639,2012,Drugs,11
+University Park,207639,2012,DUII,8
+University Park,207639,2012,Embezzlement,1
+University Park,207639,2012,Forgery,1
+University Park,207639,2012,Fraud,4
+University Park,207639,2012,Gambling,
+University Park,207639,2012,Homicide,
+University Park,207639,2012,Kidnap,
+University Park,207639,2012,Larceny,192
+University Park,207639,2012,Liquor Laws,2
+University Park,207639,2012,Motor Vehicle Theft,33
+University Park,207639,2012,Offenses Against Family,
+University Park,207639,2012,Prostitution,
+University Park,207639,2012,Rape,
+University Park,207639,2012,Robbery,5
+University Park,207639,2012,Runaway,
+University Park,207639,2012,Sex Offenses,
+University Park,207639,2012,Stolen Property,1
+University Park,207639,2012,Trespass,13
+University Park,207639,2012,Vandalism,41
+University Park,207639,2012,Weapons,
+University Park,207639,2013,Aggravated Assault,13
+University Park,207639,2013,Arson,1
+University Park,207639,2013,"Assault, Simple",8
+University Park,207639,2013,Burglary,64
+University Park,207639,2013,Curfew,
+University Park,207639,2013,Disorderly Conduct,15
+University Park,207639,2013,Drugs,7
+University Park,207639,2013,DUII,7
+University Park,207639,2013,Embezzlement,
+University Park,207639,2013,Forgery,4
+University Park,207639,2013,Fraud,7
+University Park,207639,2013,Gambling,
+University Park,207639,2013,Homicide,
+University Park,207639,2013,Kidnap,
+University Park,207639,2013,Larceny,137
+University Park,207639,2013,Liquor Laws,5
+University Park,207639,2013,Motor Vehicle Theft,42
+University Park,207639,2013,Offenses Against Family,
+University Park,207639,2013,Prostitution,
+University Park,207639,2013,Rape,2
+University Park,207639,2013,Robbery,3
+University Park,207639,2013,Runaway,1
+University Park,207639,2013,Sex Offenses,3
+University Park,207639,2013,Stolen Property,1
+University Park,207639,2013,Trespass,14
+University Park,207639,2013,Vandalism,22
+University Park,207639,2013,Weapons,1
+University Park,207639,2014,Aggravated Assault,7
+University Park,207639,2014,Arson,
+University Park,207639,2014,"Assault, Simple",8
+University Park,207639,2014,Burglary,40
+University Park,207639,2014,Curfew,
+University Park,207639,2014,Disorderly Conduct,12
+University Park,207639,2014,Drugs,9
+University Park,207639,2014,DUII,20
+University Park,207639,2014,Embezzlement,
+University Park,207639,2014,Forgery,1
+University Park,207639,2014,Fraud,12
+University Park,207639,2014,Gambling,
+University Park,207639,2014,Homicide,
+University Park,207639,2014,Kidnap,
+University Park,207639,2014,Larceny,145
+University Park,207639,2014,Liquor Laws,2
+University Park,207639,2014,Motor Vehicle Theft,26
+University Park,207639,2014,Offenses Against Family,
+University Park,207639,2014,Prostitution,
+University Park,207639,2014,Rape,
+University Park,207639,2014,Robbery,7
+University Park,207639,2014,Runaway,
+University Park,207639,2014,Sex Offenses,1
+University Park,207639,2014,Stolen Property,2
+University Park,207639,2014,Trespass,15
+University Park,207639,2014,Vandalism,22
+University Park,207639,2014,Weapons,2
+Vose,275899,2004,Aggravated Assault,
+Vose,275899,2004,Arson,
+Vose,275899,2004,"Assault, Simple",
+Vose,275899,2004,Burglary,
+Vose,275899,2004,Curfew,
+Vose,275899,2004,Disorderly Conduct,
+Vose,275899,2004,Drugs,
+Vose,275899,2004,DUII,
+Vose,275899,2004,Embezzlement,
+Vose,275899,2004,Forgery,
+Vose,275899,2004,Fraud,
+Vose,275899,2004,Gambling,
+Vose,275899,2004,Homicide,
+Vose,275899,2004,Kidnap,
+Vose,275899,2004,Larceny,
+Vose,275899,2004,Liquor Laws,
+Vose,275899,2004,Motor Vehicle Theft,
+Vose,275899,2004,Offenses Against Family,
+Vose,275899,2004,Prostitution,
+Vose,275899,2004,Rape,
+Vose,275899,2004,Robbery,
+Vose,275899,2004,Runaway,
+Vose,275899,2004,Sex Offenses,
+Vose,275899,2004,Stolen Property,
+Vose,275899,2004,Trespass,
+Vose,275899,2004,Vandalism,
+Vose,275899,2004,Weapons,
+Vose,275899,2005,Aggravated Assault,
+Vose,275899,2005,Arson,
+Vose,275899,2005,"Assault, Simple",
+Vose,275899,2005,Burglary,
+Vose,275899,2005,Curfew,
+Vose,275899,2005,Disorderly Conduct,
+Vose,275899,2005,Drugs,
+Vose,275899,2005,DUII,
+Vose,275899,2005,Embezzlement,
+Vose,275899,2005,Forgery,
+Vose,275899,2005,Fraud,
+Vose,275899,2005,Gambling,
+Vose,275899,2005,Homicide,
+Vose,275899,2005,Kidnap,
+Vose,275899,2005,Larceny,
+Vose,275899,2005,Liquor Laws,
+Vose,275899,2005,Motor Vehicle Theft,
+Vose,275899,2005,Offenses Against Family,
+Vose,275899,2005,Prostitution,
+Vose,275899,2005,Rape,
+Vose,275899,2005,Robbery,
+Vose,275899,2005,Runaway,
+Vose,275899,2005,Sex Offenses,
+Vose,275899,2005,Stolen Property,
+Vose,275899,2005,Trespass,
+Vose,275899,2005,Vandalism,
+Vose,275899,2005,Weapons,
+Vose,275899,2006,Aggravated Assault,
+Vose,275899,2006,Arson,
+Vose,275899,2006,"Assault, Simple",
+Vose,275899,2006,Burglary,
+Vose,275899,2006,Curfew,
+Vose,275899,2006,Disorderly Conduct,
+Vose,275899,2006,Drugs,
+Vose,275899,2006,DUII,
+Vose,275899,2006,Embezzlement,
+Vose,275899,2006,Forgery,
+Vose,275899,2006,Fraud,
+Vose,275899,2006,Gambling,
+Vose,275899,2006,Homicide,
+Vose,275899,2006,Kidnap,
+Vose,275899,2006,Larceny,
+Vose,275899,2006,Liquor Laws,
+Vose,275899,2006,Motor Vehicle Theft,
+Vose,275899,2006,Offenses Against Family,
+Vose,275899,2006,Prostitution,
+Vose,275899,2006,Rape,
+Vose,275899,2006,Robbery,
+Vose,275899,2006,Runaway,
+Vose,275899,2006,Sex Offenses,
+Vose,275899,2006,Stolen Property,
+Vose,275899,2006,Trespass,
+Vose,275899,2006,Vandalism,
+Vose,275899,2006,Weapons,
+Vose,275899,2007,Aggravated Assault,
+Vose,275899,2007,Arson,
+Vose,275899,2007,"Assault, Simple",
+Vose,275899,2007,Burglary,
+Vose,275899,2007,Curfew,
+Vose,275899,2007,Disorderly Conduct,
+Vose,275899,2007,Drugs,
+Vose,275899,2007,DUII,
+Vose,275899,2007,Embezzlement,
+Vose,275899,2007,Forgery,
+Vose,275899,2007,Fraud,
+Vose,275899,2007,Gambling,
+Vose,275899,2007,Homicide,
+Vose,275899,2007,Kidnap,
+Vose,275899,2007,Larceny,1
+Vose,275899,2007,Liquor Laws,
+Vose,275899,2007,Motor Vehicle Theft,
+Vose,275899,2007,Offenses Against Family,
+Vose,275899,2007,Prostitution,
+Vose,275899,2007,Rape,
+Vose,275899,2007,Robbery,
+Vose,275899,2007,Runaway,
+Vose,275899,2007,Sex Offenses,
+Vose,275899,2007,Stolen Property,
+Vose,275899,2007,Trespass,
+Vose,275899,2007,Vandalism,
+Vose,275899,2007,Weapons,
+Vose,275899,2008,Aggravated Assault,
+Vose,275899,2008,Arson,
+Vose,275899,2008,"Assault, Simple",
+Vose,275899,2008,Burglary,
+Vose,275899,2008,Curfew,
+Vose,275899,2008,Disorderly Conduct,
+Vose,275899,2008,Drugs,
+Vose,275899,2008,DUII,
+Vose,275899,2008,Embezzlement,
+Vose,275899,2008,Forgery,
+Vose,275899,2008,Fraud,
+Vose,275899,2008,Gambling,
+Vose,275899,2008,Homicide,
+Vose,275899,2008,Kidnap,
+Vose,275899,2008,Larceny,
+Vose,275899,2008,Liquor Laws,
+Vose,275899,2008,Motor Vehicle Theft,
+Vose,275899,2008,Offenses Against Family,
+Vose,275899,2008,Prostitution,
+Vose,275899,2008,Rape,
+Vose,275899,2008,Robbery,
+Vose,275899,2008,Runaway,
+Vose,275899,2008,Sex Offenses,
+Vose,275899,2008,Stolen Property,
+Vose,275899,2008,Trespass,
+Vose,275899,2008,Vandalism,
+Vose,275899,2008,Weapons,
+Vose,275899,2009,Aggravated Assault,
+Vose,275899,2009,Arson,
+Vose,275899,2009,"Assault, Simple",
+Vose,275899,2009,Burglary,
+Vose,275899,2009,Curfew,
+Vose,275899,2009,Disorderly Conduct,
+Vose,275899,2009,Drugs,
+Vose,275899,2009,DUII,
+Vose,275899,2009,Embezzlement,
+Vose,275899,2009,Forgery,
+Vose,275899,2009,Fraud,
+Vose,275899,2009,Gambling,
+Vose,275899,2009,Homicide,
+Vose,275899,2009,Kidnap,
+Vose,275899,2009,Larceny,
+Vose,275899,2009,Liquor Laws,
+Vose,275899,2009,Motor Vehicle Theft,
+Vose,275899,2009,Offenses Against Family,
+Vose,275899,2009,Prostitution,
+Vose,275899,2009,Rape,
+Vose,275899,2009,Robbery,
+Vose,275899,2009,Runaway,
+Vose,275899,2009,Sex Offenses,
+Vose,275899,2009,Stolen Property,
+Vose,275899,2009,Trespass,
+Vose,275899,2009,Vandalism,
+Vose,275899,2009,Weapons,
+Vose,275899,2010,Aggravated Assault,
+Vose,275899,2010,Arson,
+Vose,275899,2010,"Assault, Simple",
+Vose,275899,2010,Burglary,
+Vose,275899,2010,Curfew,
+Vose,275899,2010,Disorderly Conduct,
+Vose,275899,2010,Drugs,
+Vose,275899,2010,DUII,
+Vose,275899,2010,Embezzlement,
+Vose,275899,2010,Forgery,
+Vose,275899,2010,Fraud,
+Vose,275899,2010,Gambling,
+Vose,275899,2010,Homicide,
+Vose,275899,2010,Kidnap,
+Vose,275899,2010,Larceny,
+Vose,275899,2010,Liquor Laws,
+Vose,275899,2010,Motor Vehicle Theft,
+Vose,275899,2010,Offenses Against Family,
+Vose,275899,2010,Prostitution,
+Vose,275899,2010,Rape,
+Vose,275899,2010,Robbery,
+Vose,275899,2010,Runaway,
+Vose,275899,2010,Sex Offenses,
+Vose,275899,2010,Stolen Property,
+Vose,275899,2010,Trespass,
+Vose,275899,2010,Vandalism,
+Vose,275899,2010,Weapons,
+Vose,275899,2011,Aggravated Assault,
+Vose,275899,2011,Arson,
+Vose,275899,2011,"Assault, Simple",
+Vose,275899,2011,Burglary,
+Vose,275899,2011,Curfew,
+Vose,275899,2011,Disorderly Conduct,
+Vose,275899,2011,Drugs,
+Vose,275899,2011,DUII,
+Vose,275899,2011,Embezzlement,
+Vose,275899,2011,Forgery,
+Vose,275899,2011,Fraud,
+Vose,275899,2011,Gambling,
+Vose,275899,2011,Homicide,
+Vose,275899,2011,Kidnap,
+Vose,275899,2011,Larceny,
+Vose,275899,2011,Liquor Laws,
+Vose,275899,2011,Motor Vehicle Theft,
+Vose,275899,2011,Offenses Against Family,
+Vose,275899,2011,Prostitution,
+Vose,275899,2011,Rape,
+Vose,275899,2011,Robbery,
+Vose,275899,2011,Runaway,
+Vose,275899,2011,Sex Offenses,
+Vose,275899,2011,Stolen Property,
+Vose,275899,2011,Trespass,
+Vose,275899,2011,Vandalism,
+Vose,275899,2011,Weapons,
+Vose,275899,2012,Aggravated Assault,
+Vose,275899,2012,Arson,
+Vose,275899,2012,"Assault, Simple",
+Vose,275899,2012,Burglary,
+Vose,275899,2012,Curfew,
+Vose,275899,2012,Disorderly Conduct,
+Vose,275899,2012,Drugs,
+Vose,275899,2012,DUII,
+Vose,275899,2012,Embezzlement,
+Vose,275899,2012,Forgery,
+Vose,275899,2012,Fraud,
+Vose,275899,2012,Gambling,
+Vose,275899,2012,Homicide,
+Vose,275899,2012,Kidnap,
+Vose,275899,2012,Larceny,
+Vose,275899,2012,Liquor Laws,
+Vose,275899,2012,Motor Vehicle Theft,
+Vose,275899,2012,Offenses Against Family,
+Vose,275899,2012,Prostitution,
+Vose,275899,2012,Rape,
+Vose,275899,2012,Robbery,
+Vose,275899,2012,Runaway,
+Vose,275899,2012,Sex Offenses,
+Vose,275899,2012,Stolen Property,
+Vose,275899,2012,Trespass,
+Vose,275899,2012,Vandalism,
+Vose,275899,2012,Weapons,
+Vose,275899,2013,Aggravated Assault,
+Vose,275899,2013,Arson,
+Vose,275899,2013,"Assault, Simple",
+Vose,275899,2013,Burglary,
+Vose,275899,2013,Curfew,
+Vose,275899,2013,Disorderly Conduct,
+Vose,275899,2013,Drugs,
+Vose,275899,2013,DUII,
+Vose,275899,2013,Embezzlement,
+Vose,275899,2013,Forgery,
+Vose,275899,2013,Fraud,
+Vose,275899,2013,Gambling,
+Vose,275899,2013,Homicide,
+Vose,275899,2013,Kidnap,
+Vose,275899,2013,Larceny,
+Vose,275899,2013,Liquor Laws,
+Vose,275899,2013,Motor Vehicle Theft,
+Vose,275899,2013,Offenses Against Family,
+Vose,275899,2013,Prostitution,
+Vose,275899,2013,Rape,
+Vose,275899,2013,Robbery,
+Vose,275899,2013,Runaway,
+Vose,275899,2013,Sex Offenses,
+Vose,275899,2013,Stolen Property,
+Vose,275899,2013,Trespass,
+Vose,275899,2013,Vandalism,
+Vose,275899,2013,Weapons,
+Vose,275899,2014,Aggravated Assault,
+Vose,275899,2014,Arson,
+Vose,275899,2014,"Assault, Simple",
+Vose,275899,2014,Burglary,
+Vose,275899,2014,Curfew,
+Vose,275899,2014,Disorderly Conduct,
+Vose,275899,2014,Drugs,
+Vose,275899,2014,DUII,
+Vose,275899,2014,Embezzlement,
+Vose,275899,2014,Forgery,
+Vose,275899,2014,Fraud,
+Vose,275899,2014,Gambling,
+Vose,275899,2014,Homicide,
+Vose,275899,2014,Kidnap,
+Vose,275899,2014,Larceny,
+Vose,275899,2014,Liquor Laws,
+Vose,275899,2014,Motor Vehicle Theft,
+Vose,275899,2014,Offenses Against Family,
+Vose,275899,2014,Prostitution,
+Vose,275899,2014,Rape,
+Vose,275899,2014,Robbery,
+Vose,275899,2014,Runaway,
+Vose,275899,2014,Sex Offenses,
+Vose,275899,2014,Stolen Property,
+Vose,275899,2014,Trespass,
+Vose,275899,2014,Vandalism,
+Vose,275899,2014,Weapons,
+West Beaverton,271146,2004,Aggravated Assault,
+West Beaverton,271146,2004,Arson,
+West Beaverton,271146,2004,"Assault, Simple",
+West Beaverton,271146,2004,Burglary,
+West Beaverton,271146,2004,Curfew,
+West Beaverton,271146,2004,Disorderly Conduct,
+West Beaverton,271146,2004,Drugs,
+West Beaverton,271146,2004,DUII,
+West Beaverton,271146,2004,Embezzlement,
+West Beaverton,271146,2004,Forgery,
+West Beaverton,271146,2004,Fraud,
+West Beaverton,271146,2004,Gambling,
+West Beaverton,271146,2004,Homicide,
+West Beaverton,271146,2004,Kidnap,
+West Beaverton,271146,2004,Larceny,
+West Beaverton,271146,2004,Liquor Laws,
+West Beaverton,271146,2004,Motor Vehicle Theft,
+West Beaverton,271146,2004,Offenses Against Family,
+West Beaverton,271146,2004,Prostitution,
+West Beaverton,271146,2004,Rape,
+West Beaverton,271146,2004,Robbery,
+West Beaverton,271146,2004,Runaway,
+West Beaverton,271146,2004,Sex Offenses,
+West Beaverton,271146,2004,Stolen Property,
+West Beaverton,271146,2004,Trespass,
+West Beaverton,271146,2004,Vandalism,
+West Beaverton,271146,2004,Weapons,
+West Beaverton,271146,2005,Aggravated Assault,
+West Beaverton,271146,2005,Arson,
+West Beaverton,271146,2005,"Assault, Simple",
+West Beaverton,271146,2005,Burglary,
+West Beaverton,271146,2005,Curfew,
+West Beaverton,271146,2005,Disorderly Conduct,
+West Beaverton,271146,2005,Drugs,
+West Beaverton,271146,2005,DUII,
+West Beaverton,271146,2005,Embezzlement,
+West Beaverton,271146,2005,Forgery,
+West Beaverton,271146,2005,Fraud,
+West Beaverton,271146,2005,Gambling,
+West Beaverton,271146,2005,Homicide,
+West Beaverton,271146,2005,Kidnap,
+West Beaverton,271146,2005,Larceny,
+West Beaverton,271146,2005,Liquor Laws,
+West Beaverton,271146,2005,Motor Vehicle Theft,
+West Beaverton,271146,2005,Offenses Against Family,
+West Beaverton,271146,2005,Prostitution,
+West Beaverton,271146,2005,Rape,
+West Beaverton,271146,2005,Robbery,
+West Beaverton,271146,2005,Runaway,
+West Beaverton,271146,2005,Sex Offenses,
+West Beaverton,271146,2005,Stolen Property,
+West Beaverton,271146,2005,Trespass,
+West Beaverton,271146,2005,Vandalism,
+West Beaverton,271146,2005,Weapons,
+West Beaverton,271146,2006,Aggravated Assault,
+West Beaverton,271146,2006,Arson,
+West Beaverton,271146,2006,"Assault, Simple",
+West Beaverton,271146,2006,Burglary,
+West Beaverton,271146,2006,Curfew,
+West Beaverton,271146,2006,Disorderly Conduct,
+West Beaverton,271146,2006,Drugs,
+West Beaverton,271146,2006,DUII,
+West Beaverton,271146,2006,Embezzlement,
+West Beaverton,271146,2006,Forgery,
+West Beaverton,271146,2006,Fraud,
+West Beaverton,271146,2006,Gambling,
+West Beaverton,271146,2006,Homicide,
+West Beaverton,271146,2006,Kidnap,
+West Beaverton,271146,2006,Larceny,
+West Beaverton,271146,2006,Liquor Laws,
+West Beaverton,271146,2006,Motor Vehicle Theft,
+West Beaverton,271146,2006,Offenses Against Family,
+West Beaverton,271146,2006,Prostitution,
+West Beaverton,271146,2006,Rape,
+West Beaverton,271146,2006,Robbery,
+West Beaverton,271146,2006,Runaway,
+West Beaverton,271146,2006,Sex Offenses,
+West Beaverton,271146,2006,Stolen Property,
+West Beaverton,271146,2006,Trespass,
+West Beaverton,271146,2006,Vandalism,
+West Beaverton,271146,2006,Weapons,
+West Beaverton,271146,2007,Aggravated Assault,
+West Beaverton,271146,2007,Arson,
+West Beaverton,271146,2007,"Assault, Simple",
+West Beaverton,271146,2007,Burglary,
+West Beaverton,271146,2007,Curfew,
+West Beaverton,271146,2007,Disorderly Conduct,
+West Beaverton,271146,2007,Drugs,
+West Beaverton,271146,2007,DUII,
+West Beaverton,271146,2007,Embezzlement,
+West Beaverton,271146,2007,Forgery,
+West Beaverton,271146,2007,Fraud,
+West Beaverton,271146,2007,Gambling,
+West Beaverton,271146,2007,Homicide,
+West Beaverton,271146,2007,Kidnap,
+West Beaverton,271146,2007,Larceny,
+West Beaverton,271146,2007,Liquor Laws,
+West Beaverton,271146,2007,Motor Vehicle Theft,
+West Beaverton,271146,2007,Offenses Against Family,
+West Beaverton,271146,2007,Prostitution,
+West Beaverton,271146,2007,Rape,
+West Beaverton,271146,2007,Robbery,
+West Beaverton,271146,2007,Runaway,
+West Beaverton,271146,2007,Sex Offenses,
+West Beaverton,271146,2007,Stolen Property,
+West Beaverton,271146,2007,Trespass,
+West Beaverton,271146,2007,Vandalism,
+West Beaverton,271146,2007,Weapons,
+West Beaverton,271146,2008,Aggravated Assault,
+West Beaverton,271146,2008,Arson,
+West Beaverton,271146,2008,"Assault, Simple",
+West Beaverton,271146,2008,Burglary,
+West Beaverton,271146,2008,Curfew,
+West Beaverton,271146,2008,Disorderly Conduct,
+West Beaverton,271146,2008,Drugs,
+West Beaverton,271146,2008,DUII,
+West Beaverton,271146,2008,Embezzlement,
+West Beaverton,271146,2008,Forgery,
+West Beaverton,271146,2008,Fraud,
+West Beaverton,271146,2008,Gambling,
+West Beaverton,271146,2008,Homicide,
+West Beaverton,271146,2008,Kidnap,
+West Beaverton,271146,2008,Larceny,
+West Beaverton,271146,2008,Liquor Laws,
+West Beaverton,271146,2008,Motor Vehicle Theft,
+West Beaverton,271146,2008,Offenses Against Family,
+West Beaverton,271146,2008,Prostitution,
+West Beaverton,271146,2008,Rape,
+West Beaverton,271146,2008,Robbery,
+West Beaverton,271146,2008,Runaway,
+West Beaverton,271146,2008,Sex Offenses,
+West Beaverton,271146,2008,Stolen Property,
+West Beaverton,271146,2008,Trespass,
+West Beaverton,271146,2008,Vandalism,
+West Beaverton,271146,2008,Weapons,
+West Beaverton,271146,2009,Aggravated Assault,
+West Beaverton,271146,2009,Arson,
+West Beaverton,271146,2009,"Assault, Simple",
+West Beaverton,271146,2009,Burglary,
+West Beaverton,271146,2009,Curfew,
+West Beaverton,271146,2009,Disorderly Conduct,
+West Beaverton,271146,2009,Drugs,
+West Beaverton,271146,2009,DUII,
+West Beaverton,271146,2009,Embezzlement,
+West Beaverton,271146,2009,Forgery,
+West Beaverton,271146,2009,Fraud,
+West Beaverton,271146,2009,Gambling,
+West Beaverton,271146,2009,Homicide,
+West Beaverton,271146,2009,Kidnap,
+West Beaverton,271146,2009,Larceny,
+West Beaverton,271146,2009,Liquor Laws,
+West Beaverton,271146,2009,Motor Vehicle Theft,
+West Beaverton,271146,2009,Offenses Against Family,
+West Beaverton,271146,2009,Prostitution,
+West Beaverton,271146,2009,Rape,
+West Beaverton,271146,2009,Robbery,
+West Beaverton,271146,2009,Runaway,
+West Beaverton,271146,2009,Sex Offenses,
+West Beaverton,271146,2009,Stolen Property,
+West Beaverton,271146,2009,Trespass,
+West Beaverton,271146,2009,Vandalism,
+West Beaverton,271146,2009,Weapons,
+West Beaverton,271146,2010,Aggravated Assault,
+West Beaverton,271146,2010,Arson,
+West Beaverton,271146,2010,"Assault, Simple",
+West Beaverton,271146,2010,Burglary,
+West Beaverton,271146,2010,Curfew,
+West Beaverton,271146,2010,Disorderly Conduct,
+West Beaverton,271146,2010,Drugs,
+West Beaverton,271146,2010,DUII,
+West Beaverton,271146,2010,Embezzlement,
+West Beaverton,271146,2010,Forgery,
+West Beaverton,271146,2010,Fraud,
+West Beaverton,271146,2010,Gambling,
+West Beaverton,271146,2010,Homicide,
+West Beaverton,271146,2010,Kidnap,
+West Beaverton,271146,2010,Larceny,
+West Beaverton,271146,2010,Liquor Laws,
+West Beaverton,271146,2010,Motor Vehicle Theft,
+West Beaverton,271146,2010,Offenses Against Family,
+West Beaverton,271146,2010,Prostitution,
+West Beaverton,271146,2010,Rape,
+West Beaverton,271146,2010,Robbery,
+West Beaverton,271146,2010,Runaway,
+West Beaverton,271146,2010,Sex Offenses,
+West Beaverton,271146,2010,Stolen Property,
+West Beaverton,271146,2010,Trespass,
+West Beaverton,271146,2010,Vandalism,
+West Beaverton,271146,2010,Weapons,
+West Beaverton,271146,2011,Aggravated Assault,
+West Beaverton,271146,2011,Arson,
+West Beaverton,271146,2011,"Assault, Simple",
+West Beaverton,271146,2011,Burglary,
+West Beaverton,271146,2011,Curfew,
+West Beaverton,271146,2011,Disorderly Conduct,
+West Beaverton,271146,2011,Drugs,
+West Beaverton,271146,2011,DUII,
+West Beaverton,271146,2011,Embezzlement,
+West Beaverton,271146,2011,Forgery,
+West Beaverton,271146,2011,Fraud,
+West Beaverton,271146,2011,Gambling,
+West Beaverton,271146,2011,Homicide,
+West Beaverton,271146,2011,Kidnap,
+West Beaverton,271146,2011,Larceny,
+West Beaverton,271146,2011,Liquor Laws,
+West Beaverton,271146,2011,Motor Vehicle Theft,
+West Beaverton,271146,2011,Offenses Against Family,
+West Beaverton,271146,2011,Prostitution,
+West Beaverton,271146,2011,Rape,
+West Beaverton,271146,2011,Robbery,
+West Beaverton,271146,2011,Runaway,
+West Beaverton,271146,2011,Sex Offenses,
+West Beaverton,271146,2011,Stolen Property,
+West Beaverton,271146,2011,Trespass,
+West Beaverton,271146,2011,Vandalism,
+West Beaverton,271146,2011,Weapons,
+West Beaverton,271146,2012,Aggravated Assault,
+West Beaverton,271146,2012,Arson,
+West Beaverton,271146,2012,"Assault, Simple",
+West Beaverton,271146,2012,Burglary,
+West Beaverton,271146,2012,Curfew,
+West Beaverton,271146,2012,Disorderly Conduct,
+West Beaverton,271146,2012,Drugs,
+West Beaverton,271146,2012,DUII,
+West Beaverton,271146,2012,Embezzlement,
+West Beaverton,271146,2012,Forgery,
+West Beaverton,271146,2012,Fraud,
+West Beaverton,271146,2012,Gambling,
+West Beaverton,271146,2012,Homicide,
+West Beaverton,271146,2012,Kidnap,
+West Beaverton,271146,2012,Larceny,
+West Beaverton,271146,2012,Liquor Laws,
+West Beaverton,271146,2012,Motor Vehicle Theft,
+West Beaverton,271146,2012,Offenses Against Family,
+West Beaverton,271146,2012,Prostitution,
+West Beaverton,271146,2012,Rape,
+West Beaverton,271146,2012,Robbery,
+West Beaverton,271146,2012,Runaway,
+West Beaverton,271146,2012,Sex Offenses,
+West Beaverton,271146,2012,Stolen Property,
+West Beaverton,271146,2012,Trespass,
+West Beaverton,271146,2012,Vandalism,
+West Beaverton,271146,2012,Weapons,
+West Beaverton,271146,2013,Aggravated Assault,
+West Beaverton,271146,2013,Arson,
+West Beaverton,271146,2013,"Assault, Simple",
+West Beaverton,271146,2013,Burglary,
+West Beaverton,271146,2013,Curfew,
+West Beaverton,271146,2013,Disorderly Conduct,
+West Beaverton,271146,2013,Drugs,
+West Beaverton,271146,2013,DUII,
+West Beaverton,271146,2013,Embezzlement,
+West Beaverton,271146,2013,Forgery,
+West Beaverton,271146,2013,Fraud,
+West Beaverton,271146,2013,Gambling,
+West Beaverton,271146,2013,Homicide,
+West Beaverton,271146,2013,Kidnap,
+West Beaverton,271146,2013,Larceny,
+West Beaverton,271146,2013,Liquor Laws,
+West Beaverton,271146,2013,Motor Vehicle Theft,
+West Beaverton,271146,2013,Offenses Against Family,
+West Beaverton,271146,2013,Prostitution,
+West Beaverton,271146,2013,Rape,
+West Beaverton,271146,2013,Robbery,
+West Beaverton,271146,2013,Runaway,
+West Beaverton,271146,2013,Sex Offenses,
+West Beaverton,271146,2013,Stolen Property,
+West Beaverton,271146,2013,Trespass,
+West Beaverton,271146,2013,Vandalism,
+West Beaverton,271146,2013,Weapons,
+West Beaverton,271146,2014,Aggravated Assault,
+West Beaverton,271146,2014,Arson,
+West Beaverton,271146,2014,"Assault, Simple",
+West Beaverton,271146,2014,Burglary,
+West Beaverton,271146,2014,Curfew,
+West Beaverton,271146,2014,Disorderly Conduct,
+West Beaverton,271146,2014,Drugs,
+West Beaverton,271146,2014,DUII,
+West Beaverton,271146,2014,Embezzlement,
+West Beaverton,271146,2014,Forgery,
+West Beaverton,271146,2014,Fraud,1
+West Beaverton,271146,2014,Gambling,
+West Beaverton,271146,2014,Homicide,
+West Beaverton,271146,2014,Kidnap,
+West Beaverton,271146,2014,Larceny,
+West Beaverton,271146,2014,Liquor Laws,
+West Beaverton,271146,2014,Motor Vehicle Theft,
+West Beaverton,271146,2014,Offenses Against Family,
+West Beaverton,271146,2014,Prostitution,
+West Beaverton,271146,2014,Rape,
+West Beaverton,271146,2014,Robbery,
+West Beaverton,271146,2014,Runaway,
+West Beaverton,271146,2014,Sex Offenses,
+West Beaverton,271146,2014,Stolen Property,
+West Beaverton,271146,2014,Trespass,
+West Beaverton,271146,2014,Vandalism,
+West Beaverton,271146,2014,Weapons,
+West Slope,275992,2004,Aggravated Assault,
+West Slope,275992,2004,Arson,
+West Slope,275992,2004,"Assault, Simple",
+West Slope,275992,2004,Burglary,
+West Slope,275992,2004,Curfew,
+West Slope,275992,2004,Disorderly Conduct,
+West Slope,275992,2004,Drugs,
+West Slope,275992,2004,DUII,
+West Slope,275992,2004,Embezzlement,
+West Slope,275992,2004,Forgery,
+West Slope,275992,2004,Fraud,
+West Slope,275992,2004,Gambling,
+West Slope,275992,2004,Homicide,
+West Slope,275992,2004,Kidnap,
+West Slope,275992,2004,Larceny,
+West Slope,275992,2004,Liquor Laws,
+West Slope,275992,2004,Motor Vehicle Theft,
+West Slope,275992,2004,Offenses Against Family,
+West Slope,275992,2004,Prostitution,
+West Slope,275992,2004,Rape,
+West Slope,275992,2004,Robbery,
+West Slope,275992,2004,Runaway,
+West Slope,275992,2004,Sex Offenses,
+West Slope,275992,2004,Stolen Property,
+West Slope,275992,2004,Trespass,
+West Slope,275992,2004,Vandalism,
+West Slope,275992,2004,Weapons,
+West Slope,275992,2005,Aggravated Assault,
+West Slope,275992,2005,Arson,
+West Slope,275992,2005,"Assault, Simple",
+West Slope,275992,2005,Burglary,
+West Slope,275992,2005,Curfew,
+West Slope,275992,2005,Disorderly Conduct,
+West Slope,275992,2005,Drugs,
+West Slope,275992,2005,DUII,
+West Slope,275992,2005,Embezzlement,
+West Slope,275992,2005,Forgery,
+West Slope,275992,2005,Fraud,
+West Slope,275992,2005,Gambling,
+West Slope,275992,2005,Homicide,
+West Slope,275992,2005,Kidnap,
+West Slope,275992,2005,Larceny,
+West Slope,275992,2005,Liquor Laws,
+West Slope,275992,2005,Motor Vehicle Theft,
+West Slope,275992,2005,Offenses Against Family,
+West Slope,275992,2005,Prostitution,
+West Slope,275992,2005,Rape,
+West Slope,275992,2005,Robbery,
+West Slope,275992,2005,Runaway,
+West Slope,275992,2005,Sex Offenses,
+West Slope,275992,2005,Stolen Property,
+West Slope,275992,2005,Trespass,
+West Slope,275992,2005,Vandalism,
+West Slope,275992,2005,Weapons,
+West Slope,275992,2006,Aggravated Assault,
+West Slope,275992,2006,Arson,
+West Slope,275992,2006,"Assault, Simple",
+West Slope,275992,2006,Burglary,
+West Slope,275992,2006,Curfew,
+West Slope,275992,2006,Disorderly Conduct,
+West Slope,275992,2006,Drugs,
+West Slope,275992,2006,DUII,
+West Slope,275992,2006,Embezzlement,
+West Slope,275992,2006,Forgery,
+West Slope,275992,2006,Fraud,
+West Slope,275992,2006,Gambling,
+West Slope,275992,2006,Homicide,
+West Slope,275992,2006,Kidnap,
+West Slope,275992,2006,Larceny,
+West Slope,275992,2006,Liquor Laws,
+West Slope,275992,2006,Motor Vehicle Theft,
+West Slope,275992,2006,Offenses Against Family,
+West Slope,275992,2006,Prostitution,
+West Slope,275992,2006,Rape,
+West Slope,275992,2006,Robbery,
+West Slope,275992,2006,Runaway,
+West Slope,275992,2006,Sex Offenses,
+West Slope,275992,2006,Stolen Property,
+West Slope,275992,2006,Trespass,
+West Slope,275992,2006,Vandalism,
+West Slope,275992,2006,Weapons,
+West Slope,275992,2007,Aggravated Assault,
+West Slope,275992,2007,Arson,
+West Slope,275992,2007,"Assault, Simple",
+West Slope,275992,2007,Burglary,
+West Slope,275992,2007,Curfew,
+West Slope,275992,2007,Disorderly Conduct,
+West Slope,275992,2007,Drugs,
+West Slope,275992,2007,DUII,
+West Slope,275992,2007,Embezzlement,
+West Slope,275992,2007,Forgery,
+West Slope,275992,2007,Fraud,
+West Slope,275992,2007,Gambling,
+West Slope,275992,2007,Homicide,
+West Slope,275992,2007,Kidnap,
+West Slope,275992,2007,Larceny,
+West Slope,275992,2007,Liquor Laws,
+West Slope,275992,2007,Motor Vehicle Theft,
+West Slope,275992,2007,Offenses Against Family,
+West Slope,275992,2007,Prostitution,
+West Slope,275992,2007,Rape,
+West Slope,275992,2007,Robbery,
+West Slope,275992,2007,Runaway,
+West Slope,275992,2007,Sex Offenses,
+West Slope,275992,2007,Stolen Property,
+West Slope,275992,2007,Trespass,
+West Slope,275992,2007,Vandalism,
+West Slope,275992,2007,Weapons,
+West Slope,275992,2008,Aggravated Assault,
+West Slope,275992,2008,Arson,
+West Slope,275992,2008,"Assault, Simple",
+West Slope,275992,2008,Burglary,
+West Slope,275992,2008,Curfew,
+West Slope,275992,2008,Disorderly Conduct,
+West Slope,275992,2008,Drugs,
+West Slope,275992,2008,DUII,
+West Slope,275992,2008,Embezzlement,
+West Slope,275992,2008,Forgery,
+West Slope,275992,2008,Fraud,
+West Slope,275992,2008,Gambling,
+West Slope,275992,2008,Homicide,
+West Slope,275992,2008,Kidnap,
+West Slope,275992,2008,Larceny,
+West Slope,275992,2008,Liquor Laws,
+West Slope,275992,2008,Motor Vehicle Theft,
+West Slope,275992,2008,Offenses Against Family,
+West Slope,275992,2008,Prostitution,
+West Slope,275992,2008,Rape,
+West Slope,275992,2008,Robbery,
+West Slope,275992,2008,Runaway,
+West Slope,275992,2008,Sex Offenses,
+West Slope,275992,2008,Stolen Property,
+West Slope,275992,2008,Trespass,
+West Slope,275992,2008,Vandalism,
+West Slope,275992,2008,Weapons,
+West Slope,275992,2009,Aggravated Assault,
+West Slope,275992,2009,Arson,
+West Slope,275992,2009,"Assault, Simple",
+West Slope,275992,2009,Burglary,
+West Slope,275992,2009,Curfew,
+West Slope,275992,2009,Disorderly Conduct,
+West Slope,275992,2009,Drugs,
+West Slope,275992,2009,DUII,
+West Slope,275992,2009,Embezzlement,
+West Slope,275992,2009,Forgery,
+West Slope,275992,2009,Fraud,
+West Slope,275992,2009,Gambling,
+West Slope,275992,2009,Homicide,
+West Slope,275992,2009,Kidnap,
+West Slope,275992,2009,Larceny,
+West Slope,275992,2009,Liquor Laws,
+West Slope,275992,2009,Motor Vehicle Theft,
+West Slope,275992,2009,Offenses Against Family,
+West Slope,275992,2009,Prostitution,
+West Slope,275992,2009,Rape,
+West Slope,275992,2009,Robbery,
+West Slope,275992,2009,Runaway,
+West Slope,275992,2009,Sex Offenses,
+West Slope,275992,2009,Stolen Property,
+West Slope,275992,2009,Trespass,
+West Slope,275992,2009,Vandalism,
+West Slope,275992,2009,Weapons,
+West Slope,275992,2010,Aggravated Assault,
+West Slope,275992,2010,Arson,
+West Slope,275992,2010,"Assault, Simple",
+West Slope,275992,2010,Burglary,
+West Slope,275992,2010,Curfew,
+West Slope,275992,2010,Disorderly Conduct,
+West Slope,275992,2010,Drugs,
+West Slope,275992,2010,DUII,
+West Slope,275992,2010,Embezzlement,
+West Slope,275992,2010,Forgery,
+West Slope,275992,2010,Fraud,
+West Slope,275992,2010,Gambling,
+West Slope,275992,2010,Homicide,
+West Slope,275992,2010,Kidnap,
+West Slope,275992,2010,Larceny,2
+West Slope,275992,2010,Liquor Laws,
+West Slope,275992,2010,Motor Vehicle Theft,
+West Slope,275992,2010,Offenses Against Family,
+West Slope,275992,2010,Prostitution,
+West Slope,275992,2010,Rape,
+West Slope,275992,2010,Robbery,
+West Slope,275992,2010,Runaway,
+West Slope,275992,2010,Sex Offenses,
+West Slope,275992,2010,Stolen Property,
+West Slope,275992,2010,Trespass,
+West Slope,275992,2010,Vandalism,
+West Slope,275992,2010,Weapons,
+West Slope,275992,2011,Aggravated Assault,
+West Slope,275992,2011,Arson,
+West Slope,275992,2011,"Assault, Simple",
+West Slope,275992,2011,Burglary,
+West Slope,275992,2011,Curfew,
+West Slope,275992,2011,Disorderly Conduct,1
+West Slope,275992,2011,Drugs,
+West Slope,275992,2011,DUII,
+West Slope,275992,2011,Embezzlement,
+West Slope,275992,2011,Forgery,
+West Slope,275992,2011,Fraud,
+West Slope,275992,2011,Gambling,
+West Slope,275992,2011,Homicide,
+West Slope,275992,2011,Kidnap,
+West Slope,275992,2011,Larceny,
+West Slope,275992,2011,Liquor Laws,
+West Slope,275992,2011,Motor Vehicle Theft,
+West Slope,275992,2011,Offenses Against Family,
+West Slope,275992,2011,Prostitution,
+West Slope,275992,2011,Rape,
+West Slope,275992,2011,Robbery,
+West Slope,275992,2011,Runaway,
+West Slope,275992,2011,Sex Offenses,
+West Slope,275992,2011,Stolen Property,
+West Slope,275992,2011,Trespass,
+West Slope,275992,2011,Vandalism,
+West Slope,275992,2011,Weapons,
+West Slope,275992,2012,Aggravated Assault,
+West Slope,275992,2012,Arson,
+West Slope,275992,2012,"Assault, Simple",
+West Slope,275992,2012,Burglary,
+West Slope,275992,2012,Curfew,
+West Slope,275992,2012,Disorderly Conduct,
+West Slope,275992,2012,Drugs,
+West Slope,275992,2012,DUII,2
+West Slope,275992,2012,Embezzlement,
+West Slope,275992,2012,Forgery,
+West Slope,275992,2012,Fraud,
+West Slope,275992,2012,Gambling,
+West Slope,275992,2012,Homicide,
+West Slope,275992,2012,Kidnap,
+West Slope,275992,2012,Larceny,
+West Slope,275992,2012,Liquor Laws,
+West Slope,275992,2012,Motor Vehicle Theft,
+West Slope,275992,2012,Offenses Against Family,
+West Slope,275992,2012,Prostitution,
+West Slope,275992,2012,Rape,
+West Slope,275992,2012,Robbery,
+West Slope,275992,2012,Runaway,
+West Slope,275992,2012,Sex Offenses,
+West Slope,275992,2012,Stolen Property,
+West Slope,275992,2012,Trespass,
+West Slope,275992,2012,Vandalism,
+West Slope,275992,2012,Weapons,
+West Slope,275992,2013,Aggravated Assault,
+West Slope,275992,2013,Arson,
+West Slope,275992,2013,"Assault, Simple",
+West Slope,275992,2013,Burglary,
+West Slope,275992,2013,Curfew,
+West Slope,275992,2013,Disorderly Conduct,
+West Slope,275992,2013,Drugs,
+West Slope,275992,2013,DUII,
+West Slope,275992,2013,Embezzlement,
+West Slope,275992,2013,Forgery,
+West Slope,275992,2013,Fraud,
+West Slope,275992,2013,Gambling,
+West Slope,275992,2013,Homicide,
+West Slope,275992,2013,Kidnap,
+West Slope,275992,2013,Larceny,
+West Slope,275992,2013,Liquor Laws,
+West Slope,275992,2013,Motor Vehicle Theft,
+West Slope,275992,2013,Offenses Against Family,
+West Slope,275992,2013,Prostitution,
+West Slope,275992,2013,Rape,
+West Slope,275992,2013,Robbery,
+West Slope,275992,2013,Runaway,
+West Slope,275992,2013,Sex Offenses,
+West Slope,275992,2013,Stolen Property,
+West Slope,275992,2013,Trespass,
+West Slope,275992,2013,Vandalism,
+West Slope,275992,2013,Weapons,
+West Slope,275992,2014,Aggravated Assault,
+West Slope,275992,2014,Arson,
+West Slope,275992,2014,"Assault, Simple",
+West Slope,275992,2014,Burglary,
+West Slope,275992,2014,Curfew,
+West Slope,275992,2014,Disorderly Conduct,1
+West Slope,275992,2014,Drugs,
+West Slope,275992,2014,DUII,1
+West Slope,275992,2014,Embezzlement,
+West Slope,275992,2014,Forgery,
+West Slope,275992,2014,Fraud,
+West Slope,275992,2014,Gambling,
+West Slope,275992,2014,Homicide,
+West Slope,275992,2014,Kidnap,
+West Slope,275992,2014,Larceny,
+West Slope,275992,2014,Liquor Laws,
+West Slope,275992,2014,Motor Vehicle Theft,
+West Slope,275992,2014,Offenses Against Family,
+West Slope,275992,2014,Prostitution,
+West Slope,275992,2014,Rape,
+West Slope,275992,2014,Robbery,
+West Slope,275992,2014,Runaway,
+West Slope,275992,2014,Sex Offenses,
+West Slope,275992,2014,Stolen Property,
+West Slope,275992,2014,Trespass,
+West Slope,275992,2014,Vandalism,
+West Slope,275992,2014,Weapons,
+Wilkes,271150,2004,Aggravated Assault,2
+Wilkes,271150,2004,Arson,2
+Wilkes,271150,2004,"Assault, Simple",3
+Wilkes,271150,2004,Burglary,20
+Wilkes,271150,2004,Curfew,
+Wilkes,271150,2004,Disorderly Conduct,4
+Wilkes,271150,2004,Drugs,1
+Wilkes,271150,2004,DUII,2
+Wilkes,271150,2004,Embezzlement,
+Wilkes,271150,2004,Forgery,
+Wilkes,271150,2004,Fraud,2
+Wilkes,271150,2004,Gambling,
+Wilkes,271150,2004,Homicide,
+Wilkes,271150,2004,Kidnap,
+Wilkes,271150,2004,Larceny,45
+Wilkes,271150,2004,Liquor Laws,
+Wilkes,271150,2004,Motor Vehicle Theft,12
+Wilkes,271150,2004,Offenses Against Family,
+Wilkes,271150,2004,Prostitution,
+Wilkes,271150,2004,Rape,
+Wilkes,271150,2004,Robbery,5
+Wilkes,271150,2004,Runaway,
+Wilkes,271150,2004,Sex Offenses,
+Wilkes,271150,2004,Stolen Property,
+Wilkes,271150,2004,Trespass,5
+Wilkes,271150,2004,Vandalism,10
+Wilkes,271150,2004,Weapons,
+Wilkes,271150,2005,Aggravated Assault,17
+Wilkes,271150,2005,Arson,
+Wilkes,271150,2005,"Assault, Simple",22
+Wilkes,271150,2005,Burglary,114
+Wilkes,271150,2005,Curfew,1
+Wilkes,271150,2005,Disorderly Conduct,22
+Wilkes,271150,2005,Drugs,22
+Wilkes,271150,2005,DUII,9
+Wilkes,271150,2005,Embezzlement,
+Wilkes,271150,2005,Forgery,16
+Wilkes,271150,2005,Fraud,19
+Wilkes,271150,2005,Gambling,
+Wilkes,271150,2005,Homicide,
+Wilkes,271150,2005,Kidnap,1
+Wilkes,271150,2005,Larceny,273
+Wilkes,271150,2005,Liquor Laws,4
+Wilkes,271150,2005,Motor Vehicle Theft,109
+Wilkes,271150,2005,Offenses Against Family,
+Wilkes,271150,2005,Prostitution,
+Wilkes,271150,2005,Rape,
+Wilkes,271150,2005,Robbery,8
+Wilkes,271150,2005,Runaway,
+Wilkes,271150,2005,Sex Offenses,
+Wilkes,271150,2005,Stolen Property,1
+Wilkes,271150,2005,Trespass,26
+Wilkes,271150,2005,Vandalism,81
+Wilkes,271150,2005,Weapons,6
+Wilkes,271150,2006,Aggravated Assault,18
+Wilkes,271150,2006,Arson,
+Wilkes,271150,2006,"Assault, Simple",26
+Wilkes,271150,2006,Burglary,70
+Wilkes,271150,2006,Curfew,
+Wilkes,271150,2006,Disorderly Conduct,15
+Wilkes,271150,2006,Drugs,19
+Wilkes,271150,2006,DUII,17
+Wilkes,271150,2006,Embezzlement,2
+Wilkes,271150,2006,Forgery,24
+Wilkes,271150,2006,Fraud,25
+Wilkes,271150,2006,Gambling,
+Wilkes,271150,2006,Homicide,3
+Wilkes,271150,2006,Kidnap,1
+Wilkes,271150,2006,Larceny,190
+Wilkes,271150,2006,Liquor Laws,
+Wilkes,271150,2006,Motor Vehicle Theft,86
+Wilkes,271150,2006,Offenses Against Family,
+Wilkes,271150,2006,Prostitution,
+Wilkes,271150,2006,Rape,
+Wilkes,271150,2006,Robbery,6
+Wilkes,271150,2006,Runaway,
+Wilkes,271150,2006,Sex Offenses,
+Wilkes,271150,2006,Stolen Property,
+Wilkes,271150,2006,Trespass,20
+Wilkes,271150,2006,Vandalism,71
+Wilkes,271150,2006,Weapons,5
+Wilkes,271150,2007,Aggravated Assault,14
+Wilkes,271150,2007,Arson,
+Wilkes,271150,2007,"Assault, Simple",29
+Wilkes,271150,2007,Burglary,73
+Wilkes,271150,2007,Curfew,
+Wilkes,271150,2007,Disorderly Conduct,23
+Wilkes,271150,2007,Drugs,19
+Wilkes,271150,2007,DUII,21
+Wilkes,271150,2007,Embezzlement,2
+Wilkes,271150,2007,Forgery,5
+Wilkes,271150,2007,Fraud,33
+Wilkes,271150,2007,Gambling,
+Wilkes,271150,2007,Homicide,
+Wilkes,271150,2007,Kidnap,2
+Wilkes,271150,2007,Larceny,193
+Wilkes,271150,2007,Liquor Laws,3
+Wilkes,271150,2007,Motor Vehicle Theft,61
+Wilkes,271150,2007,Offenses Against Family,
+Wilkes,271150,2007,Prostitution,
+Wilkes,271150,2007,Rape,
+Wilkes,271150,2007,Robbery,6
+Wilkes,271150,2007,Runaway,
+Wilkes,271150,2007,Sex Offenses,
+Wilkes,271150,2007,Stolen Property,
+Wilkes,271150,2007,Trespass,27
+Wilkes,271150,2007,Vandalism,74
+Wilkes,271150,2007,Weapons,2
+Wilkes,271150,2008,Aggravated Assault,16
+Wilkes,271150,2008,Arson,
+Wilkes,271150,2008,"Assault, Simple",30
+Wilkes,271150,2008,Burglary,74
+Wilkes,271150,2008,Curfew,
+Wilkes,271150,2008,Disorderly Conduct,30
+Wilkes,271150,2008,Drugs,12
+Wilkes,271150,2008,DUII,11
+Wilkes,271150,2008,Embezzlement,2
+Wilkes,271150,2008,Forgery,3
+Wilkes,271150,2008,Fraud,19
+Wilkes,271150,2008,Gambling,
+Wilkes,271150,2008,Homicide,
+Wilkes,271150,2008,Kidnap,
+Wilkes,271150,2008,Larceny,209
+Wilkes,271150,2008,Liquor Laws,5
+Wilkes,271150,2008,Motor Vehicle Theft,78
+Wilkes,271150,2008,Offenses Against Family,
+Wilkes,271150,2008,Prostitution,2
+Wilkes,271150,2008,Rape,
+Wilkes,271150,2008,Robbery,11
+Wilkes,271150,2008,Runaway,
+Wilkes,271150,2008,Sex Offenses,
+Wilkes,271150,2008,Stolen Property,1
+Wilkes,271150,2008,Trespass,22
+Wilkes,271150,2008,Vandalism,53
+Wilkes,271150,2008,Weapons,2
+Wilkes,271150,2009,Aggravated Assault,24
+Wilkes,271150,2009,Arson,
+Wilkes,271150,2009,"Assault, Simple",19
+Wilkes,271150,2009,Burglary,50
+Wilkes,271150,2009,Curfew,1
+Wilkes,271150,2009,Disorderly Conduct,23
+Wilkes,271150,2009,Drugs,16
+Wilkes,271150,2009,DUII,8
+Wilkes,271150,2009,Embezzlement,1
+Wilkes,271150,2009,Forgery,2
+Wilkes,271150,2009,Fraud,18
+Wilkes,271150,2009,Gambling,
+Wilkes,271150,2009,Homicide,1
+Wilkes,271150,2009,Kidnap,
+Wilkes,271150,2009,Larceny,174
+Wilkes,271150,2009,Liquor Laws,1
+Wilkes,271150,2009,Motor Vehicle Theft,61
+Wilkes,271150,2009,Offenses Against Family,1
+Wilkes,271150,2009,Prostitution,
+Wilkes,271150,2009,Rape,1
+Wilkes,271150,2009,Robbery,13
+Wilkes,271150,2009,Runaway,1
+Wilkes,271150,2009,Sex Offenses,
+Wilkes,271150,2009,Stolen Property,1
+Wilkes,271150,2009,Trespass,17
+Wilkes,271150,2009,Vandalism,69
+Wilkes,271150,2009,Weapons,3
+Wilkes,271150,2010,Aggravated Assault,15
+Wilkes,271150,2010,Arson,1
+Wilkes,271150,2010,"Assault, Simple",25
+Wilkes,271150,2010,Burglary,57
+Wilkes,271150,2010,Curfew,1
+Wilkes,271150,2010,Disorderly Conduct,26
+Wilkes,271150,2010,Drugs,10
+Wilkes,271150,2010,DUII,10
+Wilkes,271150,2010,Embezzlement,1
+Wilkes,271150,2010,Forgery,4
+Wilkes,271150,2010,Fraud,30
+Wilkes,271150,2010,Gambling,
+Wilkes,271150,2010,Homicide,
+Wilkes,271150,2010,Kidnap,1
+Wilkes,271150,2010,Larceny,180
+Wilkes,271150,2010,Liquor Laws,1
+Wilkes,271150,2010,Motor Vehicle Theft,66
+Wilkes,271150,2010,Offenses Against Family,
+Wilkes,271150,2010,Prostitution,
+Wilkes,271150,2010,Rape,
+Wilkes,271150,2010,Robbery,15
+Wilkes,271150,2010,Runaway,
+Wilkes,271150,2010,Sex Offenses,1
+Wilkes,271150,2010,Stolen Property,1
+Wilkes,271150,2010,Trespass,28
+Wilkes,271150,2010,Vandalism,89
+Wilkes,271150,2010,Weapons,5
+Wilkes,271150,2011,Aggravated Assault,19
+Wilkes,271150,2011,Arson,
+Wilkes,271150,2011,"Assault, Simple",11
+Wilkes,271150,2011,Burglary,71
+Wilkes,271150,2011,Curfew,
+Wilkes,271150,2011,Disorderly Conduct,12
+Wilkes,271150,2011,Drugs,13
+Wilkes,271150,2011,DUII,15
+Wilkes,271150,2011,Embezzlement,
+Wilkes,271150,2011,Forgery,5
+Wilkes,271150,2011,Fraud,29
+Wilkes,271150,2011,Gambling,
+Wilkes,271150,2011,Homicide,
+Wilkes,271150,2011,Kidnap,1
+Wilkes,271150,2011,Larceny,205
+Wilkes,271150,2011,Liquor Laws,2
+Wilkes,271150,2011,Motor Vehicle Theft,80
+Wilkes,271150,2011,Offenses Against Family,
+Wilkes,271150,2011,Prostitution,1
+Wilkes,271150,2011,Rape,
+Wilkes,271150,2011,Robbery,11
+Wilkes,271150,2011,Runaway,1
+Wilkes,271150,2011,Sex Offenses,
+Wilkes,271150,2011,Stolen Property,1
+Wilkes,271150,2011,Trespass,19
+Wilkes,271150,2011,Vandalism,80
+Wilkes,271150,2011,Weapons,3
+Wilkes,271150,2012,Aggravated Assault,18
+Wilkes,271150,2012,Arson,1
+Wilkes,271150,2012,"Assault, Simple",14
+Wilkes,271150,2012,Burglary,68
+Wilkes,271150,2012,Curfew,
+Wilkes,271150,2012,Disorderly Conduct,16
+Wilkes,271150,2012,Drugs,16
+Wilkes,271150,2012,DUII,26
+Wilkes,271150,2012,Embezzlement,
+Wilkes,271150,2012,Forgery,2
+Wilkes,271150,2012,Fraud,15
+Wilkes,271150,2012,Gambling,
+Wilkes,271150,2012,Homicide,2
+Wilkes,271150,2012,Kidnap,
+Wilkes,271150,2012,Larceny,162
+Wilkes,271150,2012,Liquor Laws,1
+Wilkes,271150,2012,Motor Vehicle Theft,62
+Wilkes,271150,2012,Offenses Against Family,
+Wilkes,271150,2012,Prostitution,1
+Wilkes,271150,2012,Rape,
+Wilkes,271150,2012,Robbery,8
+Wilkes,271150,2012,Runaway,
+Wilkes,271150,2012,Sex Offenses,1
+Wilkes,271150,2012,Stolen Property,
+Wilkes,271150,2012,Trespass,17
+Wilkes,271150,2012,Vandalism,59
+Wilkes,271150,2012,Weapons,1
+Wilkes,271150,2013,Aggravated Assault,13
+Wilkes,271150,2013,Arson,
+Wilkes,271150,2013,"Assault, Simple",33
+Wilkes,271150,2013,Burglary,53
+Wilkes,271150,2013,Curfew,
+Wilkes,271150,2013,Disorderly Conduct,23
+Wilkes,271150,2013,Drugs,16
+Wilkes,271150,2013,DUII,7
+Wilkes,271150,2013,Embezzlement,2
+Wilkes,271150,2013,Forgery,4
+Wilkes,271150,2013,Fraud,18
+Wilkes,271150,2013,Gambling,
+Wilkes,271150,2013,Homicide,
+Wilkes,271150,2013,Kidnap,
+Wilkes,271150,2013,Larceny,146
+Wilkes,271150,2013,Liquor Laws,2
+Wilkes,271150,2013,Motor Vehicle Theft,44
+Wilkes,271150,2013,Offenses Against Family,
+Wilkes,271150,2013,Prostitution,
+Wilkes,271150,2013,Rape,1
+Wilkes,271150,2013,Robbery,9
+Wilkes,271150,2013,Runaway,
+Wilkes,271150,2013,Sex Offenses,1
+Wilkes,271150,2013,Stolen Property,
+Wilkes,271150,2013,Trespass,19
+Wilkes,271150,2013,Vandalism,80
+Wilkes,271150,2013,Weapons,4
+Wilkes,271150,2014,Aggravated Assault,12
+Wilkes,271150,2014,Arson,1
+Wilkes,271150,2014,"Assault, Simple",26
+Wilkes,271150,2014,Burglary,73
+Wilkes,271150,2014,Curfew,
+Wilkes,271150,2014,Disorderly Conduct,18
+Wilkes,271150,2014,Drugs,12
+Wilkes,271150,2014,DUII,12
+Wilkes,271150,2014,Embezzlement,
+Wilkes,271150,2014,Forgery,2
+Wilkes,271150,2014,Fraud,25
+Wilkes,271150,2014,Gambling,
+Wilkes,271150,2014,Homicide,
+Wilkes,271150,2014,Kidnap,2
+Wilkes,271150,2014,Larceny,227
+Wilkes,271150,2014,Liquor Laws,
+Wilkes,271150,2014,Motor Vehicle Theft,68
+Wilkes,271150,2014,Offenses Against Family,
+Wilkes,271150,2014,Prostitution,1
+Wilkes,271150,2014,Rape,
+Wilkes,271150,2014,Robbery,11
+Wilkes,271150,2014,Runaway,
+Wilkes,271150,2014,Sex Offenses,2
+Wilkes,271150,2014,Stolen Property,2
+Wilkes,271150,2014,Trespass,21
+Wilkes,271150,2014,Vandalism,61
+Wilkes,271150,2014,Weapons,7
+Woodlawn,271152,2004,Aggravated Assault,14
+Woodlawn,271152,2004,Arson,
+Woodlawn,271152,2004,"Assault, Simple",15
+Woodlawn,271152,2004,Burglary,63
+Woodlawn,271152,2004,Curfew,3
+Woodlawn,271152,2004,Disorderly Conduct,17
+Woodlawn,271152,2004,Drugs,14
+Woodlawn,271152,2004,DUII,4
+Woodlawn,271152,2004,Embezzlement,
+Woodlawn,271152,2004,Forgery,5
+Woodlawn,271152,2004,Fraud,16
+Woodlawn,271152,2004,Gambling,
+Woodlawn,271152,2004,Homicide,
+Woodlawn,271152,2004,Kidnap,2
+Woodlawn,271152,2004,Larceny,117
+Woodlawn,271152,2004,Liquor Laws,
+Woodlawn,271152,2004,Motor Vehicle Theft,28
+Woodlawn,271152,2004,Offenses Against Family,
+Woodlawn,271152,2004,Prostitution,
+Woodlawn,271152,2004,Rape,
+Woodlawn,271152,2004,Robbery,7
+Woodlawn,271152,2004,Runaway,
+Woodlawn,271152,2004,Sex Offenses,2
+Woodlawn,271152,2004,Stolen Property,1
+Woodlawn,271152,2004,Trespass,14
+Woodlawn,271152,2004,Vandalism,33
+Woodlawn,271152,2004,Weapons,6
+Woodlawn,271152,2005,Aggravated Assault,39
+Woodlawn,271152,2005,Arson,
+Woodlawn,271152,2005,"Assault, Simple",60
+Woodlawn,271152,2005,Burglary,125
+Woodlawn,271152,2005,Curfew,19
+Woodlawn,271152,2005,Disorderly Conduct,28
+Woodlawn,271152,2005,Drugs,47
+Woodlawn,271152,2005,DUII,31
+Woodlawn,271152,2005,Embezzlement,3
+Woodlawn,271152,2005,Forgery,15
+Woodlawn,271152,2005,Fraud,37
+Woodlawn,271152,2005,Gambling,2
+Woodlawn,271152,2005,Homicide,
+Woodlawn,271152,2005,Kidnap,
+Woodlawn,271152,2005,Larceny,330
+Woodlawn,271152,2005,Liquor Laws,4
+Woodlawn,271152,2005,Motor Vehicle Theft,80
+Woodlawn,271152,2005,Offenses Against Family,
+Woodlawn,271152,2005,Prostitution,2
+Woodlawn,271152,2005,Rape,
+Woodlawn,271152,2005,Robbery,18
+Woodlawn,271152,2005,Runaway,
+Woodlawn,271152,2005,Sex Offenses,2
+Woodlawn,271152,2005,Stolen Property,
+Woodlawn,271152,2005,Trespass,67
+Woodlawn,271152,2005,Vandalism,131
+Woodlawn,271152,2005,Weapons,12
+Woodlawn,271152,2006,Aggravated Assault,51
+Woodlawn,271152,2006,Arson,
+Woodlawn,271152,2006,"Assault, Simple",56
+Woodlawn,271152,2006,Burglary,189
+Woodlawn,271152,2006,Curfew,5
+Woodlawn,271152,2006,Disorderly Conduct,43
+Woodlawn,271152,2006,Drugs,75
+Woodlawn,271152,2006,DUII,45
+Woodlawn,271152,2006,Embezzlement,4
+Woodlawn,271152,2006,Forgery,12
+Woodlawn,271152,2006,Fraud,41
+Woodlawn,271152,2006,Gambling,
+Woodlawn,271152,2006,Homicide,
+Woodlawn,271152,2006,Kidnap,
+Woodlawn,271152,2006,Larceny,316
+Woodlawn,271152,2006,Liquor Laws,8
+Woodlawn,271152,2006,Motor Vehicle Theft,81
+Woodlawn,271152,2006,Offenses Against Family,
+Woodlawn,271152,2006,Prostitution,3
+Woodlawn,271152,2006,Rape,
+Woodlawn,271152,2006,Robbery,22
+Woodlawn,271152,2006,Runaway,
+Woodlawn,271152,2006,Sex Offenses,2
+Woodlawn,271152,2006,Stolen Property,1
+Woodlawn,271152,2006,Trespass,50
+Woodlawn,271152,2006,Vandalism,176
+Woodlawn,271152,2006,Weapons,16
+Woodlawn,271152,2007,Aggravated Assault,20
+Woodlawn,271152,2007,Arson,2
+Woodlawn,271152,2007,"Assault, Simple",34
+Woodlawn,271152,2007,Burglary,129
+Woodlawn,271152,2007,Curfew,3
+Woodlawn,271152,2007,Disorderly Conduct,39
+Woodlawn,271152,2007,Drugs,43
+Woodlawn,271152,2007,DUII,45
+Woodlawn,271152,2007,Embezzlement,7
+Woodlawn,271152,2007,Forgery,11
+Woodlawn,271152,2007,Fraud,33
+Woodlawn,271152,2007,Gambling,
+Woodlawn,271152,2007,Homicide,2
+Woodlawn,271152,2007,Kidnap,
+Woodlawn,271152,2007,Larceny,209
+Woodlawn,271152,2007,Liquor Laws,3
+Woodlawn,271152,2007,Motor Vehicle Theft,55
+Woodlawn,271152,2007,Offenses Against Family,
+Woodlawn,271152,2007,Prostitution,2
+Woodlawn,271152,2007,Rape,
+Woodlawn,271152,2007,Robbery,14
+Woodlawn,271152,2007,Runaway,
+Woodlawn,271152,2007,Sex Offenses,2
+Woodlawn,271152,2007,Stolen Property,1
+Woodlawn,271152,2007,Trespass,22
+Woodlawn,271152,2007,Vandalism,98
+Woodlawn,271152,2007,Weapons,6
+Woodlawn,271152,2008,Aggravated Assault,20
+Woodlawn,271152,2008,Arson,2
+Woodlawn,271152,2008,"Assault, Simple",44
+Woodlawn,271152,2008,Burglary,119
+Woodlawn,271152,2008,Curfew,
+Woodlawn,271152,2008,Disorderly Conduct,29
+Woodlawn,271152,2008,Drugs,45
+Woodlawn,271152,2008,DUII,26
+Woodlawn,271152,2008,Embezzlement,3
+Woodlawn,271152,2008,Forgery,8
+Woodlawn,271152,2008,Fraud,43
+Woodlawn,271152,2008,Gambling,
+Woodlawn,271152,2008,Homicide,
+Woodlawn,271152,2008,Kidnap,
+Woodlawn,271152,2008,Larceny,241
+Woodlawn,271152,2008,Liquor Laws,7
+Woodlawn,271152,2008,Motor Vehicle Theft,45
+Woodlawn,271152,2008,Offenses Against Family,
+Woodlawn,271152,2008,Prostitution,
+Woodlawn,271152,2008,Rape,1
+Woodlawn,271152,2008,Robbery,20
+Woodlawn,271152,2008,Runaway,
+Woodlawn,271152,2008,Sex Offenses,1
+Woodlawn,271152,2008,Stolen Property,1
+Woodlawn,271152,2008,Trespass,29
+Woodlawn,271152,2008,Vandalism,118
+Woodlawn,271152,2008,Weapons,12
+Woodlawn,271152,2009,Aggravated Assault,30
+Woodlawn,271152,2009,Arson,1
+Woodlawn,271152,2009,"Assault, Simple",32
+Woodlawn,271152,2009,Burglary,80
+Woodlawn,271152,2009,Curfew,
+Woodlawn,271152,2009,Disorderly Conduct,29
+Woodlawn,271152,2009,Drugs,44
+Woodlawn,271152,2009,DUII,30
+Woodlawn,271152,2009,Embezzlement,1
+Woodlawn,271152,2009,Forgery,6
+Woodlawn,271152,2009,Fraud,23
+Woodlawn,271152,2009,Gambling,
+Woodlawn,271152,2009,Homicide,
+Woodlawn,271152,2009,Kidnap,
+Woodlawn,271152,2009,Larceny,189
+Woodlawn,271152,2009,Liquor Laws,12
+Woodlawn,271152,2009,Motor Vehicle Theft,62
+Woodlawn,271152,2009,Offenses Against Family,
+Woodlawn,271152,2009,Prostitution,
+Woodlawn,271152,2009,Rape,1
+Woodlawn,271152,2009,Robbery,21
+Woodlawn,271152,2009,Runaway,1
+Woodlawn,271152,2009,Sex Offenses,1
+Woodlawn,271152,2009,Stolen Property,1
+Woodlawn,271152,2009,Trespass,25
+Woodlawn,271152,2009,Vandalism,108
+Woodlawn,271152,2009,Weapons,5
+Woodlawn,271152,2010,Aggravated Assault,22
+Woodlawn,271152,2010,Arson,
+Woodlawn,271152,2010,"Assault, Simple",36
+Woodlawn,271152,2010,Burglary,61
+Woodlawn,271152,2010,Curfew,2
+Woodlawn,271152,2010,Disorderly Conduct,34
+Woodlawn,271152,2010,Drugs,28
+Woodlawn,271152,2010,DUII,19
+Woodlawn,271152,2010,Embezzlement,1
+Woodlawn,271152,2010,Forgery,4
+Woodlawn,271152,2010,Fraud,21
+Woodlawn,271152,2010,Gambling,
+Woodlawn,271152,2010,Homicide,
+Woodlawn,271152,2010,Kidnap,
+Woodlawn,271152,2010,Larceny,218
+Woodlawn,271152,2010,Liquor Laws,13
+Woodlawn,271152,2010,Motor Vehicle Theft,26
+Woodlawn,271152,2010,Offenses Against Family,
+Woodlawn,271152,2010,Prostitution,
+Woodlawn,271152,2010,Rape,
+Woodlawn,271152,2010,Robbery,23
+Woodlawn,271152,2010,Runaway,
+Woodlawn,271152,2010,Sex Offenses,1
+Woodlawn,271152,2010,Stolen Property,1
+Woodlawn,271152,2010,Trespass,44
+Woodlawn,271152,2010,Vandalism,89
+Woodlawn,271152,2010,Weapons,9
+Woodlawn,271152,2011,Aggravated Assault,19
+Woodlawn,271152,2011,Arson,1
+Woodlawn,271152,2011,"Assault, Simple",23
+Woodlawn,271152,2011,Burglary,94
+Woodlawn,271152,2011,Curfew,
+Woodlawn,271152,2011,Disorderly Conduct,26
+Woodlawn,271152,2011,Drugs,20
+Woodlawn,271152,2011,DUII,31
+Woodlawn,271152,2011,Embezzlement,
+Woodlawn,271152,2011,Forgery,5
+Woodlawn,271152,2011,Fraud,12
+Woodlawn,271152,2011,Gambling,
+Woodlawn,271152,2011,Homicide,1
+Woodlawn,271152,2011,Kidnap,
+Woodlawn,271152,2011,Larceny,220
+Woodlawn,271152,2011,Liquor Laws,19
+Woodlawn,271152,2011,Motor Vehicle Theft,40
+Woodlawn,271152,2011,Offenses Against Family,
+Woodlawn,271152,2011,Prostitution,
+Woodlawn,271152,2011,Rape,
+Woodlawn,271152,2011,Robbery,9
+Woodlawn,271152,2011,Runaway,2
+Woodlawn,271152,2011,Sex Offenses,2
+Woodlawn,271152,2011,Stolen Property,
+Woodlawn,271152,2011,Trespass,21
+Woodlawn,271152,2011,Vandalism,70
+Woodlawn,271152,2011,Weapons,7
+Woodlawn,271152,2012,Aggravated Assault,25
+Woodlawn,271152,2012,Arson,
+Woodlawn,271152,2012,"Assault, Simple",32
+Woodlawn,271152,2012,Burglary,96
+Woodlawn,271152,2012,Curfew,
+Woodlawn,271152,2012,Disorderly Conduct,33
+Woodlawn,271152,2012,Drugs,21
+Woodlawn,271152,2012,DUII,29
+Woodlawn,271152,2012,Embezzlement,1
+Woodlawn,271152,2012,Forgery,5
+Woodlawn,271152,2012,Fraud,20
+Woodlawn,271152,2012,Gambling,
+Woodlawn,271152,2012,Homicide,
+Woodlawn,271152,2012,Kidnap,2
+Woodlawn,271152,2012,Larceny,195
+Woodlawn,271152,2012,Liquor Laws,16
+Woodlawn,271152,2012,Motor Vehicle Theft,42
+Woodlawn,271152,2012,Offenses Against Family,
+Woodlawn,271152,2012,Prostitution,
+Woodlawn,271152,2012,Rape,
+Woodlawn,271152,2012,Robbery,14
+Woodlawn,271152,2012,Runaway,
+Woodlawn,271152,2012,Sex Offenses,2
+Woodlawn,271152,2012,Stolen Property,2
+Woodlawn,271152,2012,Trespass,21
+Woodlawn,271152,2012,Vandalism,81
+Woodlawn,271152,2012,Weapons,9
+Woodlawn,271152,2013,Aggravated Assault,17
+Woodlawn,271152,2013,Arson,1
+Woodlawn,271152,2013,"Assault, Simple",33
+Woodlawn,271152,2013,Burglary,62
+Woodlawn,271152,2013,Curfew,1
+Woodlawn,271152,2013,Disorderly Conduct,22
+Woodlawn,271152,2013,Drugs,34
+Woodlawn,271152,2013,DUII,35
+Woodlawn,271152,2013,Embezzlement,3
+Woodlawn,271152,2013,Forgery,2
+Woodlawn,271152,2013,Fraud,17
+Woodlawn,271152,2013,Gambling,
+Woodlawn,271152,2013,Homicide,
+Woodlawn,271152,2013,Kidnap,
+Woodlawn,271152,2013,Larceny,184
+Woodlawn,271152,2013,Liquor Laws,9
+Woodlawn,271152,2013,Motor Vehicle Theft,39
+Woodlawn,271152,2013,Offenses Against Family,
+Woodlawn,271152,2013,Prostitution,
+Woodlawn,271152,2013,Rape,
+Woodlawn,271152,2013,Robbery,11
+Woodlawn,271152,2013,Runaway,
+Woodlawn,271152,2013,Sex Offenses,1
+Woodlawn,271152,2013,Stolen Property,2
+Woodlawn,271152,2013,Trespass,36
+Woodlawn,271152,2013,Vandalism,84
+Woodlawn,271152,2013,Weapons,8
+Woodlawn,271152,2014,Aggravated Assault,18
+Woodlawn,271152,2014,Arson,
+Woodlawn,271152,2014,"Assault, Simple",22
+Woodlawn,271152,2014,Burglary,80
+Woodlawn,271152,2014,Curfew,
+Woodlawn,271152,2014,Disorderly Conduct,20
+Woodlawn,271152,2014,Drugs,18
+Woodlawn,271152,2014,DUII,23
+Woodlawn,271152,2014,Embezzlement,1
+Woodlawn,271152,2014,Forgery,5
+Woodlawn,271152,2014,Fraud,12
+Woodlawn,271152,2014,Gambling,
+Woodlawn,271152,2014,Homicide,
+Woodlawn,271152,2014,Kidnap,
+Woodlawn,271152,2014,Larceny,228
+Woodlawn,271152,2014,Liquor Laws,8
+Woodlawn,271152,2014,Motor Vehicle Theft,33
+Woodlawn,271152,2014,Offenses Against Family,
+Woodlawn,271152,2014,Prostitution,
+Woodlawn,271152,2014,Rape,1
+Woodlawn,271152,2014,Robbery,12
+Woodlawn,271152,2014,Runaway,
+Woodlawn,271152,2014,Sex Offenses,
+Woodlawn,271152,2014,Stolen Property,
+Woodlawn,271152,2014,Trespass,18
+Woodlawn,271152,2014,Vandalism,64
+Woodlawn,271152,2014,Weapons,5
+Woodstock,207740,2004,Aggravated Assault,
+Woodstock,207740,2004,Arson,
+Woodstock,207740,2004,"Assault, Simple",2
+Woodstock,207740,2004,Burglary,29
+Woodstock,207740,2004,Curfew,
+Woodstock,207740,2004,Disorderly Conduct,2
+Woodstock,207740,2004,Drugs,1
+Woodstock,207740,2004,DUII,6
+Woodstock,207740,2004,Embezzlement,
+Woodstock,207740,2004,Forgery,8
+Woodstock,207740,2004,Fraud,21
+Woodstock,207740,2004,Gambling,
+Woodstock,207740,2004,Homicide,
+Woodstock,207740,2004,Kidnap,
+Woodstock,207740,2004,Larceny,63
+Woodstock,207740,2004,Liquor Laws,4
+Woodstock,207740,2004,Motor Vehicle Theft,7
+Woodstock,207740,2004,Offenses Against Family,
+Woodstock,207740,2004,Prostitution,
+Woodstock,207740,2004,Rape,
+Woodstock,207740,2004,Robbery,4
+Woodstock,207740,2004,Runaway,
+Woodstock,207740,2004,Sex Offenses,
+Woodstock,207740,2004,Stolen Property,
+Woodstock,207740,2004,Trespass,3
+Woodstock,207740,2004,Vandalism,17
+Woodstock,207740,2004,Weapons,1
+Woodstock,207740,2005,Aggravated Assault,7
+Woodstock,207740,2005,Arson,
+Woodstock,207740,2005,"Assault, Simple",9
+Woodstock,207740,2005,Burglary,62
+Woodstock,207740,2005,Curfew,1
+Woodstock,207740,2005,Disorderly Conduct,20
+Woodstock,207740,2005,Drugs,15
+Woodstock,207740,2005,DUII,13
+Woodstock,207740,2005,Embezzlement,1
+Woodstock,207740,2005,Forgery,9
+Woodstock,207740,2005,Fraud,26
+Woodstock,207740,2005,Gambling,
+Woodstock,207740,2005,Homicide,
+Woodstock,207740,2005,Kidnap,
+Woodstock,207740,2005,Larceny,251
+Woodstock,207740,2005,Liquor Laws,4
+Woodstock,207740,2005,Motor Vehicle Theft,44
+Woodstock,207740,2005,Offenses Against Family,
+Woodstock,207740,2005,Prostitution,
+Woodstock,207740,2005,Rape,
+Woodstock,207740,2005,Robbery,14
+Woodstock,207740,2005,Runaway,
+Woodstock,207740,2005,Sex Offenses,
+Woodstock,207740,2005,Stolen Property,
+Woodstock,207740,2005,Trespass,18
+Woodstock,207740,2005,Vandalism,61
+Woodstock,207740,2005,Weapons,3
+Woodstock,207740,2006,Aggravated Assault,13
+Woodstock,207740,2006,Arson,2
+Woodstock,207740,2006,"Assault, Simple",18
+Woodstock,207740,2006,Burglary,72
+Woodstock,207740,2006,Curfew,2
+Woodstock,207740,2006,Disorderly Conduct,22
+Woodstock,207740,2006,Drugs,19
+Woodstock,207740,2006,DUII,23
+Woodstock,207740,2006,Embezzlement,3
+Woodstock,207740,2006,Forgery,10
+Woodstock,207740,2006,Fraud,22
+Woodstock,207740,2006,Gambling,
+Woodstock,207740,2006,Homicide,
+Woodstock,207740,2006,Kidnap,
+Woodstock,207740,2006,Larceny,169
+Woodstock,207740,2006,Liquor Laws,6
+Woodstock,207740,2006,Motor Vehicle Theft,38
+Woodstock,207740,2006,Offenses Against Family,
+Woodstock,207740,2006,Prostitution,
+Woodstock,207740,2006,Rape,
+Woodstock,207740,2006,Robbery,6
+Woodstock,207740,2006,Runaway,
+Woodstock,207740,2006,Sex Offenses,
+Woodstock,207740,2006,Stolen Property,
+Woodstock,207740,2006,Trespass,20
+Woodstock,207740,2006,Vandalism,93
+Woodstock,207740,2006,Weapons,5
+Woodstock,207740,2007,Aggravated Assault,11
+Woodstock,207740,2007,Arson,1
+Woodstock,207740,2007,"Assault, Simple",10
+Woodstock,207740,2007,Burglary,71
+Woodstock,207740,2007,Curfew,
+Woodstock,207740,2007,Disorderly Conduct,10
+Woodstock,207740,2007,Drugs,13
+Woodstock,207740,2007,DUII,16
+Woodstock,207740,2007,Embezzlement,4
+Woodstock,207740,2007,Forgery,17
+Woodstock,207740,2007,Fraud,29
+Woodstock,207740,2007,Gambling,
+Woodstock,207740,2007,Homicide,
+Woodstock,207740,2007,Kidnap,
+Woodstock,207740,2007,Larceny,217
+Woodstock,207740,2007,Liquor Laws,12
+Woodstock,207740,2007,Motor Vehicle Theft,36
+Woodstock,207740,2007,Offenses Against Family,
+Woodstock,207740,2007,Prostitution,
+Woodstock,207740,2007,Rape,
+Woodstock,207740,2007,Robbery,8
+Woodstock,207740,2007,Runaway,
+Woodstock,207740,2007,Sex Offenses,
+Woodstock,207740,2007,Stolen Property,
+Woodstock,207740,2007,Trespass,10
+Woodstock,207740,2007,Vandalism,79
+Woodstock,207740,2007,Weapons,2
+Woodstock,207740,2008,Aggravated Assault,6
+Woodstock,207740,2008,Arson,
+Woodstock,207740,2008,"Assault, Simple",15
+Woodstock,207740,2008,Burglary,48
+Woodstock,207740,2008,Curfew,
+Woodstock,207740,2008,Disorderly Conduct,14
+Woodstock,207740,2008,Drugs,17
+Woodstock,207740,2008,DUII,7
+Woodstock,207740,2008,Embezzlement,2
+Woodstock,207740,2008,Forgery,10
+Woodstock,207740,2008,Fraud,14
+Woodstock,207740,2008,Gambling,
+Woodstock,207740,2008,Homicide,
+Woodstock,207740,2008,Kidnap,
+Woodstock,207740,2008,Larceny,170
+Woodstock,207740,2008,Liquor Laws,6
+Woodstock,207740,2008,Motor Vehicle Theft,24
+Woodstock,207740,2008,Offenses Against Family,
+Woodstock,207740,2008,Prostitution,
+Woodstock,207740,2008,Rape,
+Woodstock,207740,2008,Robbery,6
+Woodstock,207740,2008,Runaway,
+Woodstock,207740,2008,Sex Offenses,1
+Woodstock,207740,2008,Stolen Property,
+Woodstock,207740,2008,Trespass,14
+Woodstock,207740,2008,Vandalism,44
+Woodstock,207740,2008,Weapons,4
+Woodstock,207740,2009,Aggravated Assault,8
+Woodstock,207740,2009,Arson,1
+Woodstock,207740,2009,"Assault, Simple",10
+Woodstock,207740,2009,Burglary,54
+Woodstock,207740,2009,Curfew,3
+Woodstock,207740,2009,Disorderly Conduct,11
+Woodstock,207740,2009,Drugs,17
+Woodstock,207740,2009,DUII,11
+Woodstock,207740,2009,Embezzlement,3
+Woodstock,207740,2009,Forgery,11
+Woodstock,207740,2009,Fraud,15
+Woodstock,207740,2009,Gambling,
+Woodstock,207740,2009,Homicide,
+Woodstock,207740,2009,Kidnap,2
+Woodstock,207740,2009,Larceny,139
+Woodstock,207740,2009,Liquor Laws,23
+Woodstock,207740,2009,Motor Vehicle Theft,21
+Woodstock,207740,2009,Offenses Against Family,
+Woodstock,207740,2009,Prostitution,
+Woodstock,207740,2009,Rape,
+Woodstock,207740,2009,Robbery,5
+Woodstock,207740,2009,Runaway,
+Woodstock,207740,2009,Sex Offenses,
+Woodstock,207740,2009,Stolen Property,
+Woodstock,207740,2009,Trespass,13
+Woodstock,207740,2009,Vandalism,45
+Woodstock,207740,2009,Weapons,2
+Woodstock,207740,2010,Aggravated Assault,4
+Woodstock,207740,2010,Arson,
+Woodstock,207740,2010,"Assault, Simple",7
+Woodstock,207740,2010,Burglary,63
+Woodstock,207740,2010,Curfew,
+Woodstock,207740,2010,Disorderly Conduct,14
+Woodstock,207740,2010,Drugs,8
+Woodstock,207740,2010,DUII,7
+Woodstock,207740,2010,Embezzlement,1
+Woodstock,207740,2010,Forgery,7
+Woodstock,207740,2010,Fraud,7
+Woodstock,207740,2010,Gambling,
+Woodstock,207740,2010,Homicide,
+Woodstock,207740,2010,Kidnap,
+Woodstock,207740,2010,Larceny,151
+Woodstock,207740,2010,Liquor Laws,9
+Woodstock,207740,2010,Motor Vehicle Theft,32
+Woodstock,207740,2010,Offenses Against Family,
+Woodstock,207740,2010,Prostitution,
+Woodstock,207740,2010,Rape,
+Woodstock,207740,2010,Robbery,9
+Woodstock,207740,2010,Runaway,
+Woodstock,207740,2010,Sex Offenses,1
+Woodstock,207740,2010,Stolen Property,
+Woodstock,207740,2010,Trespass,9
+Woodstock,207740,2010,Vandalism,50
+Woodstock,207740,2010,Weapons,1
+Woodstock,207740,2011,Aggravated Assault,9
+Woodstock,207740,2011,Arson,2
+Woodstock,207740,2011,"Assault, Simple",11
+Woodstock,207740,2011,Burglary,101
+Woodstock,207740,2011,Curfew,
+Woodstock,207740,2011,Disorderly Conduct,8
+Woodstock,207740,2011,Drugs,4
+Woodstock,207740,2011,DUII,5
+Woodstock,207740,2011,Embezzlement,3
+Woodstock,207740,2011,Forgery,6
+Woodstock,207740,2011,Fraud,11
+Woodstock,207740,2011,Gambling,
+Woodstock,207740,2011,Homicide,
+Woodstock,207740,2011,Kidnap,
+Woodstock,207740,2011,Larceny,236
+Woodstock,207740,2011,Liquor Laws,16
+Woodstock,207740,2011,Motor Vehicle Theft,25
+Woodstock,207740,2011,Offenses Against Family,
+Woodstock,207740,2011,Prostitution,
+Woodstock,207740,2011,Rape,1
+Woodstock,207740,2011,Robbery,6
+Woodstock,207740,2011,Runaway,
+Woodstock,207740,2011,Sex Offenses,
+Woodstock,207740,2011,Stolen Property,2
+Woodstock,207740,2011,Trespass,12
+Woodstock,207740,2011,Vandalism,54
+Woodstock,207740,2011,Weapons,3
+Woodstock,207740,2012,Aggravated Assault,5
+Woodstock,207740,2012,Arson,
+Woodstock,207740,2012,"Assault, Simple",3
+Woodstock,207740,2012,Burglary,94
+Woodstock,207740,2012,Curfew,
+Woodstock,207740,2012,Disorderly Conduct,14
+Woodstock,207740,2012,Drugs,5
+Woodstock,207740,2012,DUII,8
+Woodstock,207740,2012,Embezzlement,
+Woodstock,207740,2012,Forgery,10
+Woodstock,207740,2012,Fraud,19
+Woodstock,207740,2012,Gambling,
+Woodstock,207740,2012,Homicide,
+Woodstock,207740,2012,Kidnap,
+Woodstock,207740,2012,Larceny,258
+Woodstock,207740,2012,Liquor Laws,3
+Woodstock,207740,2012,Motor Vehicle Theft,22
+Woodstock,207740,2012,Offenses Against Family,
+Woodstock,207740,2012,Prostitution,
+Woodstock,207740,2012,Rape,
+Woodstock,207740,2012,Robbery,13
+Woodstock,207740,2012,Runaway,1
+Woodstock,207740,2012,Sex Offenses,
+Woodstock,207740,2012,Stolen Property,
+Woodstock,207740,2012,Trespass,12
+Woodstock,207740,2012,Vandalism,61
+Woodstock,207740,2012,Weapons,2
+Woodstock,207740,2013,Aggravated Assault,2
+Woodstock,207740,2013,Arson,1
+Woodstock,207740,2013,"Assault, Simple",8
+Woodstock,207740,2013,Burglary,64
+Woodstock,207740,2013,Curfew,
+Woodstock,207740,2013,Disorderly Conduct,5
+Woodstock,207740,2013,Drugs,2
+Woodstock,207740,2013,DUII,12
+Woodstock,207740,2013,Embezzlement,2
+Woodstock,207740,2013,Forgery,11
+Woodstock,207740,2013,Fraud,17
+Woodstock,207740,2013,Gambling,
+Woodstock,207740,2013,Homicide,
+Woodstock,207740,2013,Kidnap,1
+Woodstock,207740,2013,Larceny,276
+Woodstock,207740,2013,Liquor Laws,2
+Woodstock,207740,2013,Motor Vehicle Theft,28
+Woodstock,207740,2013,Offenses Against Family,
+Woodstock,207740,2013,Prostitution,
+Woodstock,207740,2013,Rape,
+Woodstock,207740,2013,Robbery,4
+Woodstock,207740,2013,Runaway,
+Woodstock,207740,2013,Sex Offenses,
+Woodstock,207740,2013,Stolen Property,
+Woodstock,207740,2013,Trespass,10
+Woodstock,207740,2013,Vandalism,52
+Woodstock,207740,2013,Weapons,
+Woodstock,207740,2014,Aggravated Assault,3
+Woodstock,207740,2014,Arson,
+Woodstock,207740,2014,"Assault, Simple",13
+Woodstock,207740,2014,Burglary,80
+Woodstock,207740,2014,Curfew,
+Woodstock,207740,2014,Disorderly Conduct,12
+Woodstock,207740,2014,Drugs,3
+Woodstock,207740,2014,DUII,4
+Woodstock,207740,2014,Embezzlement,2
+Woodstock,207740,2014,Forgery,4
+Woodstock,207740,2014,Fraud,20
+Woodstock,207740,2014,Gambling,
+Woodstock,207740,2014,Homicide,2
+Woodstock,207740,2014,Kidnap,
+Woodstock,207740,2014,Larceny,198
+Woodstock,207740,2014,Liquor Laws,3
+Woodstock,207740,2014,Motor Vehicle Theft,30
+Woodstock,207740,2014,Offenses Against Family,
+Woodstock,207740,2014,Prostitution,
+Woodstock,207740,2014,Rape,
+Woodstock,207740,2014,Robbery,11
+Woodstock,207740,2014,Runaway,
+Woodstock,207740,2014,Sex Offenses,1
+Woodstock,207740,2014,Stolen Property,1
+Woodstock,207740,2014,Trespass,20
+Woodstock,207740,2014,Vandalism,107
+Woodstock,207740,2014,Weapons,

--- a/json/city_data/zillow_neighborhoods_crime_violent.csv
+++ b/json/city_data/zillow_neighborhoods_crime_violent.csv
@@ -1,0 +1,1871 @@
+name,regionid,year,violent,count
+Alameda,206428,2004,f,288
+Alameda,206428,2004,t,42
+Alameda,206428,2005,f,734
+Alameda,206428,2005,t,105
+Alameda,206428,2006,f,609
+Alameda,206428,2006,t,121
+Alameda,206428,2007,f,476
+Alameda,206428,2007,t,104
+Alameda,206428,2008,f,482
+Alameda,206428,2008,t,76
+Alameda,206428,2009,f,426
+Alameda,206428,2009,t,53
+Alameda,206428,2010,f,422
+Alameda,206428,2010,t,73
+Alameda,206428,2011,f,412
+Alameda,206428,2011,t,62
+Alameda,206428,2012,f,378
+Alameda,206428,2012,t,84
+Alameda,206428,2013,f,502
+Alameda,206428,2013,t,92
+Alameda,206428,2014,f,365
+Alameda,206428,2014,t,69
+Arbor Lodge,271060,2004,f,177
+Arbor Lodge,271060,2004,t,47
+Arbor Lodge,271060,2005,f,886
+Arbor Lodge,271060,2005,t,125
+Arbor Lodge,271060,2006,f,889
+Arbor Lodge,271060,2006,t,125
+Arbor Lodge,271060,2007,f,920
+Arbor Lodge,271060,2007,t,136
+Arbor Lodge,271060,2008,f,869
+Arbor Lodge,271060,2008,t,127
+Arbor Lodge,271060,2009,f,781
+Arbor Lodge,271060,2009,t,111
+Arbor Lodge,271060,2010,f,529
+Arbor Lodge,271060,2010,t,78
+Arbor Lodge,271060,2011,f,609
+Arbor Lodge,271060,2011,t,92
+Arbor Lodge,271060,2012,f,640
+Arbor Lodge,271060,2012,t,95
+Arbor Lodge,271060,2013,f,615
+Arbor Lodge,271060,2013,t,109
+Arbor Lodge,271060,2014,f,610
+Arbor Lodge,271060,2014,t,92
+Ardenwald,272783,2004,f,
+Ardenwald,272783,2004,t,
+Ardenwald,272783,2005,f,1
+Ardenwald,272783,2005,t,
+Ardenwald,272783,2006,f,
+Ardenwald,272783,2006,t,
+Ardenwald,272783,2007,f,
+Ardenwald,272783,2007,t,
+Ardenwald,272783,2008,f,2
+Ardenwald,272783,2008,t,
+Ardenwald,272783,2009,f,1
+Ardenwald,272783,2009,t,
+Ardenwald,272783,2010,f,
+Ardenwald,272783,2010,t,
+Ardenwald,272783,2011,f,1
+Ardenwald,272783,2011,t,
+Ardenwald,272783,2012,f,2
+Ardenwald,272783,2012,t,
+Ardenwald,272783,2013,f,3
+Ardenwald,272783,2013,t,
+Ardenwald,272783,2014,f,
+Ardenwald,272783,2014,t,1
+Argay,271061,2004,f,167
+Argay,271061,2004,t,38
+Argay,271061,2005,f,672
+Argay,271061,2005,t,177
+Argay,271061,2006,f,608
+Argay,271061,2006,t,124
+Argay,271061,2007,f,657
+Argay,271061,2007,t,121
+Argay,271061,2008,f,587
+Argay,271061,2008,t,117
+Argay,271061,2009,f,471
+Argay,271061,2009,t,97
+Argay,271061,2010,f,501
+Argay,271061,2010,t,102
+Argay,271061,2011,f,465
+Argay,271061,2011,t,120
+Argay,271061,2012,f,389
+Argay,271061,2012,t,102
+Argay,271061,2013,f,397
+Argay,271061,2013,t,82
+Argay,271061,2014,f,480
+Argay,271061,2014,t,116
+Boise,271065,2004,f,268
+Boise,271065,2004,t,100
+Boise,271065,2005,f,832
+Boise,271065,2005,t,242
+Boise,271065,2006,f,845
+Boise,271065,2006,t,252
+Boise,271065,2007,f,804
+Boise,271065,2007,t,263
+Boise,271065,2008,f,736
+Boise,271065,2008,t,216
+Boise,271065,2009,f,509
+Boise,271065,2009,t,167
+Boise,271065,2010,f,597
+Boise,271065,2010,t,141
+Boise,271065,2011,f,621
+Boise,271065,2011,t,156
+Boise,271065,2012,f,840
+Boise,271065,2012,t,119
+Boise,271065,2013,f,604
+Boise,271065,2013,t,120
+Boise,271065,2014,f,703
+Boise,271065,2014,t,170
+Brentwood-Darlington,276222,2004,f,158
+Brentwood-Darlington,276222,2004,t,44
+Brentwood-Darlington,276222,2005,f,761
+Brentwood-Darlington,276222,2005,t,173
+Brentwood-Darlington,276222,2006,f,582
+Brentwood-Darlington,276222,2006,t,197
+Brentwood-Darlington,276222,2007,f,677
+Brentwood-Darlington,276222,2007,t,186
+Brentwood-Darlington,276222,2008,f,506
+Brentwood-Darlington,276222,2008,t,150
+Brentwood-Darlington,276222,2009,f,446
+Brentwood-Darlington,276222,2009,t,137
+Brentwood-Darlington,276222,2010,f,456
+Brentwood-Darlington,276222,2010,t,140
+Brentwood-Darlington,276222,2011,f,433
+Brentwood-Darlington,276222,2011,t,144
+Brentwood-Darlington,276222,2012,f,481
+Brentwood-Darlington,276222,2012,t,130
+Brentwood-Darlington,276222,2013,f,487
+Brentwood-Darlington,276222,2013,t,150
+Brentwood-Darlington,276222,2014,f,458
+Brentwood-Darlington,276222,2014,t,135
+Bridgeton,271067,2004,f,82
+Bridgeton,271067,2004,t,15
+Bridgeton,271067,2005,f,438
+Bridgeton,271067,2005,t,107
+Bridgeton,271067,2006,f,403
+Bridgeton,271067,2006,t,101
+Bridgeton,271067,2007,f,411
+Bridgeton,271067,2007,t,78
+Bridgeton,271067,2008,f,457
+Bridgeton,271067,2008,t,72
+Bridgeton,271067,2009,f,344
+Bridgeton,271067,2009,t,57
+Bridgeton,271067,2010,f,364
+Bridgeton,271067,2010,t,60
+Bridgeton,271067,2011,f,337
+Bridgeton,271067,2011,t,46
+Bridgeton,271067,2012,f,396
+Bridgeton,271067,2012,t,58
+Bridgeton,271067,2013,f,418
+Bridgeton,271067,2013,t,53
+Bridgeton,271067,2014,f,582
+Bridgeton,271067,2014,t,72
+Bridlemile,206554,2004,f,31
+Bridlemile,206554,2004,t,5
+Bridlemile,206554,2005,f,164
+Bridlemile,206554,2005,t,38
+Bridlemile,206554,2006,f,100
+Bridlemile,206554,2006,t,31
+Bridlemile,206554,2007,f,129
+Bridlemile,206554,2007,t,18
+Bridlemile,206554,2008,f,137
+Bridlemile,206554,2008,t,28
+Bridlemile,206554,2009,f,138
+Bridlemile,206554,2009,t,23
+Bridlemile,206554,2010,f,103
+Bridlemile,206554,2010,t,21
+Bridlemile,206554,2011,f,107
+Bridlemile,206554,2011,t,19
+Bridlemile,206554,2012,f,109
+Bridlemile,206554,2012,t,46
+Bridlemile,206554,2013,f,84
+Bridlemile,206554,2013,t,16
+Bridlemile,206554,2014,f,107
+Bridlemile,206554,2014,t,18
+Brooklyn,206562,2004,f,95
+Brooklyn,206562,2004,t,33
+Brooklyn,206562,2005,f,334
+Brooklyn,206562,2005,t,73
+Brooklyn,206562,2006,f,346
+Brooklyn,206562,2006,t,56
+Brooklyn,206562,2007,f,288
+Brooklyn,206562,2007,t,59
+Brooklyn,206562,2008,f,235
+Brooklyn,206562,2008,t,45
+Brooklyn,206562,2009,f,269
+Brooklyn,206562,2009,t,50
+Brooklyn,206562,2010,f,279
+Brooklyn,206562,2010,t,41
+Brooklyn,206562,2011,f,291
+Brooklyn,206562,2011,t,57
+Brooklyn,206562,2012,f,263
+Brooklyn,206562,2012,t,76
+Brooklyn,206562,2013,f,288
+Brooklyn,206562,2013,t,44
+Brooklyn,206562,2014,f,209
+Brooklyn,206562,2014,t,43
+Buckman,271068,2004,f,520
+Buckman,271068,2004,t,89
+Buckman,271068,2005,f,1710
+Buckman,271068,2005,t,231
+Buckman,271068,2006,f,1425
+Buckman,271068,2006,t,229
+Buckman,271068,2007,f,1342
+Buckman,271068,2007,t,228
+Buckman,271068,2008,f,1539
+Buckman,271068,2008,t,181
+Buckman,271068,2009,f,1547
+Buckman,271068,2009,t,179
+Buckman,271068,2010,f,1221
+Buckman,271068,2010,t,202
+Buckman,271068,2011,f,1395
+Buckman,271068,2011,t,179
+Buckman,271068,2012,f,1665
+Buckman,271068,2012,t,198
+Buckman,271068,2013,f,1531
+Buckman,271068,2013,t,217
+Buckman,271068,2014,f,1601
+Buckman,271068,2014,t,214
+Cathedral Park,271070,2004,f,356
+Cathedral Park,271070,2004,t,95
+Cathedral Park,271070,2005,f,1135
+Cathedral Park,271070,2005,t,242
+Cathedral Park,271070,2006,f,888
+Cathedral Park,271070,2006,t,234
+Cathedral Park,271070,2007,f,1100
+Cathedral Park,271070,2007,t,202
+Cathedral Park,271070,2008,f,874
+Cathedral Park,271070,2008,t,196
+Cathedral Park,271070,2009,f,896
+Cathedral Park,271070,2009,t,167
+Cathedral Park,271070,2010,f,851
+Cathedral Park,271070,2010,t,176
+Cathedral Park,271070,2011,f,805
+Cathedral Park,271070,2011,t,148
+Cathedral Park,271070,2012,f,840
+Cathedral Park,271070,2012,t,193
+Cathedral Park,271070,2013,f,775
+Cathedral Park,271070,2013,t,183
+Cathedral Park,271070,2014,f,734
+Cathedral Park,271070,2014,t,178
+Centennial,271071,2004,f,289
+Centennial,271071,2004,t,93
+Centennial,271071,2005,f,1951
+Centennial,271071,2005,t,375
+Centennial,271071,2006,f,1521
+Centennial,271071,2006,t,377
+Centennial,271071,2007,f,1618
+Centennial,271071,2007,t,375
+Centennial,271071,2008,f,1477
+Centennial,271071,2008,t,410
+Centennial,271071,2009,f,1372
+Centennial,271071,2009,t,344
+Centennial,271071,2010,f,1369
+Centennial,271071,2010,t,331
+Centennial,271071,2011,f,1372
+Centennial,271071,2011,t,352
+Centennial,271071,2012,f,1398
+Centennial,271071,2012,t,372
+Centennial,271071,2013,f,1286
+Centennial,271071,2013,t,349
+Centennial,271071,2014,f,1261
+Centennial,271071,2014,t,306
+Center,271072,2004,f,184
+Center,271072,2004,t,42
+Center,271072,2005,f,741
+Center,271072,2005,t,158
+Center,271072,2006,f,552
+Center,271072,2006,t,120
+Center,271072,2007,f,523
+Center,271072,2007,t,84
+Center,271072,2008,f,436
+Center,271072,2008,t,98
+Center,271072,2009,f,473
+Center,271072,2009,t,66
+Center,271072,2010,f,417
+Center,271072,2010,t,125
+Center,271072,2011,f,490
+Center,271072,2011,t,89
+Center,271072,2012,f,449
+Center,271072,2012,t,99
+Center,271072,2013,f,448
+Center,271072,2013,t,78
+Center,271072,2014,f,447
+Center,271072,2014,t,88
+Central Beaverton,273187,2004,f,
+Central Beaverton,273187,2004,t,
+Central Beaverton,273187,2005,f,1
+Central Beaverton,273187,2005,t,
+Central Beaverton,273187,2006,f,
+Central Beaverton,273187,2006,t,
+Central Beaverton,273187,2007,f,
+Central Beaverton,273187,2007,t,
+Central Beaverton,273187,2008,f,1
+Central Beaverton,273187,2008,t,
+Central Beaverton,273187,2009,f,
+Central Beaverton,273187,2009,t,
+Central Beaverton,273187,2010,f,
+Central Beaverton,273187,2010,t,
+Central Beaverton,273187,2011,f,1
+Central Beaverton,273187,2011,t,
+Central Beaverton,273187,2012,f,8
+Central Beaverton,273187,2012,t,
+Central Beaverton,273187,2013,f,6
+Central Beaverton,273187,2013,t,
+Central Beaverton,273187,2014,f,2
+Central Beaverton,273187,2014,t,
+Concordia,271076,2004,f,129
+Concordia,271076,2004,t,47
+Concordia,271076,2005,f,552
+Concordia,271076,2005,t,167
+Concordia,271076,2006,f,508
+Concordia,271076,2006,t,152
+Concordia,271076,2007,f,525
+Concordia,271076,2007,t,130
+Concordia,271076,2008,f,534
+Concordia,271076,2008,t,123
+Concordia,271076,2009,f,385
+Concordia,271076,2009,t,95
+Concordia,271076,2010,f,324
+Concordia,271076,2010,t,104
+Concordia,271076,2011,f,329
+Concordia,271076,2011,t,72
+Concordia,271076,2012,f,334
+Concordia,271076,2012,t,109
+Concordia,271076,2013,f,360
+Concordia,271076,2013,t,70
+Concordia,271076,2014,f,370
+Concordia,271076,2014,t,91
+Corbett-Terwilliger-Lair Hill,273346,2004,f,101
+Corbett-Terwilliger-Lair Hill,273346,2004,t,19
+Corbett-Terwilliger-Lair Hill,273346,2005,f,396
+Corbett-Terwilliger-Lair Hill,273346,2005,t,106
+Corbett-Terwilliger-Lair Hill,273346,2006,f,372
+Corbett-Terwilliger-Lair Hill,273346,2006,t,64
+Corbett-Terwilliger-Lair Hill,273346,2007,f,369
+Corbett-Terwilliger-Lair Hill,273346,2007,t,60
+Corbett-Terwilliger-Lair Hill,273346,2008,f,287
+Corbett-Terwilliger-Lair Hill,273346,2008,t,47
+Corbett-Terwilliger-Lair Hill,273346,2009,f,291
+Corbett-Terwilliger-Lair Hill,273346,2009,t,55
+Corbett-Terwilliger-Lair Hill,273346,2010,f,359
+Corbett-Terwilliger-Lair Hill,273346,2010,t,40
+Corbett-Terwilliger-Lair Hill,273346,2011,f,322
+Corbett-Terwilliger-Lair Hill,273346,2011,t,31
+Corbett-Terwilliger-Lair Hill,273346,2012,f,315
+Corbett-Terwilliger-Lair Hill,273346,2012,t,38
+Corbett-Terwilliger-Lair Hill,273346,2013,f,295
+Corbett-Terwilliger-Lair Hill,273346,2013,t,51
+Corbett-Terwilliger-Lair Hill,273346,2014,f,357
+Corbett-Terwilliger-Lair Hill,273346,2014,t,42
+Creston-Kenilworth,273402,2004,f,189
+Creston-Kenilworth,273402,2004,t,49
+Creston-Kenilworth,273402,2005,f,552
+Creston-Kenilworth,273402,2005,t,114
+Creston-Kenilworth,273402,2006,f,465
+Creston-Kenilworth,273402,2006,t,126
+Creston-Kenilworth,273402,2007,f,474
+Creston-Kenilworth,273402,2007,t,116
+Creston-Kenilworth,273402,2008,f,337
+Creston-Kenilworth,273402,2008,t,69
+Creston-Kenilworth,273402,2009,f,282
+Creston-Kenilworth,273402,2009,t,55
+Creston-Kenilworth,273402,2010,f,351
+Creston-Kenilworth,273402,2010,t,94
+Creston-Kenilworth,273402,2011,f,334
+Creston-Kenilworth,273402,2011,t,85
+Creston-Kenilworth,273402,2012,f,325
+Creston-Kenilworth,273402,2012,t,94
+Creston-Kenilworth,273402,2013,f,321
+Creston-Kenilworth,273402,2013,t,65
+Creston-Kenilworth,273402,2014,f,387
+Creston-Kenilworth,273402,2014,t,68
+Cully,271079,2004,f,341
+Cully,271079,2004,t,107
+Cully,271079,2005,f,1374
+Cully,271079,2005,t,381
+Cully,271079,2006,f,1200
+Cully,271079,2006,t,395
+Cully,271079,2007,f,1196
+Cully,271079,2007,t,353
+Cully,271079,2008,f,1180
+Cully,271079,2008,t,278
+Cully,271079,2009,f,998
+Cully,271079,2009,t,236
+Cully,271079,2010,f,873
+Cully,271079,2010,t,236
+Cully,271079,2011,f,981
+Cully,271079,2011,t,251
+Cully,271079,2012,f,992
+Cully,271079,2012,t,283
+Cully,271079,2013,f,910
+Cully,271079,2013,t,216
+Cully,271079,2014,f,844
+Cully,271079,2014,t,209
+Denny Whitford,276294,2004,f,
+Denny Whitford,276294,2004,t,
+Denny Whitford,276294,2005,f,
+Denny Whitford,276294,2005,t,
+Denny Whitford,276294,2006,f,
+Denny Whitford,276294,2006,t,
+Denny Whitford,276294,2007,f,
+Denny Whitford,276294,2007,t,
+Denny Whitford,276294,2008,f,
+Denny Whitford,276294,2008,t,
+Denny Whitford,276294,2009,f,
+Denny Whitford,276294,2009,t,
+Denny Whitford,276294,2010,f,
+Denny Whitford,276294,2010,t,
+Denny Whitford,276294,2011,f,
+Denny Whitford,276294,2011,t,
+Denny Whitford,276294,2012,f,
+Denny Whitford,276294,2012,t,
+Denny Whitford,276294,2013,f,
+Denny Whitford,276294,2013,t,
+Denny Whitford,276294,2014,f,
+Denny Whitford,276294,2014,t,
+Downtown,271082,2004,f,1668
+Downtown,271082,2004,t,205
+Downtown,271082,2005,f,5704
+Downtown,271082,2005,t,675
+Downtown,271082,2006,f,4860
+Downtown,271082,2006,t,751
+Downtown,271082,2007,f,3989
+Downtown,271082,2007,t,551
+Downtown,271082,2008,f,3717
+Downtown,271082,2008,t,522
+Downtown,271082,2009,f,3260
+Downtown,271082,2009,t,441
+Downtown,271082,2010,f,3273
+Downtown,271082,2010,t,444
+Downtown,271082,2011,f,3898
+Downtown,271082,2011,t,441
+Downtown,271082,2012,f,3961
+Downtown,271082,2012,t,468
+Downtown,271082,2013,f,3980
+Downtown,271082,2013,t,420
+Downtown,271082,2014,f,4366
+Downtown,271082,2014,t,467
+Eastmoreland,206780,2004,f,54
+Eastmoreland,206780,2004,t,17
+Eastmoreland,206780,2005,f,303
+Eastmoreland,206780,2005,t,49
+Eastmoreland,206780,2006,f,246
+Eastmoreland,206780,2006,t,42
+Eastmoreland,206780,2007,f,246
+Eastmoreland,206780,2007,t,35
+Eastmoreland,206780,2008,f,179
+Eastmoreland,206780,2008,t,31
+Eastmoreland,206780,2009,f,136
+Eastmoreland,206780,2009,t,35
+Eastmoreland,206780,2010,f,163
+Eastmoreland,206780,2010,t,39
+Eastmoreland,206780,2011,f,189
+Eastmoreland,206780,2011,t,51
+Eastmoreland,206780,2012,f,153
+Eastmoreland,206780,2012,t,37
+Eastmoreland,206780,2013,f,148
+Eastmoreland,206780,2013,t,50
+Eastmoreland,206780,2014,f,158
+Eastmoreland,206780,2014,t,51
+Eliot,271085,2004,f,186
+Eliot,271085,2004,t,43
+Eliot,271085,2005,f,654
+Eliot,271085,2005,t,155
+Eliot,271085,2006,f,660
+Eliot,271085,2006,t,161
+Eliot,271085,2007,f,591
+Eliot,271085,2007,t,155
+Eliot,271085,2008,f,557
+Eliot,271085,2008,t,124
+Eliot,271085,2009,f,664
+Eliot,271085,2009,t,128
+Eliot,271085,2010,f,736
+Eliot,271085,2010,t,96
+Eliot,271085,2011,f,629
+Eliot,271085,2011,t,109
+Eliot,271085,2012,f,821
+Eliot,271085,2012,t,129
+Eliot,271085,2013,f,704
+Eliot,271085,2013,t,124
+Eliot,271085,2014,f,782
+Eliot,271085,2014,t,148
+Far Southwest,271087,2004,f,86
+Far Southwest,271087,2004,t,16
+Far Southwest,271087,2005,f,597
+Far Southwest,271087,2005,t,92
+Far Southwest,271087,2006,f,639
+Far Southwest,271087,2006,t,100
+Far Southwest,271087,2007,f,488
+Far Southwest,271087,2007,t,104
+Far Southwest,271087,2008,f,500
+Far Southwest,271087,2008,t,66
+Far Southwest,271087,2009,f,480
+Far Southwest,271087,2009,t,78
+Far Southwest,271087,2010,f,481
+Far Southwest,271087,2010,t,63
+Far Southwest,271087,2011,f,498
+Far Southwest,271087,2011,t,89
+Far Southwest,271087,2012,f,559
+Far Southwest,271087,2012,t,105
+Far Southwest,271087,2013,f,492
+Far Southwest,271087,2013,t,73
+Far Southwest,271087,2014,f,361
+Far Southwest,271087,2014,t,55
+Five Oaks,271089,2004,f,
+Five Oaks,271089,2004,t,
+Five Oaks,271089,2005,f,
+Five Oaks,271089,2005,t,
+Five Oaks,271089,2006,f,
+Five Oaks,271089,2006,t,
+Five Oaks,271089,2007,f,
+Five Oaks,271089,2007,t,
+Five Oaks,271089,2008,f,
+Five Oaks,271089,2008,t,
+Five Oaks,271089,2009,f,
+Five Oaks,271089,2009,t,
+Five Oaks,271089,2010,f,
+Five Oaks,271089,2010,t,
+Five Oaks,271089,2011,f,2
+Five Oaks,271089,2011,t,
+Five Oaks,271089,2012,f,1
+Five Oaks,271089,2012,t,
+Five Oaks,271089,2013,f,1
+Five Oaks,271089,2013,t,
+Five Oaks,271089,2014,f,
+Five Oaks,271089,2014,t,
+Forest Park,271090,2004,f,23
+Forest Park,271090,2004,t,6
+Forest Park,271090,2005,f,223
+Forest Park,271090,2005,t,66
+Forest Park,271090,2006,f,273
+Forest Park,271090,2006,t,52
+Forest Park,271090,2007,f,229
+Forest Park,271090,2007,t,36
+Forest Park,271090,2008,f,263
+Forest Park,271090,2008,t,38
+Forest Park,271090,2009,f,278
+Forest Park,271090,2009,t,46
+Forest Park,271090,2010,f,264
+Forest Park,271090,2010,t,38
+Forest Park,271090,2011,f,241
+Forest Park,271090,2011,t,52
+Forest Park,271090,2012,f,270
+Forest Park,271090,2012,t,30
+Forest Park,271090,2013,f,200
+Forest Park,271090,2013,t,29
+Forest Park,271090,2014,f,252
+Forest Park,271090,2014,t,46
+Foster Powell,344054,2004,f,422
+Foster Powell,344054,2004,t,77
+Foster Powell,344054,2005,f,1596
+Foster Powell,344054,2005,t,220
+Foster Powell,344054,2006,f,1512
+Foster Powell,344054,2006,t,242
+Foster Powell,344054,2007,f,1428
+Foster Powell,344054,2007,t,246
+Foster Powell,344054,2008,f,1342
+Foster Powell,344054,2008,t,201
+Foster Powell,344054,2009,f,1310
+Foster Powell,344054,2009,t,140
+Foster Powell,344054,2010,f,1288
+Foster Powell,344054,2010,t,144
+Foster Powell,344054,2011,f,1262
+Foster Powell,344054,2011,t,199
+Foster Powell,344054,2012,f,1344
+Foster Powell,344054,2012,t,208
+Foster Powell,344054,2013,f,1362
+Foster Powell,344054,2013,t,184
+Foster Powell,344054,2014,f,1058
+Foster Powell,344054,2014,t,189
+Government Island,273856,2004,f,
+Government Island,273856,2004,t,
+Government Island,273856,2005,f,
+Government Island,273856,2005,t,
+Government Island,273856,2006,f,
+Government Island,273856,2006,t,
+Government Island,273856,2007,f,
+Government Island,273856,2007,t,
+Government Island,273856,2008,f,
+Government Island,273856,2008,t,
+Government Island,273856,2009,f,1
+Government Island,273856,2009,t,
+Government Island,273856,2010,f,
+Government Island,273856,2010,t,
+Government Island,273856,2011,f,
+Government Island,273856,2011,t,
+Government Island,273856,2012,f,
+Government Island,273856,2012,t,
+Government Island,273856,2013,f,
+Government Island,273856,2013,t,
+Government Island,273856,2014,f,
+Government Island,273856,2014,t,
+Greenway,273899,2004,f,
+Greenway,273899,2004,t,
+Greenway,273899,2005,f,
+Greenway,273899,2005,t,
+Greenway,273899,2006,f,
+Greenway,273899,2006,t,
+Greenway,273899,2007,f,
+Greenway,273899,2007,t,
+Greenway,273899,2008,f,
+Greenway,273899,2008,t,
+Greenway,273899,2009,f,
+Greenway,273899,2009,t,
+Greenway,273899,2010,f,
+Greenway,273899,2010,t,
+Greenway,273899,2011,f,
+Greenway,273899,2011,t,
+Greenway,273899,2012,f,
+Greenway,273899,2012,t,
+Greenway,273899,2013,f,1
+Greenway,273899,2013,t,
+Greenway,273899,2014,f,
+Greenway,273899,2014,t,
+Haden Island,273912,2004,f,3
+Haden Island,273912,2004,t,
+Haden Island,273912,2005,f,530
+Haden Island,273912,2005,t,70
+Haden Island,273912,2006,f,443
+Haden Island,273912,2006,t,72
+Haden Island,273912,2007,f,408
+Haden Island,273912,2007,t,38
+Haden Island,273912,2008,f,346
+Haden Island,273912,2008,t,46
+Haden Island,273912,2009,f,386
+Haden Island,273912,2009,t,36
+Haden Island,273912,2010,f,333
+Haden Island,273912,2010,t,36
+Haden Island,273912,2011,f,335
+Haden Island,273912,2011,t,35
+Haden Island,273912,2012,f,329
+Haden Island,273912,2012,t,35
+Haden Island,273912,2013,f,380
+Haden Island,273912,2013,t,41
+Haden Island,273912,2014,f,396
+Haden Island,273912,2014,t,28
+Hayhurst,271098,2004,f,18
+Hayhurst,271098,2004,t,2
+Hayhurst,271098,2005,f,108
+Hayhurst,271098,2005,t,26
+Hayhurst,271098,2006,f,83
+Hayhurst,271098,2006,t,24
+Hayhurst,271098,2007,f,77
+Hayhurst,271098,2007,t,15
+Hayhurst,271098,2008,f,71
+Hayhurst,271098,2008,t,13
+Hayhurst,271098,2009,f,91
+Hayhurst,271098,2009,t,14
+Hayhurst,271098,2010,f,66
+Hayhurst,271098,2010,t,10
+Hayhurst,271098,2011,f,77
+Hayhurst,271098,2011,t,23
+Hayhurst,271098,2012,f,129
+Hayhurst,271098,2012,t,22
+Hayhurst,271098,2013,f,71
+Hayhurst,271098,2013,t,11
+Hayhurst,271098,2014,f,82
+Hayhurst,271098,2014,t,13
+Hazelwood,206971,2004,f,594
+Hazelwood,206971,2004,t,122
+Hazelwood,206971,2005,f,3468
+Hazelwood,206971,2005,t,489
+Hazelwood,206971,2006,f,3255
+Hazelwood,206971,2006,t,476
+Hazelwood,206971,2007,f,3243
+Hazelwood,206971,2007,t,559
+Hazelwood,206971,2008,f,2961
+Hazelwood,206971,2008,t,483
+Hazelwood,206971,2009,f,2691
+Hazelwood,206971,2009,t,399
+Hazelwood,206971,2010,f,2880
+Hazelwood,206971,2010,t,518
+Hazelwood,206971,2011,f,2944
+Hazelwood,206971,2011,t,477
+Hazelwood,206971,2012,f,2854
+Hazelwood,206971,2012,t,494
+Hazelwood,206971,2013,f,2572
+Hazelwood,206971,2013,t,454
+Hazelwood,206971,2014,f,2596
+Hazelwood,206971,2014,t,480
+Hector Campbell,273955,2004,f,
+Hector Campbell,273955,2004,t,
+Hector Campbell,273955,2005,f,
+Hector Campbell,273955,2005,t,
+Hector Campbell,273955,2006,f,
+Hector Campbell,273955,2006,t,
+Hector Campbell,273955,2007,f,
+Hector Campbell,273955,2007,t,
+Hector Campbell,273955,2008,f,
+Hector Campbell,273955,2008,t,
+Hector Campbell,273955,2009,f,
+Hector Campbell,273955,2009,t,
+Hector Campbell,273955,2010,f,
+Hector Campbell,273955,2010,t,
+Hector Campbell,273955,2011,f,
+Hector Campbell,273955,2011,t,
+Hector Campbell,273955,2012,f,
+Hector Campbell,273955,2012,t,
+Hector Campbell,273955,2013,f,
+Hector Campbell,273955,2013,t,
+Hector Campbell,273955,2014,f,
+Hector Campbell,273955,2014,t,
+Highlands,274008,2004,f,
+Highlands,274008,2004,t,
+Highlands,274008,2005,f,
+Highlands,274008,2005,t,
+Highlands,274008,2006,f,
+Highlands,274008,2006,t,
+Highlands,274008,2007,f,
+Highlands,274008,2007,t,
+Highlands,274008,2008,f,
+Highlands,274008,2008,t,
+Highlands,274008,2009,f,
+Highlands,274008,2009,t,
+Highlands,274008,2010,f,
+Highlands,274008,2010,t,
+Highlands,274008,2011,f,
+Highlands,274008,2011,t,
+Highlands,274008,2012,f,
+Highlands,274008,2012,t,
+Highlands,274008,2013,f,
+Highlands,274008,2013,t,
+Highlands,274008,2014,f,
+Highlands,274008,2014,t,
+Hillsdale,206987,2004,f,43
+Hillsdale,206987,2004,t,15
+Hillsdale,206987,2005,f,318
+Hillsdale,206987,2005,t,56
+Hillsdale,206987,2006,f,290
+Hillsdale,206987,2006,t,60
+Hillsdale,206987,2007,f,298
+Hillsdale,206987,2007,t,54
+Hillsdale,206987,2008,f,248
+Hillsdale,206987,2008,t,47
+Hillsdale,206987,2009,f,328
+Hillsdale,206987,2009,t,63
+Hillsdale,206987,2010,f,255
+Hillsdale,206987,2010,t,61
+Hillsdale,206987,2011,f,219
+Hillsdale,206987,2011,t,66
+Hillsdale,206987,2012,f,218
+Hillsdale,206987,2012,t,58
+Hillsdale,206987,2013,f,228
+Hillsdale,206987,2013,t,52
+Hillsdale,206987,2014,f,183
+Hillsdale,206987,2014,t,22
+Historic Milwaukie,274035,2004,f,
+Historic Milwaukie,274035,2004,t,
+Historic Milwaukie,274035,2005,f,
+Historic Milwaukie,274035,2005,t,
+Historic Milwaukie,274035,2006,f,
+Historic Milwaukie,274035,2006,t,
+Historic Milwaukie,274035,2007,f,
+Historic Milwaukie,274035,2007,t,
+Historic Milwaukie,274035,2008,f,
+Historic Milwaukie,274035,2008,t,
+Historic Milwaukie,274035,2009,f,
+Historic Milwaukie,274035,2009,t,
+Historic Milwaukie,274035,2010,f,
+Historic Milwaukie,274035,2010,t,
+Historic Milwaukie,274035,2011,f,1
+Historic Milwaukie,274035,2011,t,
+Historic Milwaukie,274035,2012,f,2
+Historic Milwaukie,274035,2012,t,
+Historic Milwaukie,274035,2013,f,1
+Historic Milwaukie,274035,2013,t,
+Historic Milwaukie,274035,2014,f,1
+Historic Milwaukie,274035,2014,t,
+Homestead,274053,2004,f,96
+Homestead,274053,2004,t,10
+Homestead,274053,2005,f,318
+Homestead,274053,2005,t,43
+Homestead,274053,2006,f,276
+Homestead,274053,2006,t,30
+Homestead,274053,2007,f,249
+Homestead,274053,2007,t,15
+Homestead,274053,2008,f,205
+Homestead,274053,2008,t,21
+Homestead,274053,2009,f,181
+Homestead,274053,2009,t,25
+Homestead,274053,2010,f,157
+Homestead,274053,2010,t,24
+Homestead,274053,2011,f,250
+Homestead,274053,2011,t,17
+Homestead,274053,2012,f,140
+Homestead,274053,2012,t,14
+Homestead,274053,2013,f,175
+Homestead,274053,2013,t,23
+Homestead,274053,2014,f,368
+Homestead,274053,2014,t,38
+Hosford,274059,2004,f,233
+Hosford,274059,2004,t,59
+Hosford,274059,2005,f,813
+Hosford,274059,2005,t,178
+Hosford,274059,2006,f,781
+Hosford,274059,2006,t,145
+Hosford,274059,2007,f,704
+Hosford,274059,2007,t,145
+Hosford,274059,2008,f,612
+Hosford,274059,2008,t,86
+Hosford,274059,2009,f,618
+Hosford,274059,2009,t,96
+Hosford,274059,2010,f,643
+Hosford,274059,2010,t,97
+Hosford,274059,2011,f,623
+Hosford,274059,2011,t,113
+Hosford,274059,2012,f,724
+Hosford,274059,2012,t,111
+Hosford,274059,2013,f,720
+Hosford,274059,2013,t,98
+Hosford,274059,2014,f,757
+Hosford,274059,2014,t,82
+Irvington,207031,2004,f,233
+Irvington,207031,2004,t,61
+Irvington,207031,2005,f,652
+Irvington,207031,2005,t,146
+Irvington,207031,2006,f,602
+Irvington,207031,2006,t,138
+Irvington,207031,2007,f,578
+Irvington,207031,2007,t,104
+Irvington,207031,2008,f,520
+Irvington,207031,2008,t,103
+Irvington,207031,2009,f,569
+Irvington,207031,2009,t,77
+Irvington,207031,2010,f,554
+Irvington,207031,2010,t,84
+Irvington,207031,2011,f,500
+Irvington,207031,2011,t,76
+Irvington,207031,2012,f,567
+Irvington,207031,2012,t,109
+Irvington,207031,2013,f,664
+Irvington,207031,2013,t,119
+Irvington,207031,2014,f,619
+Irvington,207031,2014,t,97
+Island Station,274111,2004,f,
+Island Station,274111,2004,t,
+Island Station,274111,2005,f,
+Island Station,274111,2005,t,
+Island Station,274111,2006,f,
+Island Station,274111,2006,t,
+Island Station,274111,2007,f,
+Island Station,274111,2007,t,
+Island Station,274111,2008,f,
+Island Station,274111,2008,t,
+Island Station,274111,2009,f,
+Island Station,274111,2009,t,
+Island Station,274111,2010,f,
+Island Station,274111,2010,t,
+Island Station,274111,2011,f,
+Island Station,274111,2011,t,
+Island Station,274111,2012,f,1
+Island Station,274111,2012,t,
+Island Station,274111,2013,f,
+Island Station,274111,2013,t,
+Island Station,274111,2014,f,1
+Island Station,274111,2014,t,
+Kenton,207061,2004,f,190
+Kenton,207061,2004,t,40
+Kenton,207061,2005,f,564
+Kenton,207061,2005,t,145
+Kenton,207061,2006,f,536
+Kenton,207061,2006,t,142
+Kenton,207061,2007,f,467
+Kenton,207061,2007,t,105
+Kenton,207061,2008,f,458
+Kenton,207061,2008,t,108
+Kenton,207061,2009,f,462
+Kenton,207061,2009,t,104
+Kenton,207061,2010,f,362
+Kenton,207061,2010,t,111
+Kenton,207061,2011,f,397
+Kenton,207061,2011,t,80
+Kenton,207061,2012,f,416
+Kenton,207061,2012,t,98
+Kenton,207061,2013,f,360
+Kenton,207061,2013,t,95
+Kenton,207061,2014,f,363
+Kenton,207061,2014,t,88
+Kerns,271104,2004,f,353
+Kerns,271104,2004,t,51
+Kerns,271104,2005,f,1006
+Kerns,271104,2005,t,144
+Kerns,271104,2006,f,826
+Kerns,271104,2006,t,137
+Kerns,271104,2007,f,817
+Kerns,271104,2007,t,126
+Kerns,271104,2008,f,712
+Kerns,271104,2008,t,109
+Kerns,271104,2009,f,680
+Kerns,271104,2009,t,106
+Kerns,271104,2010,f,647
+Kerns,271104,2010,t,102
+Kerns,271104,2011,f,693
+Kerns,271104,2011,t,100
+Kerns,271104,2012,f,762
+Kerns,271104,2012,t,99
+Kerns,271104,2013,f,779
+Kerns,271104,2013,t,91
+Kerns,271104,2014,f,774
+Kerns,271104,2014,t,108
+King,271105,2004,f,533
+King,271105,2004,t,134
+King,271105,2005,f,1448
+King,271105,2005,t,371
+King,271105,2006,f,1298
+King,271105,2006,t,363
+King,271105,2007,f,1134
+King,271105,2007,t,329
+King,271105,2008,f,1024
+King,271105,2008,t,341
+King,271105,2009,f,795
+King,271105,2009,t,262
+King,271105,2010,f,654
+King,271105,2010,t,169
+King,271105,2011,f,711
+King,271105,2011,t,190
+King,271105,2012,f,742
+King,271105,2012,t,185
+King,271105,2013,f,743
+King,271105,2013,t,162
+King,271105,2014,f,706
+King,271105,2014,t,150
+Lake Road,274239,2004,f,
+Lake Road,274239,2004,t,
+Lake Road,274239,2005,f,
+Lake Road,274239,2005,t,
+Lake Road,274239,2006,f,
+Lake Road,274239,2006,t,
+Lake Road,274239,2007,f,
+Lake Road,274239,2007,t,
+Lake Road,274239,2008,f,
+Lake Road,274239,2008,t,
+Lake Road,274239,2009,f,
+Lake Road,274239,2009,t,
+Lake Road,274239,2010,f,1
+Lake Road,274239,2010,t,
+Lake Road,274239,2011,f,
+Lake Road,274239,2011,t,
+Lake Road,274239,2012,f,
+Lake Road,274239,2012,t,
+Lake Road,274239,2013,f,
+Lake Road,274239,2013,t,
+Lake Road,274239,2014,f,
+Lake Road,274239,2014,t,
+Lents,207108,2004,f,345
+Lents,207108,2004,t,112
+Lents,207108,2005,f,1746
+Lents,207108,2005,t,435
+Lents,207108,2006,f,1684
+Lents,207108,2006,t,387
+Lents,207108,2007,f,1660
+Lents,207108,2007,t,400
+Lents,207108,2008,f,1203
+Lents,207108,2008,t,332
+Lents,207108,2009,f,1210
+Lents,207108,2009,t,360
+Lents,207108,2010,f,1184
+Lents,207108,2010,t,410
+Lents,207108,2011,f,1364
+Lents,207108,2011,t,372
+Lents,207108,2012,f,1198
+Lents,207108,2012,t,307
+Lents,207108,2013,f,1221
+Lents,207108,2013,t,352
+Lents,207108,2014,f,1234
+Lents,207108,2014,t,321
+Lewelling,274295,2004,f,
+Lewelling,274295,2004,t,
+Lewelling,274295,2005,f,
+Lewelling,274295,2005,t,
+Lewelling,274295,2006,f,
+Lewelling,274295,2006,t,
+Lewelling,274295,2007,f,3
+Lewelling,274295,2007,t,
+Lewelling,274295,2008,f,4
+Lewelling,274295,2008,t,
+Lewelling,274295,2009,f,1
+Lewelling,274295,2009,t,
+Lewelling,274295,2010,f,
+Lewelling,274295,2010,t,
+Lewelling,274295,2011,f,2
+Lewelling,274295,2011,t,
+Lewelling,274295,2012,f,6
+Lewelling,274295,2012,t,
+Lewelling,274295,2013,f,6
+Lewelling,274295,2013,t,
+Lewelling,274295,2014,f,4
+Lewelling,274295,2014,t,
+Linnton,207125,2004,f,5
+Linnton,207125,2004,t,4
+Linnton,207125,2005,f,55
+Linnton,207125,2005,t,19
+Linnton,207125,2006,f,68
+Linnton,207125,2006,t,5
+Linnton,207125,2007,f,84
+Linnton,207125,2007,t,15
+Linnton,207125,2008,f,89
+Linnton,207125,2008,t,14
+Linnton,207125,2009,f,67
+Linnton,207125,2009,t,11
+Linnton,207125,2010,f,77
+Linnton,207125,2010,t,12
+Linnton,207125,2011,f,60
+Linnton,207125,2011,t,10
+Linnton,207125,2012,f,71
+Linnton,207125,2012,t,11
+Linnton,207125,2013,f,96
+Linnton,207125,2013,t,8
+Linnton,207125,2014,f,73
+Linnton,207125,2014,t,9
+Linwood,274327,2004,f,
+Linwood,274327,2004,t,
+Linwood,274327,2005,f,
+Linwood,274327,2005,t,
+Linwood,274327,2006,f,
+Linwood,274327,2006,t,
+Linwood,274327,2007,f,
+Linwood,274327,2007,t,
+Linwood,274327,2008,f,
+Linwood,274327,2008,t,
+Linwood,274327,2009,f,
+Linwood,274327,2009,t,
+Linwood,274327,2010,f,
+Linwood,274327,2010,t,
+Linwood,274327,2011,f,
+Linwood,274327,2011,t,
+Linwood,274327,2012,f,
+Linwood,274327,2012,t,
+Linwood,274327,2013,f,
+Linwood,274327,2013,t,1
+Linwood,274327,2014,f,1
+Linwood,274327,2014,t,
+Lloyd,274337,2004,f,218
+Lloyd,274337,2004,t,29
+Lloyd,274337,2005,f,1733
+Lloyd,274337,2005,t,195
+Lloyd,274337,2006,f,1808
+Lloyd,274337,2006,t,183
+Lloyd,274337,2007,f,1909
+Lloyd,274337,2007,t,160
+Lloyd,274337,2008,f,1668
+Lloyd,274337,2008,t,157
+Lloyd,274337,2009,f,1682
+Lloyd,274337,2009,t,165
+Lloyd,274337,2010,f,1523
+Lloyd,274337,2010,t,146
+Lloyd,274337,2011,f,1315
+Lloyd,274337,2011,t,167
+Lloyd,274337,2012,f,1648
+Lloyd,274337,2012,t,159
+Lloyd,274337,2013,f,1548
+Lloyd,274337,2013,t,180
+Lloyd,274337,2014,f,1395
+Lloyd,274337,2014,t,147
+Madison South,271108,2004,f,118
+Madison South,271108,2004,t,39
+Madison South,271108,2005,f,677
+Madison South,271108,2005,t,146
+Madison South,271108,2006,f,491
+Madison South,271108,2006,t,137
+Madison South,271108,2007,f,532
+Madison South,271108,2007,t,121
+Madison South,271108,2008,f,410
+Madison South,271108,2008,t,85
+Madison South,271108,2009,f,475
+Madison South,271108,2009,t,72
+Madison South,271108,2010,f,304
+Madison South,271108,2010,t,98
+Madison South,271108,2011,f,391
+Madison South,271108,2011,t,91
+Madison South,271108,2012,f,399
+Madison South,271108,2012,t,92
+Madison South,271108,2013,f,317
+Madison South,271108,2013,t,101
+Madison South,271108,2014,f,311
+Madison South,271108,2014,t,79
+Maplewood-Ashcreek,274417,2004,f,100
+Maplewood-Ashcreek,274417,2004,t,12
+Maplewood-Ashcreek,274417,2005,f,615
+Maplewood-Ashcreek,274417,2005,t,96
+Maplewood-Ashcreek,274417,2006,f,489
+Maplewood-Ashcreek,274417,2006,t,84
+Maplewood-Ashcreek,274417,2007,f,437
+Maplewood-Ashcreek,274417,2007,t,93
+Maplewood-Ashcreek,274417,2008,f,369
+Maplewood-Ashcreek,274417,2008,t,73
+Maplewood-Ashcreek,274417,2009,f,424
+Maplewood-Ashcreek,274417,2009,t,68
+Maplewood-Ashcreek,274417,2010,f,361
+Maplewood-Ashcreek,274417,2010,t,69
+Maplewood-Ashcreek,274417,2011,f,326
+Maplewood-Ashcreek,274417,2011,t,75
+Maplewood-Ashcreek,274417,2012,f,414
+Maplewood-Ashcreek,274417,2012,t,91
+Maplewood-Ashcreek,274417,2013,f,272
+Maplewood-Ashcreek,274417,2013,t,57
+Maplewood-Ashcreek,274417,2014,f,294
+Maplewood-Ashcreek,274417,2014,t,61
+McLoughlin Industrial,274478,2004,f,
+McLoughlin Industrial,274478,2004,t,
+McLoughlin Industrial,274478,2005,f,1
+McLoughlin Industrial,274478,2005,t,
+McLoughlin Industrial,274478,2006,f,
+McLoughlin Industrial,274478,2006,t,
+McLoughlin Industrial,274478,2007,f,
+McLoughlin Industrial,274478,2007,t,
+McLoughlin Industrial,274478,2008,f,
+McLoughlin Industrial,274478,2008,t,
+McLoughlin Industrial,274478,2009,f,
+McLoughlin Industrial,274478,2009,t,
+McLoughlin Industrial,274478,2010,f,
+McLoughlin Industrial,274478,2010,t,
+McLoughlin Industrial,274478,2011,f,1
+McLoughlin Industrial,274478,2011,t,
+McLoughlin Industrial,274478,2012,f,2
+McLoughlin Industrial,274478,2012,t,
+McLoughlin Industrial,274478,2013,f,
+McLoughlin Industrial,274478,2013,t,
+McLoughlin Industrial,274478,2014,f,2
+McLoughlin Industrial,274478,2014,t,1
+Mill Park,271111,2004,f,197
+Mill Park,271111,2004,t,35
+Mill Park,271111,2005,f,634
+Mill Park,271111,2005,t,154
+Mill Park,271111,2006,f,647
+Mill Park,271111,2006,t,97
+Mill Park,271111,2007,f,684
+Mill Park,271111,2007,t,135
+Mill Park,271111,2008,f,638
+Mill Park,271111,2008,t,142
+Mill Park,271111,2009,f,523
+Mill Park,271111,2009,t,121
+Mill Park,271111,2010,f,529
+Mill Park,271111,2010,t,136
+Mill Park,271111,2011,f,554
+Mill Park,271111,2011,t,150
+Mill Park,271111,2012,f,480
+Mill Park,271111,2012,t,144
+Mill Park,271111,2013,f,589
+Mill Park,271111,2013,t,119
+Mill Park,271111,2014,f,547
+Mill Park,271111,2014,t,136
+Milwaukie Business-Industry,274545,2004,f,
+Milwaukie Business-Industry,274545,2004,t,
+Milwaukie Business-Industry,274545,2005,f,
+Milwaukie Business-Industry,274545,2005,t,
+Milwaukie Business-Industry,274545,2006,f,
+Milwaukie Business-Industry,274545,2006,t,
+Milwaukie Business-Industry,274545,2007,f,
+Milwaukie Business-Industry,274545,2007,t,
+Milwaukie Business-Industry,274545,2008,f,
+Milwaukie Business-Industry,274545,2008,t,
+Milwaukie Business-Industry,274545,2009,f,
+Milwaukie Business-Industry,274545,2009,t,
+Milwaukie Business-Industry,274545,2010,f,
+Milwaukie Business-Industry,274545,2010,t,
+Milwaukie Business-Industry,274545,2011,f,
+Milwaukie Business-Industry,274545,2011,t,
+Milwaukie Business-Industry,274545,2012,f,
+Milwaukie Business-Industry,274545,2012,t,
+Milwaukie Business-Industry,274545,2013,f,
+Milwaukie Business-Industry,274545,2013,t,
+Milwaukie Business-Industry,274545,2014,f,
+Milwaukie Business-Industry,274545,2014,t,
+Montavilla,207230,2004,f,562
+Montavilla,207230,2004,t,121
+Montavilla,207230,2005,f,1890
+Montavilla,207230,2005,t,328
+Montavilla,207230,2006,f,1644
+Montavilla,207230,2006,t,412
+Montavilla,207230,2007,f,1647
+Montavilla,207230,2007,t,301
+Montavilla,207230,2008,f,1439
+Montavilla,207230,2008,t,277
+Montavilla,207230,2009,f,1048
+Montavilla,207230,2009,t,240
+Montavilla,207230,2010,f,1133
+Montavilla,207230,2010,t,239
+Montavilla,207230,2011,f,1146
+Montavilla,207230,2011,t,281
+Montavilla,207230,2012,f,1027
+Montavilla,207230,2012,t,258
+Montavilla,207230,2013,f,956
+Montavilla,207230,2013,t,246
+Montavilla,207230,2014,f,944
+Montavilla,207230,2014,t,234
+Mount Scott,274604,2004,f,212
+Mount Scott,274604,2004,t,75
+Mount Scott,274604,2005,f,723
+Mount Scott,274604,2005,t,154
+Mount Scott,274604,2006,f,594
+Mount Scott,274604,2006,t,140
+Mount Scott,274604,2007,f,644
+Mount Scott,274604,2007,t,152
+Mount Scott,274604,2008,f,477
+Mount Scott,274604,2008,t,117
+Mount Scott,274604,2009,f,419
+Mount Scott,274604,2009,t,121
+Mount Scott,274604,2010,f,437
+Mount Scott,274604,2010,t,117
+Mount Scott,274604,2011,f,465
+Mount Scott,274604,2011,t,127
+Mount Scott,274604,2012,f,529
+Mount Scott,274604,2012,t,139
+Mount Scott,274604,2013,f,516
+Mount Scott,274604,2013,t,109
+Mount Scott,274604,2014,f,469
+Mount Scott,274604,2014,t,125
+Mount Tabor,274605,2004,f,151
+Mount Tabor,274605,2004,t,36
+Mount Tabor,274605,2005,f,491
+Mount Tabor,274605,2005,t,118
+Mount Tabor,274605,2006,f,480
+Mount Tabor,274605,2006,t,99
+Mount Tabor,274605,2007,f,505
+Mount Tabor,274605,2007,t,81
+Mount Tabor,274605,2008,f,364
+Mount Tabor,274605,2008,t,75
+Mount Tabor,274605,2009,f,363
+Mount Tabor,274605,2009,t,68
+Mount Tabor,274605,2010,f,419
+Mount Tabor,274605,2010,t,82
+Mount Tabor,274605,2011,f,401
+Mount Tabor,274605,2011,t,82
+Mount Tabor,274605,2012,f,453
+Mount Tabor,274605,2012,t,90
+Mount Tabor,274605,2013,f,384
+Mount Tabor,274605,2013,t,83
+Mount Tabor,274605,2014,f,309
+Mount Tabor,274605,2014,t,69
+Neighbors Southwest,274653,2004,f,
+Neighbors Southwest,274653,2004,t,
+Neighbors Southwest,274653,2005,f,
+Neighbors Southwest,274653,2005,t,
+Neighbors Southwest,274653,2006,f,
+Neighbors Southwest,274653,2006,t,
+Neighbors Southwest,274653,2007,f,
+Neighbors Southwest,274653,2007,t,
+Neighbors Southwest,274653,2008,f,
+Neighbors Southwest,274653,2008,t,
+Neighbors Southwest,274653,2009,f,
+Neighbors Southwest,274653,2009,t,
+Neighbors Southwest,274653,2010,f,
+Neighbors Southwest,274653,2010,t,
+Neighbors Southwest,274653,2011,f,
+Neighbors Southwest,274653,2011,t,
+Neighbors Southwest,274653,2012,f,
+Neighbors Southwest,274653,2012,t,
+Neighbors Southwest,274653,2013,f,
+Neighbors Southwest,274653,2013,t,
+Neighbors Southwest,274653,2014,f,
+Neighbors Southwest,274653,2014,t,
+Northwest,274797,2004,f,905
+Northwest,274797,2004,t,135
+Northwest,274797,2005,f,2671
+Northwest,274797,2005,t,367
+Northwest,274797,2006,f,2167
+Northwest,274797,2006,t,324
+Northwest,274797,2007,f,2266
+Northwest,274797,2007,t,331
+Northwest,274797,2008,f,2242
+Northwest,274797,2008,t,360
+Northwest,274797,2009,f,2191
+Northwest,274797,2009,t,271
+Northwest,274797,2010,f,2505
+Northwest,274797,2010,t,279
+Northwest,274797,2011,f,2430
+Northwest,274797,2011,t,239
+Northwest,274797,2012,f,2303
+Northwest,274797,2012,t,276
+Northwest,274797,2013,f,2102
+Northwest,274797,2013,t,253
+Northwest,274797,2014,f,2461
+Northwest,274797,2014,t,313
+Old Town-Chinatown,274898,2004,f,1152
+Old Town-Chinatown,274898,2004,t,118
+Old Town-Chinatown,274898,2005,f,2475
+Old Town-Chinatown,274898,2005,t,310
+Old Town-Chinatown,274898,2006,f,2411
+Old Town-Chinatown,274898,2006,t,414
+Old Town-Chinatown,274898,2007,f,2680
+Old Town-Chinatown,274898,2007,t,404
+Old Town-Chinatown,274898,2008,f,2666
+Old Town-Chinatown,274898,2008,t,382
+Old Town-Chinatown,274898,2009,f,2401
+Old Town-Chinatown,274898,2009,t,466
+Old Town-Chinatown,274898,2010,f,2276
+Old Town-Chinatown,274898,2010,t,448
+Old Town-Chinatown,274898,2011,f,2824
+Old Town-Chinatown,274898,2011,t,445
+Old Town-Chinatown,274898,2012,f,2731
+Old Town-Chinatown,274898,2012,t,420
+Old Town-Chinatown,274898,2013,f,3154
+Old Town-Chinatown,274898,2013,t,416
+Old Town-Chinatown,274898,2014,f,2917
+Old Town-Chinatown,274898,2014,t,406
+Overlook,271119,2004,f,172
+Overlook,271119,2004,t,56
+Overlook,271119,2005,f,705
+Overlook,271119,2005,t,131
+Overlook,271119,2006,f,624
+Overlook,271119,2006,t,138
+Overlook,271119,2007,f,635
+Overlook,271119,2007,t,158
+Overlook,271119,2008,f,546
+Overlook,271119,2008,t,113
+Overlook,271119,2009,f,521
+Overlook,271119,2009,t,92
+Overlook,271119,2010,f,486
+Overlook,271119,2010,t,83
+Overlook,271119,2011,f,522
+Overlook,271119,2011,t,107
+Overlook,271119,2012,f,592
+Overlook,271119,2012,t,123
+Overlook,271119,2013,f,481
+Overlook,271119,2013,t,85
+Overlook,271119,2014,f,525
+Overlook,271119,2014,t,111
+Parkrose,207340,2004,f,347
+Parkrose,207340,2004,t,54
+Parkrose,207340,2005,f,1284
+Parkrose,207340,2005,t,228
+Parkrose,207340,2006,f,1333
+Parkrose,207340,2006,t,183
+Parkrose,207340,2007,f,1302
+Parkrose,207340,2007,t,228
+Parkrose,207340,2008,f,1266
+Parkrose,207340,2008,t,189
+Parkrose,207340,2009,f,944
+Parkrose,207340,2009,t,167
+Parkrose,207340,2010,f,1054
+Parkrose,207340,2010,t,206
+Parkrose,207340,2011,f,1041
+Parkrose,207340,2011,t,215
+Parkrose,207340,2012,f,949
+Parkrose,207340,2012,t,200
+Parkrose,207340,2013,f,1096
+Parkrose,207340,2013,t,170
+Parkrose,207340,2014,f,1087
+Parkrose,207340,2014,t,204
+Pearl District,271122,2004,f,270
+Pearl District,271122,2004,t,39
+Pearl District,271122,2005,f,814
+Pearl District,271122,2005,t,121
+Pearl District,271122,2006,f,825
+Pearl District,271122,2006,t,109
+Pearl District,271122,2007,f,867
+Pearl District,271122,2007,t,130
+Pearl District,271122,2008,f,887
+Pearl District,271122,2008,t,134
+Pearl District,271122,2009,f,1006
+Pearl District,271122,2009,t,107
+Pearl District,271122,2010,f,1080
+Pearl District,271122,2010,t,92
+Pearl District,271122,2011,f,1292
+Pearl District,271122,2011,t,110
+Pearl District,271122,2012,f,1240
+Pearl District,271122,2012,t,130
+Pearl District,271122,2013,f,1322
+Pearl District,271122,2013,t,127
+Pearl District,271122,2014,f,1478
+Pearl District,271122,2014,t,140
+Pleasant Valley,275055,2004,f,60
+Pleasant Valley,275055,2004,t,19
+Pleasant Valley,275055,2005,f,402
+Pleasant Valley,275055,2005,t,118
+Pleasant Valley,275055,2006,f,412
+Pleasant Valley,275055,2006,t,101
+Pleasant Valley,275055,2007,f,411
+Pleasant Valley,275055,2007,t,120
+Pleasant Valley,275055,2008,f,356
+Pleasant Valley,275055,2008,t,101
+Pleasant Valley,275055,2009,f,379
+Pleasant Valley,275055,2009,t,108
+Pleasant Valley,275055,2010,f,375
+Pleasant Valley,275055,2010,t,146
+Pleasant Valley,275055,2011,f,326
+Pleasant Valley,275055,2011,t,103
+Pleasant Valley,275055,2012,f,336
+Pleasant Valley,275055,2012,t,118
+Pleasant Valley,275055,2013,f,254
+Pleasant Valley,275055,2013,t,94
+Pleasant Valley,275055,2014,f,270
+Pleasant Valley,275055,2014,t,77
+Portsmith,275080,2004,f,128
+Portsmith,275080,2004,t,35
+Portsmith,275080,2005,f,480
+Portsmith,275080,2005,t,113
+Portsmith,275080,2006,f,559
+Portsmith,275080,2006,t,150
+Portsmith,275080,2007,f,591
+Portsmith,275080,2007,t,168
+Portsmith,275080,2008,f,571
+Portsmith,275080,2008,t,150
+Portsmith,275080,2009,f,472
+Portsmith,275080,2009,t,126
+Portsmith,275080,2010,f,478
+Portsmith,275080,2010,t,167
+Portsmith,275080,2011,f,455
+Portsmith,275080,2011,t,146
+Portsmith,275080,2012,f,428
+Portsmith,275080,2012,t,133
+Portsmith,275080,2013,f,505
+Portsmith,275080,2013,t,159
+Portsmith,275080,2014,f,393
+Portsmith,275080,2014,t,124
+Powellhurst,207384,2004,f,322
+Powellhurst,207384,2004,t,94
+Powellhurst,207384,2005,f,1971
+Powellhurst,207384,2005,t,558
+Powellhurst,207384,2006,f,1670
+Powellhurst,207384,2006,t,450
+Powellhurst,207384,2007,f,1703
+Powellhurst,207384,2007,t,500
+Powellhurst,207384,2008,f,1626
+Powellhurst,207384,2008,t,420
+Powellhurst,207384,2009,f,1569
+Powellhurst,207384,2009,t,447
+Powellhurst,207384,2010,f,1695
+Powellhurst,207384,2010,t,490
+Powellhurst,207384,2011,f,1423
+Powellhurst,207384,2011,t,447
+Powellhurst,207384,2012,f,1470
+Powellhurst,207384,2012,t,465
+Powellhurst,207384,2013,f,1518
+Powellhurst,207384,2013,t,449
+Powellhurst,207384,2014,f,1442
+Powellhurst,207384,2014,t,371
+Raleigh West,275125,2004,f,
+Raleigh West,275125,2004,t,
+Raleigh West,275125,2005,f,
+Raleigh West,275125,2005,t,
+Raleigh West,275125,2006,f,
+Raleigh West,275125,2006,t,
+Raleigh West,275125,2007,f,
+Raleigh West,275125,2007,t,
+Raleigh West,275125,2008,f,
+Raleigh West,275125,2008,t,
+Raleigh West,275125,2009,f,
+Raleigh West,275125,2009,t,
+Raleigh West,275125,2010,f,1
+Raleigh West,275125,2010,t,
+Raleigh West,275125,2011,f,1
+Raleigh West,275125,2011,t,
+Raleigh West,275125,2012,f,
+Raleigh West,275125,2012,t,
+Raleigh West,275125,2013,f,2
+Raleigh West,275125,2013,t,
+Raleigh West,275125,2014,f,
+Raleigh West,275125,2014,t,
+Reed,344057,2004,f,64
+Reed,344057,2004,t,19
+Reed,344057,2005,f,204
+Reed,344057,2005,t,52
+Reed,344057,2006,f,192
+Reed,344057,2006,t,60
+Reed,344057,2007,f,194
+Reed,344057,2007,t,42
+Reed,344057,2008,f,129
+Reed,344057,2008,t,30
+Reed,344057,2009,f,111
+Reed,344057,2009,t,31
+Reed,344057,2010,f,136
+Reed,344057,2010,t,31
+Reed,344057,2011,f,139
+Reed,344057,2011,t,41
+Reed,344057,2012,f,149
+Reed,344057,2012,t,48
+Reed,344057,2013,f,137
+Reed,344057,2013,t,30
+Reed,344057,2014,f,130
+Reed,344057,2014,t,22
+Richmond,276532,2004,f,636
+Richmond,276532,2004,t,131
+Richmond,276532,2005,f,1461
+Richmond,276532,2005,t,299
+Richmond,276532,2006,f,1337
+Richmond,276532,2006,t,293
+Richmond,276532,2007,f,1344
+Richmond,276532,2007,t,234
+Richmond,276532,2008,f,1063
+Richmond,276532,2008,t,186
+Richmond,276532,2009,f,1122
+Richmond,276532,2009,t,152
+Richmond,276532,2010,f,1178
+Richmond,276532,2010,t,165
+Richmond,276532,2011,f,1161
+Richmond,276532,2011,t,157
+Richmond,276532,2012,f,1152
+Richmond,276532,2012,t,200
+Richmond,276532,2013,f,1256
+Richmond,276532,2013,t,168
+Richmond,276532,2014,f,1393
+Richmond,276532,2014,t,139
+Roseway,271127,2004,f,572
+Roseway,271127,2004,t,141
+Roseway,271127,2005,f,1818
+Roseway,271127,2005,t,436
+Roseway,271127,2006,f,1599
+Roseway,271127,2006,t,390
+Roseway,271127,2007,f,1543
+Roseway,271127,2007,t,319
+Roseway,271127,2008,f,1382
+Roseway,271127,2008,t,272
+Roseway,271127,2009,f,1252
+Roseway,271127,2009,t,272
+Roseway,271127,2010,f,1133
+Roseway,271127,2010,t,269
+Roseway,271127,2011,f,1271
+Roseway,271127,2011,t,270
+Roseway,271127,2012,f,1433
+Roseway,271127,2012,t,274
+Roseway,271127,2013,f,1374
+Roseway,271127,2013,t,255
+Roseway,271127,2014,f,1164
+Roseway,271127,2014,t,246
+Ross Island,275256,2004,f,
+Ross Island,275256,2004,t,
+Ross Island,275256,2005,f,
+Ross Island,275256,2005,t,
+Ross Island,275256,2006,f,
+Ross Island,275256,2006,t,
+Ross Island,275256,2007,f,
+Ross Island,275256,2007,t,
+Ross Island,275256,2008,f,
+Ross Island,275256,2008,t,
+Ross Island,275256,2009,f,
+Ross Island,275256,2009,t,
+Ross Island,275256,2010,f,
+Ross Island,275256,2010,t,
+Ross Island,275256,2011,f,
+Ross Island,275256,2011,t,
+Ross Island,275256,2012,f,
+Ross Island,275256,2012,t,
+Ross Island,275256,2013,f,
+Ross Island,275256,2013,t,
+Ross Island,275256,2014,f,
+Ross Island,275256,2014,t,
+Saintjohns,275553,2004,f,124
+Saintjohns,275553,2004,t,36
+Saintjohns,275553,2005,f,524
+Saintjohns,275553,2005,t,155
+Saintjohns,275553,2006,f,534
+Saintjohns,275553,2006,t,183
+Saintjohns,275553,2007,f,488
+Saintjohns,275553,2007,t,122
+Saintjohns,275553,2008,f,417
+Saintjohns,275553,2008,t,115
+Saintjohns,275553,2009,f,400
+Saintjohns,275553,2009,t,119
+Saintjohns,275553,2010,f,334
+Saintjohns,275553,2010,t,83
+Saintjohns,275553,2011,f,330
+Saintjohns,275553,2011,t,100
+Saintjohns,275553,2012,f,323
+Saintjohns,275553,2012,t,71
+Saintjohns,275553,2013,f,329
+Saintjohns,275553,2013,t,82
+Saintjohns,275553,2014,f,247
+Saintjohns,275553,2014,t,79
+Sellwood-Moreland,275327,2004,f,226
+Sellwood-Moreland,275327,2004,t,41
+Sellwood-Moreland,275327,2005,f,659
+Sellwood-Moreland,275327,2005,t,122
+Sellwood-Moreland,275327,2006,f,657
+Sellwood-Moreland,275327,2006,t,135
+Sellwood-Moreland,275327,2007,f,522
+Sellwood-Moreland,275327,2007,t,119
+Sellwood-Moreland,275327,2008,f,544
+Sellwood-Moreland,275327,2008,t,106
+Sellwood-Moreland,275327,2009,f,409
+Sellwood-Moreland,275327,2009,t,82
+Sellwood-Moreland,275327,2010,f,425
+Sellwood-Moreland,275327,2010,t,74
+Sellwood-Moreland,275327,2011,f,636
+Sellwood-Moreland,275327,2011,t,96
+Sellwood-Moreland,275327,2012,f,611
+Sellwood-Moreland,275327,2012,t,125
+Sellwood-Moreland,275327,2013,f,560
+Sellwood-Moreland,275327,2013,t,77
+Sellwood-Moreland,275327,2014,f,511
+Sellwood-Moreland,275327,2014,t,76
+Sexton Mountain,271131,2004,f,
+Sexton Mountain,271131,2004,t,
+Sexton Mountain,271131,2005,f,
+Sexton Mountain,271131,2005,t,
+Sexton Mountain,271131,2006,f,
+Sexton Mountain,271131,2006,t,
+Sexton Mountain,271131,2007,f,
+Sexton Mountain,271131,2007,t,
+Sexton Mountain,271131,2008,f,
+Sexton Mountain,271131,2008,t,
+Sexton Mountain,271131,2009,f,
+Sexton Mountain,271131,2009,t,
+Sexton Mountain,271131,2010,f,
+Sexton Mountain,271131,2010,t,
+Sexton Mountain,271131,2011,f,
+Sexton Mountain,271131,2011,t,
+Sexton Mountain,271131,2012,f,
+Sexton Mountain,271131,2012,t,
+Sexton Mountain,271131,2013,f,
+Sexton Mountain,271131,2013,t,
+Sexton Mountain,271131,2014,f,
+Sexton Mountain,271131,2014,t,
+South Beaverton,275412,2004,f,
+South Beaverton,275412,2004,t,
+South Beaverton,275412,2005,f,
+South Beaverton,275412,2005,t,
+South Beaverton,275412,2006,f,
+South Beaverton,275412,2006,t,
+South Beaverton,275412,2007,f,
+South Beaverton,275412,2007,t,
+South Beaverton,275412,2008,f,
+South Beaverton,275412,2008,t,
+South Beaverton,275412,2009,f,
+South Beaverton,275412,2009,t,
+South Beaverton,275412,2010,f,
+South Beaverton,275412,2010,t,
+South Beaverton,275412,2011,f,
+South Beaverton,275412,2011,t,
+South Beaverton,275412,2012,f,
+South Beaverton,275412,2012,t,
+South Beaverton,275412,2013,f,
+South Beaverton,275412,2013,t,
+South Beaverton,275412,2014,f,
+South Beaverton,275412,2014,t,
+South Tabor,344059,2004,f,190
+South Tabor,344059,2004,t,70
+South Tabor,344059,2005,f,632
+South Tabor,344059,2005,t,150
+South Tabor,344059,2006,f,488
+South Tabor,344059,2006,t,114
+South Tabor,344059,2007,f,526
+South Tabor,344059,2007,t,123
+South Tabor,344059,2008,f,445
+South Tabor,344059,2008,t,99
+South Tabor,344059,2009,f,309
+South Tabor,344059,2009,t,87
+South Tabor,344059,2010,f,402
+South Tabor,344059,2010,t,64
+South Tabor,344059,2011,f,389
+South Tabor,344059,2011,t,91
+South Tabor,344059,2012,f,434
+South Tabor,344059,2012,t,143
+South Tabor,344059,2013,f,381
+South Tabor,344059,2013,t,96
+South Tabor,344059,2014,f,318
+South Tabor,344059,2014,t,81
+Southwest Hills,271136,2004,f,23
+Southwest Hills,271136,2004,t,5
+Southwest Hills,271136,2005,f,203
+Southwest Hills,271136,2005,t,42
+Southwest Hills,271136,2006,f,190
+Southwest Hills,271136,2006,t,26
+Southwest Hills,271136,2007,f,199
+Southwest Hills,271136,2007,t,21
+Southwest Hills,271136,2008,f,149
+Southwest Hills,271136,2008,t,19
+Southwest Hills,271136,2009,f,116
+Southwest Hills,271136,2009,t,20
+Southwest Hills,271136,2010,f,131
+Southwest Hills,271136,2010,t,27
+Southwest Hills,271136,2011,f,140
+Southwest Hills,271136,2011,t,40
+Southwest Hills,271136,2012,f,147
+Southwest Hills,271136,2012,t,27
+Southwest Hills,271136,2013,f,97
+Southwest Hills,271136,2013,t,29
+Southwest Hills,271136,2014,f,112
+Southwest Hills,271136,2014,t,40
+Sunderland,271139,2004,f,21
+Sunderland,271139,2004,t,5
+Sunderland,271139,2005,f,121
+Sunderland,271139,2005,t,23
+Sunderland,271139,2006,f,109
+Sunderland,271139,2006,t,18
+Sunderland,271139,2007,f,124
+Sunderland,271139,2007,t,24
+Sunderland,271139,2008,f,192
+Sunderland,271139,2008,t,22
+Sunderland,271139,2009,f,199
+Sunderland,271139,2009,t,10
+Sunderland,271139,2010,f,305
+Sunderland,271139,2010,t,22
+Sunderland,271139,2011,f,280
+Sunderland,271139,2011,t,18
+Sunderland,271139,2012,f,268
+Sunderland,271139,2012,t,23
+Sunderland,271139,2013,f,269
+Sunderland,271139,2013,t,15
+Sunderland,271139,2014,f,294
+Sunderland,271139,2014,t,8
+Triple Creek,271142,2004,f,
+Triple Creek,271142,2004,t,
+Triple Creek,271142,2005,f,
+Triple Creek,271142,2005,t,
+Triple Creek,271142,2006,f,
+Triple Creek,271142,2006,t,
+Triple Creek,271142,2007,f,
+Triple Creek,271142,2007,t,
+Triple Creek,271142,2008,f,
+Triple Creek,271142,2008,t,
+Triple Creek,271142,2009,f,
+Triple Creek,271142,2009,t,
+Triple Creek,271142,2010,f,
+Triple Creek,271142,2010,t,
+Triple Creek,271142,2011,f,1
+Triple Creek,271142,2011,t,
+Triple Creek,271142,2012,f,
+Triple Creek,271142,2012,t,
+Triple Creek,271142,2013,f,
+Triple Creek,271142,2013,t,
+Triple Creek,271142,2014,f,
+Triple Creek,271142,2014,t,
+University Park,207639,2004,f,89
+University Park,207639,2004,t,14
+University Park,207639,2005,f,353
+University Park,207639,2005,t,80
+University Park,207639,2006,f,315
+University Park,207639,2006,t,56
+University Park,207639,2007,f,258
+University Park,207639,2007,t,72
+University Park,207639,2008,f,268
+University Park,207639,2008,t,58
+University Park,207639,2009,f,306
+University Park,207639,2009,t,73
+University Park,207639,2010,f,321
+University Park,207639,2010,t,89
+University Park,207639,2011,f,257
+University Park,207639,2011,t,73
+University Park,207639,2012,f,320
+University Park,207639,2012,t,60
+University Park,207639,2013,f,267
+University Park,207639,2013,t,90
+University Park,207639,2014,f,269
+University Park,207639,2014,t,62
+Vose,275899,2004,f,
+Vose,275899,2004,t,
+Vose,275899,2005,f,
+Vose,275899,2005,t,
+Vose,275899,2006,f,
+Vose,275899,2006,t,
+Vose,275899,2007,f,1
+Vose,275899,2007,t,
+Vose,275899,2008,f,
+Vose,275899,2008,t,
+Vose,275899,2009,f,
+Vose,275899,2009,t,
+Vose,275899,2010,f,
+Vose,275899,2010,t,
+Vose,275899,2011,f,
+Vose,275899,2011,t,
+Vose,275899,2012,f,
+Vose,275899,2012,t,
+Vose,275899,2013,f,
+Vose,275899,2013,t,
+Vose,275899,2014,f,
+Vose,275899,2014,t,
+West Beaverton,271146,2004,f,
+West Beaverton,271146,2004,t,
+West Beaverton,271146,2005,f,
+West Beaverton,271146,2005,t,
+West Beaverton,271146,2006,f,
+West Beaverton,271146,2006,t,
+West Beaverton,271146,2007,f,
+West Beaverton,271146,2007,t,
+West Beaverton,271146,2008,f,
+West Beaverton,271146,2008,t,
+West Beaverton,271146,2009,f,
+West Beaverton,271146,2009,t,
+West Beaverton,271146,2010,f,
+West Beaverton,271146,2010,t,
+West Beaverton,271146,2011,f,
+West Beaverton,271146,2011,t,
+West Beaverton,271146,2012,f,
+West Beaverton,271146,2012,t,
+West Beaverton,271146,2013,f,
+West Beaverton,271146,2013,t,
+West Beaverton,271146,2014,f,1
+West Beaverton,271146,2014,t,
+West Slope,275992,2004,f,
+West Slope,275992,2004,t,
+West Slope,275992,2005,f,
+West Slope,275992,2005,t,
+West Slope,275992,2006,f,
+West Slope,275992,2006,t,
+West Slope,275992,2007,f,
+West Slope,275992,2007,t,
+West Slope,275992,2008,f,
+West Slope,275992,2008,t,
+West Slope,275992,2009,f,
+West Slope,275992,2009,t,
+West Slope,275992,2010,f,2
+West Slope,275992,2010,t,
+West Slope,275992,2011,f,1
+West Slope,275992,2011,t,
+West Slope,275992,2012,f,2
+West Slope,275992,2012,t,
+West Slope,275992,2013,f,
+West Slope,275992,2013,t,
+West Slope,275992,2014,f,2
+West Slope,275992,2014,t,
+Wilkes,271150,2004,f,83
+Wilkes,271150,2004,t,30
+Wilkes,271150,2005,f,589
+Wilkes,271150,2005,t,162
+Wilkes,271150,2006,f,474
+Wilkes,271150,2006,t,124
+Wilkes,271150,2007,f,463
+Wilkes,271150,2007,t,124
+Wilkes,271150,2008,f,449
+Wilkes,271150,2008,t,131
+Wilkes,271150,2009,f,397
+Wilkes,271150,2009,t,108
+Wilkes,271150,2010,f,454
+Wilkes,271150,2010,t,113
+Wilkes,271150,2011,f,466
+Wilkes,271150,2011,t,113
+Wilkes,271150,2012,f,380
+Wilkes,271150,2012,t,110
+Wilkes,271150,2013,f,366
+Wilkes,271150,2013,t,109
+Wilkes,271150,2014,f,459
+Wilkes,271150,2014,t,124
+Woodlawn,271152,2004,f,260
+Woodlawn,271152,2004,t,101
+Woodlawn,271152,2005,f,810
+Woodlawn,271152,2005,t,242
+Woodlawn,271152,2006,f,878
+Woodlawn,271152,2006,t,318
+Woodlawn,271152,2007,f,581
+Woodlawn,271152,2007,t,199
+Woodlawn,271152,2008,f,610
+Woodlawn,271152,2008,t,204
+Woodlawn,271152,2009,f,538
+Woodlawn,271152,2009,t,164
+Woodlawn,271152,2010,f,510
+Woodlawn,271152,2010,t,142
+Woodlawn,271152,2011,f,476
+Woodlawn,271152,2011,t,146
+Woodlawn,271152,2012,f,477
+Woodlawn,271152,2012,t,169
+Woodlawn,271152,2013,f,478
+Woodlawn,271152,2013,t,123
+Woodlawn,271152,2014,f,435
+Woodlawn,271152,2014,t,133
+Woodstock,207740,2004,f,133
+Woodstock,207740,2004,t,35
+Woodstock,207740,2005,f,466
+Woodstock,207740,2005,t,92
+Woodstock,207740,2006,f,434
+Woodstock,207740,2006,t,109
+Woodstock,207740,2007,f,446
+Woodstock,207740,2007,t,100
+Woodstock,207740,2008,f,327
+Woodstock,207740,2008,t,75
+Woodstock,207740,2009,f,315
+Woodstock,207740,2009,t,79
+Woodstock,207740,2010,f,297
+Woodstock,207740,2010,t,83
+Woodstock,207740,2011,f,387
+Woodstock,207740,2011,t,128
+Woodstock,207740,2012,f,415
+Woodstock,207740,2012,t,115
+Woodstock,207740,2013,f,418
+Woodstock,207740,2013,t,79
+Woodstock,207740,2014,f,405
+Woodstock,207740,2014,t,109

--- a/json/city_data/zillow_neighborhoods_demolitions.csv
+++ b/json/city_data/zillow_neighborhoods_demolitions.csv
@@ -1,0 +1,936 @@
+name,regionid,year,count
+Alameda,206428,2004,
+Alameda,206428,2005,1
+Alameda,206428,2006,
+Alameda,206428,2007,1
+Alameda,206428,2008,
+Alameda,206428,2009,
+Alameda,206428,2010,1
+Alameda,206428,2011,1
+Alameda,206428,2012,2
+Alameda,206428,2013,2
+Alameda,206428,2014,3
+Arbor Lodge,271060,2004,
+Arbor Lodge,271060,2005,4
+Arbor Lodge,271060,2006,5
+Arbor Lodge,271060,2007,2
+Arbor Lodge,271060,2008,2
+Arbor Lodge,271060,2009,2
+Arbor Lodge,271060,2010,3
+Arbor Lodge,271060,2011,2
+Arbor Lodge,271060,2012,3
+Arbor Lodge,271060,2013,8
+Arbor Lodge,271060,2014,11
+Ardenwald,272783,2004,
+Ardenwald,272783,2005,
+Ardenwald,272783,2006,
+Ardenwald,272783,2007,
+Ardenwald,272783,2008,
+Ardenwald,272783,2009,
+Ardenwald,272783,2010,
+Ardenwald,272783,2011,
+Ardenwald,272783,2012,
+Ardenwald,272783,2013,
+Ardenwald,272783,2014,
+Argay,271061,2004,
+Argay,271061,2005,5
+Argay,271061,2006,
+Argay,271061,2007,
+Argay,271061,2008,
+Argay,271061,2009,
+Argay,271061,2010,
+Argay,271061,2011,
+Argay,271061,2012,
+Argay,271061,2013,
+Argay,271061,2014,
+Boise,271065,2004,
+Boise,271065,2005,2
+Boise,271065,2006,4
+Boise,271065,2007,
+Boise,271065,2008,1
+Boise,271065,2009,6
+Boise,271065,2010,1
+Boise,271065,2011,3
+Boise,271065,2012,4
+Boise,271065,2013,4
+Boise,271065,2014,14
+Brentwood-Darlington,276222,2004,12
+Brentwood-Darlington,276222,2005,20
+Brentwood-Darlington,276222,2006,19
+Brentwood-Darlington,276222,2007,17
+Brentwood-Darlington,276222,2008,14
+Brentwood-Darlington,276222,2009,7
+Brentwood-Darlington,276222,2010,8
+Brentwood-Darlington,276222,2011,3
+Brentwood-Darlington,276222,2012,6
+Brentwood-Darlington,276222,2013,9
+Brentwood-Darlington,276222,2014,10
+Bridgeton,271067,2004,3
+Bridgeton,271067,2005,5
+Bridgeton,271067,2006,1
+Bridgeton,271067,2007,
+Bridgeton,271067,2008,1
+Bridgeton,271067,2009,1
+Bridgeton,271067,2010,
+Bridgeton,271067,2011,1
+Bridgeton,271067,2012,
+Bridgeton,271067,2013,
+Bridgeton,271067,2014,
+Bridlemile,206554,2004,2
+Bridlemile,206554,2005,
+Bridlemile,206554,2006,
+Bridlemile,206554,2007,
+Bridlemile,206554,2008,2
+Bridlemile,206554,2009,
+Bridlemile,206554,2010,
+Bridlemile,206554,2011,
+Bridlemile,206554,2012,2
+Bridlemile,206554,2013,3
+Bridlemile,206554,2014,3
+Brooklyn,206562,2004,
+Brooklyn,206562,2005,
+Brooklyn,206562,2006,
+Brooklyn,206562,2007,
+Brooklyn,206562,2008,1
+Brooklyn,206562,2009,
+Brooklyn,206562,2010,1
+Brooklyn,206562,2011,
+Brooklyn,206562,2012,
+Brooklyn,206562,2013,3
+Brooklyn,206562,2014,6
+Buckman,271068,2004,
+Buckman,271068,2005,
+Buckman,271068,2006,
+Buckman,271068,2007,
+Buckman,271068,2008,
+Buckman,271068,2009,1
+Buckman,271068,2010,
+Buckman,271068,2011,2
+Buckman,271068,2012,
+Buckman,271068,2013,2
+Buckman,271068,2014,
+Cathedral Park,271070,2004,8
+Cathedral Park,271070,2005,5
+Cathedral Park,271070,2006,6
+Cathedral Park,271070,2007,8
+Cathedral Park,271070,2008,3
+Cathedral Park,271070,2009,2
+Cathedral Park,271070,2010,2
+Cathedral Park,271070,2011,1
+Cathedral Park,271070,2012,6
+Cathedral Park,271070,2013,2
+Cathedral Park,271070,2014,7
+Centennial,271071,2004,3
+Centennial,271071,2005,9
+Centennial,271071,2006,4
+Centennial,271071,2007,4
+Centennial,271071,2008,2
+Centennial,271071,2009,1
+Centennial,271071,2010,
+Centennial,271071,2011,2
+Centennial,271071,2012,2
+Centennial,271071,2013,3
+Centennial,271071,2014,4
+Center,271072,2004,2
+Center,271072,2005,
+Center,271072,2006,
+Center,271072,2007,1
+Center,271072,2008,1
+Center,271072,2009,1
+Center,271072,2010,
+Center,271072,2011,1
+Center,271072,2012,
+Center,271072,2013,4
+Center,271072,2014,4
+Central Beaverton,273187,2004,
+Central Beaverton,273187,2005,
+Central Beaverton,273187,2006,
+Central Beaverton,273187,2007,
+Central Beaverton,273187,2008,
+Central Beaverton,273187,2009,
+Central Beaverton,273187,2010,
+Central Beaverton,273187,2011,
+Central Beaverton,273187,2012,
+Central Beaverton,273187,2013,
+Central Beaverton,273187,2014,
+Concordia,271076,2004,
+Concordia,271076,2005,4
+Concordia,271076,2006,1
+Concordia,271076,2007,3
+Concordia,271076,2008,13
+Concordia,271076,2009,4
+Concordia,271076,2010,2
+Concordia,271076,2011,21
+Concordia,271076,2012,7
+Concordia,271076,2013,10
+Concordia,271076,2014,9
+Corbett-Terwilliger-Lair Hill,273346,2004,1
+Corbett-Terwilliger-Lair Hill,273346,2005,4
+Corbett-Terwilliger-Lair Hill,273346,2006,2
+Corbett-Terwilliger-Lair Hill,273346,2007,1
+Corbett-Terwilliger-Lair Hill,273346,2008,1
+Corbett-Terwilliger-Lair Hill,273346,2009,
+Corbett-Terwilliger-Lair Hill,273346,2010,1
+Corbett-Terwilliger-Lair Hill,273346,2011,
+Corbett-Terwilliger-Lair Hill,273346,2012,2
+Corbett-Terwilliger-Lair Hill,273346,2013,2
+Corbett-Terwilliger-Lair Hill,273346,2014,1
+Creston-Kenilworth,273402,2004,
+Creston-Kenilworth,273402,2005,1
+Creston-Kenilworth,273402,2006,
+Creston-Kenilworth,273402,2007,
+Creston-Kenilworth,273402,2008,
+Creston-Kenilworth,273402,2009,1
+Creston-Kenilworth,273402,2010,
+Creston-Kenilworth,273402,2011,1
+Creston-Kenilworth,273402,2012,3
+Creston-Kenilworth,273402,2013,6
+Creston-Kenilworth,273402,2014,2
+Cully,271079,2004,3
+Cully,271079,2005,3
+Cully,271079,2006,3
+Cully,271079,2007,15
+Cully,271079,2008,6
+Cully,271079,2009,4
+Cully,271079,2010,5
+Cully,271079,2011,2
+Cully,271079,2012,7
+Cully,271079,2013,9
+Cully,271079,2014,12
+Denny Whitford,276294,2004,
+Denny Whitford,276294,2005,
+Denny Whitford,276294,2006,
+Denny Whitford,276294,2007,
+Denny Whitford,276294,2008,
+Denny Whitford,276294,2009,
+Denny Whitford,276294,2010,
+Denny Whitford,276294,2011,
+Denny Whitford,276294,2012,
+Denny Whitford,276294,2013,
+Denny Whitford,276294,2014,
+Downtown,271082,2004,
+Downtown,271082,2005,
+Downtown,271082,2006,
+Downtown,271082,2007,2
+Downtown,271082,2008,
+Downtown,271082,2009,
+Downtown,271082,2010,
+Downtown,271082,2011,
+Downtown,271082,2012,
+Downtown,271082,2013,2
+Downtown,271082,2014,
+Eastmoreland,206780,2004,
+Eastmoreland,206780,2005,1
+Eastmoreland,206780,2006,
+Eastmoreland,206780,2007,2
+Eastmoreland,206780,2008,
+Eastmoreland,206780,2009,
+Eastmoreland,206780,2010,1
+Eastmoreland,206780,2011,
+Eastmoreland,206780,2012,3
+Eastmoreland,206780,2013,3
+Eastmoreland,206780,2014,4
+Eliot,271085,2004,
+Eliot,271085,2005,
+Eliot,271085,2006,
+Eliot,271085,2007,2
+Eliot,271085,2008,1
+Eliot,271085,2009,
+Eliot,271085,2010,1
+Eliot,271085,2011,
+Eliot,271085,2012,2
+Eliot,271085,2013,5
+Eliot,271085,2014,3
+Far Southwest,271087,2004,5
+Far Southwest,271087,2005,15
+Far Southwest,271087,2006,8
+Far Southwest,271087,2007,6
+Far Southwest,271087,2008,1
+Far Southwest,271087,2009,2
+Far Southwest,271087,2010,
+Far Southwest,271087,2011,3
+Far Southwest,271087,2012,5
+Far Southwest,271087,2013,3
+Far Southwest,271087,2014,7
+Five Oaks,271089,2004,
+Five Oaks,271089,2005,
+Five Oaks,271089,2006,
+Five Oaks,271089,2007,
+Five Oaks,271089,2008,
+Five Oaks,271089,2009,
+Five Oaks,271089,2010,
+Five Oaks,271089,2011,
+Five Oaks,271089,2012,
+Five Oaks,271089,2013,
+Five Oaks,271089,2014,
+Forest Park,271090,2004,
+Forest Park,271090,2005,
+Forest Park,271090,2006,2
+Forest Park,271090,2007,1
+Forest Park,271090,2008,
+Forest Park,271090,2009,3
+Forest Park,271090,2010,2
+Forest Park,271090,2011,2
+Forest Park,271090,2012,
+Forest Park,271090,2013,
+Forest Park,271090,2014,1
+Foster Powell,344054,2004,2
+Foster Powell,344054,2005,6
+Foster Powell,344054,2006,4
+Foster Powell,344054,2007,2
+Foster Powell,344054,2008,3
+Foster Powell,344054,2009,2
+Foster Powell,344054,2010,4
+Foster Powell,344054,2011,5
+Foster Powell,344054,2012,9
+Foster Powell,344054,2013,6
+Foster Powell,344054,2014,6
+Government Island,273856,2004,
+Government Island,273856,2005,
+Government Island,273856,2006,
+Government Island,273856,2007,
+Government Island,273856,2008,
+Government Island,273856,2009,
+Government Island,273856,2010,
+Government Island,273856,2011,
+Government Island,273856,2012,
+Government Island,273856,2013,
+Government Island,273856,2014,
+Greenway,273899,2004,
+Greenway,273899,2005,
+Greenway,273899,2006,
+Greenway,273899,2007,
+Greenway,273899,2008,
+Greenway,273899,2009,
+Greenway,273899,2010,
+Greenway,273899,2011,
+Greenway,273899,2012,
+Greenway,273899,2013,
+Greenway,273899,2014,
+Haden Island,273912,2004,
+Haden Island,273912,2005,
+Haden Island,273912,2006,
+Haden Island,273912,2007,
+Haden Island,273912,2008,1
+Haden Island,273912,2009,1
+Haden Island,273912,2010,1
+Haden Island,273912,2011,
+Haden Island,273912,2012,
+Haden Island,273912,2013,
+Haden Island,273912,2014,
+Hayhurst,271098,2004,1
+Hayhurst,271098,2005,
+Hayhurst,271098,2006,1
+Hayhurst,271098,2007,3
+Hayhurst,271098,2008,1
+Hayhurst,271098,2009,2
+Hayhurst,271098,2010,2
+Hayhurst,271098,2011,
+Hayhurst,271098,2012,3
+Hayhurst,271098,2013,5
+Hayhurst,271098,2014,4
+Hazelwood,206971,2004,3
+Hazelwood,206971,2005,6
+Hazelwood,206971,2006,9
+Hazelwood,206971,2007,7
+Hazelwood,206971,2008,6
+Hazelwood,206971,2009,3
+Hazelwood,206971,2010,3
+Hazelwood,206971,2011,4
+Hazelwood,206971,2012,8
+Hazelwood,206971,2013,14
+Hazelwood,206971,2014,3
+Hector Campbell,273955,2004,
+Hector Campbell,273955,2005,
+Hector Campbell,273955,2006,
+Hector Campbell,273955,2007,
+Hector Campbell,273955,2008,
+Hector Campbell,273955,2009,
+Hector Campbell,273955,2010,
+Hector Campbell,273955,2011,
+Hector Campbell,273955,2012,
+Hector Campbell,273955,2013,
+Hector Campbell,273955,2014,
+Highlands,274008,2004,
+Highlands,274008,2005,
+Highlands,274008,2006,
+Highlands,274008,2007,
+Highlands,274008,2008,
+Highlands,274008,2009,
+Highlands,274008,2010,
+Highlands,274008,2011,
+Highlands,274008,2012,
+Highlands,274008,2013,
+Highlands,274008,2014,
+Hillsdale,206987,2004,1
+Hillsdale,206987,2005,1
+Hillsdale,206987,2006,4
+Hillsdale,206987,2007,
+Hillsdale,206987,2008,2
+Hillsdale,206987,2009,4
+Hillsdale,206987,2010,
+Hillsdale,206987,2011,
+Hillsdale,206987,2012,
+Hillsdale,206987,2013,1
+Hillsdale,206987,2014,2
+Historic Milwaukie,274035,2004,
+Historic Milwaukie,274035,2005,
+Historic Milwaukie,274035,2006,
+Historic Milwaukie,274035,2007,
+Historic Milwaukie,274035,2008,
+Historic Milwaukie,274035,2009,
+Historic Milwaukie,274035,2010,
+Historic Milwaukie,274035,2011,
+Historic Milwaukie,274035,2012,
+Historic Milwaukie,274035,2013,
+Historic Milwaukie,274035,2014,
+Homestead,274053,2004,1
+Homestead,274053,2005,1
+Homestead,274053,2006,
+Homestead,274053,2007,1
+Homestead,274053,2008,2
+Homestead,274053,2009,1
+Homestead,274053,2010,1
+Homestead,274053,2011,
+Homestead,274053,2012,
+Homestead,274053,2013,
+Homestead,274053,2014,
+Hosford,274059,2004,
+Hosford,274059,2005,1
+Hosford,274059,2006,
+Hosford,274059,2007,1
+Hosford,274059,2008,2
+Hosford,274059,2009,2
+Hosford,274059,2010,2
+Hosford,274059,2011,1
+Hosford,274059,2012,3
+Hosford,274059,2013,5
+Hosford,274059,2014,3
+Irvington,207031,2004,4
+Irvington,207031,2005,2
+Irvington,207031,2006,1
+Irvington,207031,2007,5
+Irvington,207031,2008,4
+Irvington,207031,2009,2
+Irvington,207031,2010,6
+Irvington,207031,2011,6
+Irvington,207031,2012,6
+Irvington,207031,2013,2
+Irvington,207031,2014,
+Island Station,274111,2004,
+Island Station,274111,2005,
+Island Station,274111,2006,
+Island Station,274111,2007,
+Island Station,274111,2008,
+Island Station,274111,2009,
+Island Station,274111,2010,
+Island Station,274111,2011,
+Island Station,274111,2012,
+Island Station,274111,2013,
+Island Station,274111,2014,
+Kenton,207061,2004,4
+Kenton,207061,2005,4
+Kenton,207061,2006,3
+Kenton,207061,2007,1
+Kenton,207061,2008,3
+Kenton,207061,2009,1
+Kenton,207061,2010,1
+Kenton,207061,2011,4
+Kenton,207061,2012,3
+Kenton,207061,2013,5
+Kenton,207061,2014,7
+Kerns,271104,2004,
+Kerns,271104,2005,
+Kerns,271104,2006,
+Kerns,271104,2007,1
+Kerns,271104,2008,
+Kerns,271104,2009,
+Kerns,271104,2010,
+Kerns,271104,2011,
+Kerns,271104,2012,1
+Kerns,271104,2013,1
+Kerns,271104,2014,1
+King,271105,2004,
+King,271105,2005,4
+King,271105,2006,4
+King,271105,2007,2
+King,271105,2008,2
+King,271105,2009,8
+King,271105,2010,6
+King,271105,2011,6
+King,271105,2012,2
+King,271105,2013,12
+King,271105,2014,14
+Lake Road,274239,2004,
+Lake Road,274239,2005,
+Lake Road,274239,2006,
+Lake Road,274239,2007,
+Lake Road,274239,2008,
+Lake Road,274239,2009,
+Lake Road,274239,2010,
+Lake Road,274239,2011,
+Lake Road,274239,2012,
+Lake Road,274239,2013,
+Lake Road,274239,2014,
+Lents,207108,2004,11
+Lents,207108,2005,12
+Lents,207108,2006,14
+Lents,207108,2007,16
+Lents,207108,2008,9
+Lents,207108,2009,15
+Lents,207108,2010,8
+Lents,207108,2011,12
+Lents,207108,2012,10
+Lents,207108,2013,14
+Lents,207108,2014,6
+Lewelling,274295,2004,
+Lewelling,274295,2005,
+Lewelling,274295,2006,
+Lewelling,274295,2007,
+Lewelling,274295,2008,
+Lewelling,274295,2009,
+Lewelling,274295,2010,
+Lewelling,274295,2011,
+Lewelling,274295,2012,
+Lewelling,274295,2013,
+Lewelling,274295,2014,
+Linnton,207125,2004,
+Linnton,207125,2005,1
+Linnton,207125,2006,2
+Linnton,207125,2007,1
+Linnton,207125,2008,
+Linnton,207125,2009,
+Linnton,207125,2010,1
+Linnton,207125,2011,1
+Linnton,207125,2012,2
+Linnton,207125,2013,1
+Linnton,207125,2014,
+Linwood,274327,2004,
+Linwood,274327,2005,
+Linwood,274327,2006,
+Linwood,274327,2007,
+Linwood,274327,2008,
+Linwood,274327,2009,
+Linwood,274327,2010,
+Linwood,274327,2011,
+Linwood,274327,2012,
+Linwood,274327,2013,
+Linwood,274327,2014,
+Lloyd,274337,2004,
+Lloyd,274337,2005,
+Lloyd,274337,2006,
+Lloyd,274337,2007,
+Lloyd,274337,2008,
+Lloyd,274337,2009,
+Lloyd,274337,2010,
+Lloyd,274337,2011,
+Lloyd,274337,2012,
+Lloyd,274337,2013,
+Lloyd,274337,2014,
+Madison South,271108,2004,
+Madison South,271108,2005,
+Madison South,271108,2006,
+Madison South,271108,2007,1
+Madison South,271108,2008,1
+Madison South,271108,2009,1
+Madison South,271108,2010,
+Madison South,271108,2011,
+Madison South,271108,2012,
+Madison South,271108,2013,1
+Madison South,271108,2014,2
+Maplewood-Ashcreek,274417,2004,5
+Maplewood-Ashcreek,274417,2005,6
+Maplewood-Ashcreek,274417,2006,12
+Maplewood-Ashcreek,274417,2007,16
+Maplewood-Ashcreek,274417,2008,5
+Maplewood-Ashcreek,274417,2009,2
+Maplewood-Ashcreek,274417,2010,4
+Maplewood-Ashcreek,274417,2011,2
+Maplewood-Ashcreek,274417,2012,1
+Maplewood-Ashcreek,274417,2013,11
+Maplewood-Ashcreek,274417,2014,15
+McLoughlin Industrial,274478,2004,
+McLoughlin Industrial,274478,2005,
+McLoughlin Industrial,274478,2006,
+McLoughlin Industrial,274478,2007,
+McLoughlin Industrial,274478,2008,
+McLoughlin Industrial,274478,2009,
+McLoughlin Industrial,274478,2010,
+McLoughlin Industrial,274478,2011,
+McLoughlin Industrial,274478,2012,
+McLoughlin Industrial,274478,2013,
+McLoughlin Industrial,274478,2014,
+Mill Park,271111,2004,8
+Mill Park,271111,2005,2
+Mill Park,271111,2006,11
+Mill Park,271111,2007,3
+Mill Park,271111,2008,
+Mill Park,271111,2009,
+Mill Park,271111,2010,1
+Mill Park,271111,2011,
+Mill Park,271111,2012,5
+Mill Park,271111,2013,
+Mill Park,271111,2014,2
+Milwaukie Business-Industry,274545,2004,
+Milwaukie Business-Industry,274545,2005,
+Milwaukie Business-Industry,274545,2006,
+Milwaukie Business-Industry,274545,2007,
+Milwaukie Business-Industry,274545,2008,
+Milwaukie Business-Industry,274545,2009,
+Milwaukie Business-Industry,274545,2010,
+Milwaukie Business-Industry,274545,2011,
+Milwaukie Business-Industry,274545,2012,
+Milwaukie Business-Industry,274545,2013,
+Milwaukie Business-Industry,274545,2014,
+Montavilla,207230,2004,6
+Montavilla,207230,2005,8
+Montavilla,207230,2006,8
+Montavilla,207230,2007,10
+Montavilla,207230,2008,5
+Montavilla,207230,2009,5
+Montavilla,207230,2010,4
+Montavilla,207230,2011,7
+Montavilla,207230,2012,6
+Montavilla,207230,2013,8
+Montavilla,207230,2014,9
+Mount Scott,274604,2004,2
+Mount Scott,274604,2005,2
+Mount Scott,274604,2006,6
+Mount Scott,274604,2007,5
+Mount Scott,274604,2008,3
+Mount Scott,274604,2009,1
+Mount Scott,274604,2010,4
+Mount Scott,274604,2011,3
+Mount Scott,274604,2012,2
+Mount Scott,274604,2013,5
+Mount Scott,274604,2014,13
+Mount Tabor,274605,2004,1
+Mount Tabor,274605,2005,2
+Mount Tabor,274605,2006,2
+Mount Tabor,274605,2007,2
+Mount Tabor,274605,2008,
+Mount Tabor,274605,2009,9
+Mount Tabor,274605,2010,
+Mount Tabor,274605,2011,
+Mount Tabor,274605,2012,3
+Mount Tabor,274605,2013,2
+Mount Tabor,274605,2014,6
+Neighbors Southwest,274653,2004,
+Neighbors Southwest,274653,2005,
+Neighbors Southwest,274653,2006,
+Neighbors Southwest,274653,2007,
+Neighbors Southwest,274653,2008,
+Neighbors Southwest,274653,2009,
+Neighbors Southwest,274653,2010,
+Neighbors Southwest,274653,2011,
+Neighbors Southwest,274653,2012,
+Neighbors Southwest,274653,2013,
+Neighbors Southwest,274653,2014,
+Northwest,274797,2004,
+Northwest,274797,2005,2
+Northwest,274797,2006,2
+Northwest,274797,2007,
+Northwest,274797,2008,
+Northwest,274797,2009,
+Northwest,274797,2010,1
+Northwest,274797,2011,
+Northwest,274797,2012,
+Northwest,274797,2013,1
+Northwest,274797,2014,6
+Old Town-Chinatown,274898,2004,
+Old Town-Chinatown,274898,2005,
+Old Town-Chinatown,274898,2006,
+Old Town-Chinatown,274898,2007,
+Old Town-Chinatown,274898,2008,
+Old Town-Chinatown,274898,2009,
+Old Town-Chinatown,274898,2010,
+Old Town-Chinatown,274898,2011,
+Old Town-Chinatown,274898,2012,
+Old Town-Chinatown,274898,2013,
+Old Town-Chinatown,274898,2014,3
+Overlook,271119,2004,1
+Overlook,271119,2005,3
+Overlook,271119,2006,5
+Overlook,271119,2007,4
+Overlook,271119,2008,1
+Overlook,271119,2009,3
+Overlook,271119,2010,8
+Overlook,271119,2011,1
+Overlook,271119,2012,3
+Overlook,271119,2013,7
+Overlook,271119,2014,1
+Parkrose,207340,2004,2
+Parkrose,207340,2005,3
+Parkrose,207340,2006,3
+Parkrose,207340,2007,4
+Parkrose,207340,2008,2
+Parkrose,207340,2009,1
+Parkrose,207340,2010,1
+Parkrose,207340,2011,
+Parkrose,207340,2012,1
+Parkrose,207340,2013,1
+Parkrose,207340,2014,3
+Pearl District,271122,2004,
+Pearl District,271122,2005,
+Pearl District,271122,2006,
+Pearl District,271122,2007,
+Pearl District,271122,2008,
+Pearl District,271122,2009,
+Pearl District,271122,2010,
+Pearl District,271122,2011,
+Pearl District,271122,2012,
+Pearl District,271122,2013,
+Pearl District,271122,2014,
+Pleasant Valley,275055,2004,1
+Pleasant Valley,275055,2005,2
+Pleasant Valley,275055,2006,7
+Pleasant Valley,275055,2007,3
+Pleasant Valley,275055,2008,4
+Pleasant Valley,275055,2009,
+Pleasant Valley,275055,2010,
+Pleasant Valley,275055,2011,4
+Pleasant Valley,275055,2012,1
+Pleasant Valley,275055,2013,2
+Pleasant Valley,275055,2014,6
+Portsmith,275080,2004,2
+Portsmith,275080,2005,
+Portsmith,275080,2006,3
+Portsmith,275080,2007,1
+Portsmith,275080,2008,6
+Portsmith,275080,2009,3
+Portsmith,275080,2010,2
+Portsmith,275080,2011,1
+Portsmith,275080,2012,2
+Portsmith,275080,2013,7
+Portsmith,275080,2014,6
+Powellhurst,207384,2004,7
+Powellhurst,207384,2005,9
+Powellhurst,207384,2006,14
+Powellhurst,207384,2007,15
+Powellhurst,207384,2008,14
+Powellhurst,207384,2009,7
+Powellhurst,207384,2010,3
+Powellhurst,207384,2011,4
+Powellhurst,207384,2012,5
+Powellhurst,207384,2013,8
+Powellhurst,207384,2014,10
+Raleigh West,275125,2004,
+Raleigh West,275125,2005,
+Raleigh West,275125,2006,
+Raleigh West,275125,2007,
+Raleigh West,275125,2008,
+Raleigh West,275125,2009,
+Raleigh West,275125,2010,
+Raleigh West,275125,2011,
+Raleigh West,275125,2012,
+Raleigh West,275125,2013,
+Raleigh West,275125,2014,
+Reed,344057,2004,
+Reed,344057,2005,
+Reed,344057,2006,
+Reed,344057,2007,
+Reed,344057,2008,
+Reed,344057,2009,
+Reed,344057,2010,
+Reed,344057,2011,
+Reed,344057,2012,2
+Reed,344057,2013,1
+Reed,344057,2014,1
+Richmond,276532,2004,
+Richmond,276532,2005,
+Richmond,276532,2006,2
+Richmond,276532,2007,2
+Richmond,276532,2008,2
+Richmond,276532,2009,
+Richmond,276532,2010,2
+Richmond,276532,2011,5
+Richmond,276532,2012,2
+Richmond,276532,2013,7
+Richmond,276532,2014,11
+Roseway,271127,2004,3
+Roseway,271127,2005,7
+Roseway,271127,2006,2
+Roseway,271127,2007,3
+Roseway,271127,2008,1
+Roseway,271127,2009,2
+Roseway,271127,2010,1
+Roseway,271127,2011,10
+Roseway,271127,2012,2
+Roseway,271127,2013,6
+Roseway,271127,2014,12
+Ross Island,275256,2004,
+Ross Island,275256,2005,
+Ross Island,275256,2006,
+Ross Island,275256,2007,
+Ross Island,275256,2008,
+Ross Island,275256,2009,
+Ross Island,275256,2010,
+Ross Island,275256,2011,
+Ross Island,275256,2012,
+Ross Island,275256,2013,
+Ross Island,275256,2014,
+Saintjohns,275553,2004,
+Saintjohns,275553,2005,
+Saintjohns,275553,2006,3
+Saintjohns,275553,2007,
+Saintjohns,275553,2008,1
+Saintjohns,275553,2009,3
+Saintjohns,275553,2010,
+Saintjohns,275553,2011,
+Saintjohns,275553,2012,1
+Saintjohns,275553,2013,1
+Saintjohns,275553,2014,1
+Sellwood-Moreland,275327,2004,2
+Sellwood-Moreland,275327,2005,2
+Sellwood-Moreland,275327,2006,2
+Sellwood-Moreland,275327,2007,4
+Sellwood-Moreland,275327,2008,7
+Sellwood-Moreland,275327,2009,10
+Sellwood-Moreland,275327,2010,9
+Sellwood-Moreland,275327,2011,8
+Sellwood-Moreland,275327,2012,15
+Sellwood-Moreland,275327,2013,22
+Sellwood-Moreland,275327,2014,13
+Sexton Mountain,271131,2004,
+Sexton Mountain,271131,2005,
+Sexton Mountain,271131,2006,
+Sexton Mountain,271131,2007,
+Sexton Mountain,271131,2008,
+Sexton Mountain,271131,2009,
+Sexton Mountain,271131,2010,
+Sexton Mountain,271131,2011,
+Sexton Mountain,271131,2012,
+Sexton Mountain,271131,2013,
+Sexton Mountain,271131,2014,
+South Beaverton,275412,2004,
+South Beaverton,275412,2005,
+South Beaverton,275412,2006,
+South Beaverton,275412,2007,
+South Beaverton,275412,2008,
+South Beaverton,275412,2009,
+South Beaverton,275412,2010,
+South Beaverton,275412,2011,
+South Beaverton,275412,2012,
+South Beaverton,275412,2013,
+South Beaverton,275412,2014,
+South Tabor,344059,2004,
+South Tabor,344059,2005,
+South Tabor,344059,2006,
+South Tabor,344059,2007,1
+South Tabor,344059,2008,
+South Tabor,344059,2009,
+South Tabor,344059,2010,1
+South Tabor,344059,2011,
+South Tabor,344059,2012,2
+South Tabor,344059,2013,3
+South Tabor,344059,2014,2
+Southwest Hills,271136,2004,
+Southwest Hills,271136,2005,
+Southwest Hills,271136,2006,1
+Southwest Hills,271136,2007,1
+Southwest Hills,271136,2008,1
+Southwest Hills,271136,2009,
+Southwest Hills,271136,2010,
+Southwest Hills,271136,2011,1
+Southwest Hills,271136,2012,
+Southwest Hills,271136,2013,3
+Southwest Hills,271136,2014,2
+Sunderland,271139,2004,1
+Sunderland,271139,2005,
+Sunderland,271139,2006,
+Sunderland,271139,2007,
+Sunderland,271139,2008,1
+Sunderland,271139,2009,
+Sunderland,271139,2010,
+Sunderland,271139,2011,
+Sunderland,271139,2012,
+Sunderland,271139,2013,
+Sunderland,271139,2014,
+Triple Creek,271142,2004,
+Triple Creek,271142,2005,
+Triple Creek,271142,2006,
+Triple Creek,271142,2007,
+Triple Creek,271142,2008,
+Triple Creek,271142,2009,
+Triple Creek,271142,2010,
+Triple Creek,271142,2011,
+Triple Creek,271142,2012,
+Triple Creek,271142,2013,
+Triple Creek,271142,2014,
+University Park,207639,2004,1
+University Park,207639,2005,1
+University Park,207639,2006,1
+University Park,207639,2007,2
+University Park,207639,2008,2
+University Park,207639,2009,2
+University Park,207639,2010,4
+University Park,207639,2011,4
+University Park,207639,2012,4
+University Park,207639,2013,7
+University Park,207639,2014,6
+Vose,275899,2004,
+Vose,275899,2005,
+Vose,275899,2006,
+Vose,275899,2007,
+Vose,275899,2008,
+Vose,275899,2009,
+Vose,275899,2010,
+Vose,275899,2011,
+Vose,275899,2012,
+Vose,275899,2013,
+Vose,275899,2014,
+West Beaverton,271146,2004,
+West Beaverton,271146,2005,
+West Beaverton,271146,2006,
+West Beaverton,271146,2007,
+West Beaverton,271146,2008,
+West Beaverton,271146,2009,
+West Beaverton,271146,2010,
+West Beaverton,271146,2011,
+West Beaverton,271146,2012,
+West Beaverton,271146,2013,
+West Beaverton,271146,2014,
+West Slope,275992,2004,
+West Slope,275992,2005,
+West Slope,275992,2006,
+West Slope,275992,2007,
+West Slope,275992,2008,
+West Slope,275992,2009,
+West Slope,275992,2010,
+West Slope,275992,2011,
+West Slope,275992,2012,
+West Slope,275992,2013,
+West Slope,275992,2014,
+Wilkes,271150,2004,1
+Wilkes,271150,2005,3
+Wilkes,271150,2006,2
+Wilkes,271150,2007,1
+Wilkes,271150,2008,1
+Wilkes,271150,2009,1
+Wilkes,271150,2010,1
+Wilkes,271150,2011,4
+Wilkes,271150,2012,
+Wilkes,271150,2013,2
+Wilkes,271150,2014,2
+Woodlawn,271152,2004,
+Woodlawn,271152,2005,
+Woodlawn,271152,2006,3
+Woodlawn,271152,2007,2
+Woodlawn,271152,2008,2
+Woodlawn,271152,2009,
+Woodlawn,271152,2010,1
+Woodlawn,271152,2011,5
+Woodlawn,271152,2012,7
+Woodlawn,271152,2013,8
+Woodlawn,271152,2014,11
+Woodstock,207740,2004,5
+Woodstock,207740,2005,2
+Woodstock,207740,2006,4
+Woodstock,207740,2007,3
+Woodstock,207740,2008,6
+Woodstock,207740,2009,3
+Woodstock,207740,2010,2
+Woodstock,207740,2011,6
+Woodstock,207740,2012,4
+Woodstock,207740,2013,13
+Woodstock,207740,2014,12


### PR DESCRIPTION
To be able to run these queries you need the `crime` table in your database.

The `CREATE-TABLE-crime.sql` dump can be grabbed from slack at https://files.slack.com/files-pri/T0LK1LTK3-F1C61CU04/download/create-table-crime.sql and placed in `urbandev-etl/postgresql/scripts/sql`. (this file is too large for github)

Then in `build_db` you should be able to uncomment the line `psql -f $SQL/CREATE-TABLE-crime.sql $db` and re-run.

After adding that table you should be able to run `aggregate_to_zillow_neighborhoods.sql` which will generate the output csv files.